### PR TITLE
Add serverside search to pipeline page

### DIFF
--- a/app/assets/stylesheets/modules/_search.scss
+++ b/app/assets/stylesheets/modules/_search.scss
@@ -1,4 +1,6 @@
 .records-search {
+  margin-bottom: 20px;
+
   .search-input {
     border: 2px solid #0b0c0c;
     font-size: 16px;

--- a/app/views/spina/registers/_register.html.haml
+++ b/app/views/spina/registers/_register.html.haml
@@ -1,4 +1,4 @@
-%tr{class: "js-filter-item", "data-filter-terms" => "#{register.name}"}
+%tr
   %th{"data-title" => index, }
     %h4.heading-xsmall= register.name
     - if register.register_phase == 'Backlog'

--- a/app/views/spina/registers/index.html.haml
+++ b/app/views/spina/registers/index.html.haml
@@ -64,13 +64,12 @@
             %span.data-item.bold-xsmall Registers in progress
 
   .grid-row
-    .column-two-thirds.js-hidden
-      %div{class: "js-filter-list", "aria-hidden" => "true"}
-        %form.js-filter-form
-          %fieldset
-            .form-group
-              %label{class: "form-label", for: "search"} Search for a register
-              %input{name: "search", id: "search", class: "form-control form-control-3-4"}
+    = search_form_for @search do |f|
+      .column-one-third
+        .records-search
+          = f.label :name_cont, 'Search', class: 'form-label'
+          = f.search_field :name_cont, class: 'search-input'
+          = f.submit 'Search', class: 'search-submit'
 
     .column-one-whole
       %h3.heading-small.mq-small-only Sort by:
@@ -84,16 +83,10 @@
             %th{role: "columnheader", scope: "col"}
               = sort_link(@search, :register_authority, "Managed by", default_order: :asc)
             %th{role: "columnheader", scope: "col", colspan: "2"}
-        %tbody.js-filter-block
+        %tbody
           - @registers.each_with_index do |register, index|
             - index = index + 1
             = render partial: 'spina/registers/register', object: register, locals: { index: index }
 
       %h3.heading-medium Suggest a register
       = link_to "Find out more", spina.new_register_path
-
-= content_for :javascript do
-  :javascript
-    jQuery(function($) {
-      GOVUK.filterListItems.init();
-    });

--- a/app/views/spina/registers/show.html.haml
+++ b/app/views/spina/registers/show.html.haml
@@ -76,7 +76,7 @@
             .column-one-third
               .records-search
                 = label_tag 'Search', nil, class: 'form-label', for: 'q'
-                = text_field_tag 'q', nil, class: 'search-input', value: params[:q]
+                = search_field_tag 'q', nil, class: 'search-input', value: params[:q]
                 = submit_tag 'Search', class: 'search-submit', name: nil
             .column-one-third
               .form-group.js-enabled


### PR DESCRIPTION
We are using [Ransack](https://github.com/activerecord-hackery/ransack#ransacks-search_form_for-helper-replaces-form_for-for-creating-the-view-search-form) on this view so the syntax is slightly different from the other search views.

We should look to use ransack on the other views.