### PR TITLE
format cardinality n records

### DIFF
--- a/app/views/spina/registers/_record.html.haml
+++ b/app/views/spina/registers/_record.html.haml
@@ -1,4 +1,5 @@
 %tr
   - @register_data.get_field_definitions.each do |field|
+    - field_value = record[:item][field[:item]['field']]
     %td{class: field[:item]['field']}
-      = record[:item][field[:item]['field']].is_a?(Array) ? (record[:item][field[:item]['field']]).join(', ') : record[:item][field[:item]['field']] || "<span class='unknown'>No data found</span>".html_safe
+      = field_value.is_a?(Array) ? field_value.join(', ') : field_value || "<span class='unknown'>No data found</span>".html_safe

--- a/app/views/spina/registers/_record.html.haml
+++ b/app/views/spina/registers/_record.html.haml
@@ -1,4 +1,4 @@
 %tr
   - @register_data.get_field_definitions.each do |field|
     %td{class: field[:item]['field']}
-      = record[:item][field[:item]['field']] || "<span class='unknown'>No data found</span>".html_safe
+      = record[:item][field[:item]['field']].is_a?(Array) ? (record[:item][field[:item]['field']]).join(', ') : record[:item][field[:item]['field']] || "<span class='unknown'>No data found</span>".html_safe


### PR DESCRIPTION
### Context
Previously the template made no allowance for cardinality N records, so they were styled using the default array to string representation

### Changes proposed in this pull request

Format as comma separated list:

before:

<img width="1030" alt="screen shot 2017-12-01 at 14 36 28" src="https://user-images.githubusercontent.com/1764158/33487531-7162ae54-d6a5-11e7-8386-3cb623879fb6.png">

after: 

<img width="1050" alt="screen shot 2017-12-01 at 14 36 05" src="https://user-images.githubusercontent.com/1764158/33487565-86b1a9e0-d6a5-11e7-89bd-ff029ea76c35.png">

_FAO @danmitchell- on the API inspector we markup these as `<li>` and use CSS to comma separate them. Should we do the same here?_

### Guidance to review
View register with cardinality n fields in frontend.


