### PR TITLE
Increase instance memory from 256MB to 1GB

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -1,7 +1,7 @@
 ---
 applications:
 - name: registers-frontend
-  memory: 256MB
+  memory: 1GB
   buildpack: ruby_buildpack
   instances: 2
   domain: registers-trial.service.gov.uk


### PR DESCRIPTION
The instances were crashing due to out of memory exceptions. This
occurs when trying to view the new frontend pages (records and
entry timeline) for large registers such as school. I tested
increasing to 512MB but out of memory exceptions still occurred.