### PR TITLE
Fix build-up of register register

### DIFF
--- a/app/controllers/spina/registers_controller.rb
+++ b/app/controllers/spina/registers_controller.rb
@@ -26,7 +26,7 @@ module Spina
       beta_register_register = @@registers_client.get_register('register', 'beta').get_records
       alpha_register_register = @@registers_client.get_register('register', 'alpha').get_records
       discovery_register_register = @@registers_client.get_register('register', 'discovery').get_records
-      @register_registers = [beta_register_register, alpha_register_register, discovery_register_register]
+      @register_registers = beta_register_register.to_a + alpha_register_register.to_a + discovery_register_register.to_a
     end
 
     def show


### PR DESCRIPTION
This PR fixes the build-up of the `@register_registers` variable in the `RegistersController`, so that the generated array contains all registers from all environments, rather than containing sub-arrays of registers of those environments. 

To the extent of my Ruby knowledge, I believe that combining registers in the way I originally thought possible (creating an array by passing in the separate args i.e. `[registers, more_registers, etc]`) and instead by calling `to_a` on each individual register group and then using the `+` operator are probably equivalent behind the scenes, but I'm happy to be corrected on this.