### PR TITLE
Map registers-trial.service.gov.uk route to PaaS app

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -4,6 +4,8 @@ applications:
   memory: 256MB
   buildpack: ruby_buildpack
   instances: 2
+  domain: registers-trial.service.gov.uk
+  no-hostname: true
   services:
     # postgres database
     - registers-prod


### PR DESCRIPTION
This creates the registers-trial.service.gov.uk route and maps it
to the registers-frontend app. I have also removed the
registers-frontend.cloudapps.digital route such that this
"private beta" app is only available via
https://registers-trial.service.gov.uk and not
https://registers-frontend.cloudapps.digital.