### PR TITLE
Update registers client library to 0.3.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,7 @@ gem 'govuk_template'
 gem 'govuk_elements_rails'
 gem 'govspeak', '~> 3.4.0'
 gem 'govuk_elements_form_builder', git: 'https://github.com/ministryofjustice/govuk_elements_form_builder.git'
-gem 'registers-ruby-client', git: 'https://github.com/openregister/registers-ruby-client.git', tag: 'v0.1.1'
+gem 'registers-ruby-client', git: 'https://github.com/openregister/registers-ruby-client.git', tag: 'v0.3.0'
 
 # Spina CMS
 gem 'spina', github: 'denkGroot/Spina', branch: 'master'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -43,10 +43,10 @@ GIT
 
 GIT
   remote: https://github.com/openregister/registers-ruby-client.git
-  revision: f0f4326fc4f2b846e38b40dd0ac321e2068eb0c5
-  tag: v0.1.1
+  revision: 2e6edd4f2f15ac2801d33262713198135f7ebcfd
+  tag: v0.3.0
   specs:
-    registers-ruby-client (0.1.1)
+    registers-ruby-client (0.3.0)
       mini_cache (~> 1.1.0)
       rest-client (~> 2)
 

--- a/app/views/spina/registers/show.html.haml
+++ b/app/views/spina/registers/show.html.haml
@@ -38,7 +38,7 @@
             = link_to @register.authority, "https://www.gov.uk/government/organisations/#{@register.authority.parameterize}", target: :blank
           %dt Updated:
           %dd
-            = formatted_date(@register_data.get_entries.last[:timestamp])
+            = formatted_date(Array(@register_data.get_entries).last[:timestamp])
             %strong.text-spacing -
             = link_to "See all register updates", history_path(@register.slug)
 


### PR DESCRIPTION
### Context
This commit updates the version of the registers client library from 0.1.1 to 0.3.0. With this change, `Enumerable` objects are now returned from the majority of calls to the client library, which has necessitated a number of changes in this app to compensate.

### Changes proposed in this pull request
Update registers client library to 0.3.0.

### Guidance to review
I have attempted to avoid calling `to_a` on the results returned by the client library, where possible.
