### PR TITLE
Styling tweaks

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -153,7 +153,7 @@ dl dd {
 }
 
 .register-data-table {
-  margin: 40px 0 20px 0;
+  margin: 0 0 20px 0;
 
   td,
   th {
@@ -449,9 +449,13 @@ dl dd {
   margin: 40px 0 20px 0;
   padding-top: 40px;
 
-  .heading-large {
+  .heading-medium {
     margin-top: 0;
   }
+}
+
+.form-group-wrapper {
+  margin-top: 20px;
 }
 
 .entries {
@@ -504,4 +508,8 @@ dl dd {
   padding: 7px;
   text-align: left;
   width: 100%;
+}
+
+.text-spacing {
+  margin: 0 5px;
 }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -494,3 +494,14 @@ dl dd {
 .unknown {
   color: $grey-2;
 }
+
+.panel-change-notification {
+  background-color: rgba($yellow-50, 0.5);
+  border-color: $yellow-50;
+  border-width: 5px;
+  display: inline-block;
+  margin: -7px 20px -4px 0;
+  padding: 7px;
+  text-align: left;
+  width: 100%;
+}

--- a/app/decorators/helpers/spina/application_helper_decorator.rb
+++ b/app/decorators/helpers/spina/application_helper_decorator.rb
@@ -58,5 +58,9 @@ module Spina
         'In the backlog'
       end
     end
+
+    def formatted_date(date)
+      DateTime.parse(date).strftime('%d/%m/%Y')
+    end
   end
 end

--- a/app/views/spina/registers/_timeline_record.html.haml
+++ b/app/views/spina/registers/_timeline_record.html.haml
@@ -17,4 +17,7 @@
           %td
             = timeline_record[:previous_record].present? ? timeline_record[:previous_record][:item][field_name] : "<span class='unknown'>No data found</span>".html_safe
           %td
-            = timeline_record[:current_record][:item][field_name].present? ? timeline_record[:current_record][:item][field_name] : "<span class='unknown'>No data found</span>".html_safe
+            - if timeline_record[:current_record][:item][field_name].present?
+              %span.panel.panel-change-notification= timeline_record[:current_record][:item][field_name]
+            - else
+              %span.unknown No data found

--- a/app/views/spina/registers/show.html.haml
+++ b/app/views/spina/registers/show.html.haml
@@ -33,12 +33,14 @@
 
       .govuk-metadata
         %dl
-          %dt Updated:
-          %dd
-            = DateTime.parse(@register_data.get_entries.last[:timestamp]).strftime('%d/%m/%Y')
           %dt Managed by:
           %dd
             = link_to @register.authority, "https://www.gov.uk/government/organisations/#{@register.authority.parameterize}", target: :blank
+          %dt Updated:
+          %dd
+            = DateTime.parse(@register_data.get_entries.last[:timestamp]).strftime('%d/%m/%Y')
+            %strong.text-spacing -
+            = link_to "See all register updates", history_path(@register.slug)
 
       %h2.heading-medium About this register
       %p= @register_data.get_register_definition[:item]['text']
@@ -57,9 +59,9 @@
             %li
               = link_to "Register informaton", register_info_path(@register.slug)
             %li
-              = link_to "Register updates", history_path(@register.slug)
-            %li
               = link_to "API documentation", "https://registers-docs.cloudapps.digital", target: :blank
+          %h4.heading-small Help
+          %ul
             %li
               = link_to "Create a register", "https://www.gov.uk/guidance/creating-a-register", target: :blank
             %li
@@ -68,13 +70,7 @@
   .grid-row
     .column-one-whole
       .search-wrapper
-        .form-group-wrapper.js-enabled
-          = form_tag registers_path(@register.slug), method: :get, id: 'search_records' do
-            .form-group
-              = label_tag 'Filter by', nil, class: 'form-label', for: 'record_status'
-              = select_tag "status", options_for_select([['Existing records', 'current'], ['Closed records', 'closed'], ['Existing and closed records', 'all']], selected: params[:status]), class: "form-control", id: 'record_status'
-
-        %h3.heading-large #{@records.total_count} Records
+        %h3.heading-medium There are #{@register_data.get_records.count} Records in this register
 
         %details{:role => "group"}
           %summary{"aria-controls" => "details-content-0", "aria-expanded" => "false", :role => "button"}
@@ -91,6 +87,17 @@
               - @register_data.get_field_definitions.each do |field|
                 %dt= field[:item]['field']
                 %dd= field[:item]['text']
+
+        .form-group-wrapper.js-enabled
+          = form_tag register_path(@register.slug), method: :get, id: 'search_records' do
+            .form-group
+              = label_tag 'Show', nil, class: 'form-label', for: 'record_status'
+              = select_tag "status", options_for_select([['Existing records', 'current'], ['Closed records', 'closed'], ['Existing and closed records', 'all']], selected: params[:status]), class: "form-control", id: 'record_status'
+
+      %p
+        Showing
+        %strong.text-spacing= @records.count
+        records
 
       .table-scroll
         %table.register-data-table

--- a/app/views/spina/registers/show.html.haml
+++ b/app/views/spina/registers/show.html.haml
@@ -38,7 +38,7 @@
             = link_to @register.authority, "https://www.gov.uk/government/organisations/#{@register.authority.parameterize}", target: :blank
           %dt Updated:
           %dd
-            = DateTime.parse(@register_data.get_entries.last[:timestamp]).strftime('%d/%m/%Y')
+            = formatted_date(@register_data.get_entries.last[:timestamp])
             %strong.text-spacing -
             = link_to "See all register updates", history_path(@register.slug)
 

--- a/app/views/spina/registers/show.html.haml
+++ b/app/views/spina/registers/show.html.haml
@@ -97,7 +97,7 @@
       %p
         Showing
         %strong.text-spacing= @records.count
-        records
+        = 'record'.pluralize(@records.count)
 
       .table-scroll
         %table.register-data-table


### PR DESCRIPTION
Tweak layout of records header area and styling of new value on entries timeline

Context https://trello.com/c/FCIuHiPO && https://trello.com/c/GADrefEH

# After
<img width="811" alt="screen shot 2017-11-27 at 09 15 22" src="https://user-images.githubusercontent.com/3071606/33259196-0990855c-d354-11e7-9534-2a9ff0d52abb.png">
<img width="811" alt="screen shot 2017-11-27 at 09 15 28" src="https://user-images.githubusercontent.com/3071606/33259198-0b068d14-d354-11e7-92ba-0adfcd371ae6.png">
