### PR TITLE
Fix pagination when search of filter parameters already exist

### DIFF
--- a/app/views/spina/registers/history.html.haml
+++ b/app/views/spina/registers/history.html.haml
@@ -40,4 +40,4 @@
           Showing #{@entries_with_items.offset_value + 1} &ndash; #{@entries_with_items.offset_value + @entries_with_items.length} of #{@entries_with_items.total_count} records
 
       - unless @entries_with_items.last_page?
-        = link_to 'Load more', history_path(@register.slug, page: @entries_with_items.current_page + 1), id: 'load-more-entries', class: 'js-hidden', remote: true
+        = link_to_next_page @entries_with_items, 'Load more', id: 'load-more-entries', class: 'js-hidden', remote: true

--- a/app/views/spina/registers/history.js.erb
+++ b/app/views/spina/registers/history.js.erb
@@ -1,8 +1,7 @@
 $("#entries-list").append("<%= j(render(partial: 'timeline_record', collection: @entries_with_items)) %>");
-$("#load-more-entries").attr("href", "<%= history_path(@register.slug, page: (@entries_with_items.current_page + 1)) %>");
 
 <% if @entries_with_items.last_page? %>
   $("#load-more-entries").hide();
 <% else %>
-  $("#load-more-entries").attr("href", "<%= history_path(@register.slug, page: (@entries_with_items.current_page + 1)) %>");
+  $("#load-more-entries").replaceWith("<%= escape_javascript(link_to_next_page @entries_with_items, 'Load more', id: 'load-more-entries', class: 'js-hidden', remote: true) %>");
 <% end %>

--- a/app/views/spina/registers/show.html.haml
+++ b/app/views/spina/registers/show.html.haml
@@ -125,7 +125,7 @@
             Showing #{@records.offset_value + 1} &ndash; #{@records.offset_value + @records.length} of #{@records.total_count} records
 
         - unless @records.last_page?
-          = link_to 'Load more', register_path(@register.slug, page: @records.current_page + 1), id: 'load-more-records', class: 'js-hidden', remote: true
+          = link_to_next_page @records, 'Load more', id: 'load-more-records', class: 'js-hidden', remote: true
 
 = content_for :javascript do
   :javascript

--- a/app/views/spina/registers/show.js.erb
+++ b/app/views/spina/registers/show.js.erb
@@ -1,10 +1,8 @@
 $("#records-tbody").append("<%= j(render(partial: 'record', collection: @records)) %>");
-$("#load-more-records").attr("href", "<%= register_path(@register.slug, page: (@records.current_page + 1)) %>");
-
 $("#records-count").html("Showing<strong class='text-spacing'><%= @records.count + @records.offset_value %></strong><%= 'record'.pluralize(@records.count + @records.offset_value) %>")
 
 <% if @records.last_page? %>
   $("#load-more-records").hide();
 <% else %>
-  $("#load-more-records").attr("href", "<%= register_path(@register.slug, page: (@records.current_page + 1)) %>");
+  $("#load-more-records").replaceWith("<%= escape_javascript(link_to_next_page @records, 'Load more', id: 'load-more-records', class: 'js-hidden', remote: true) %>");
 <% end %>


### PR DESCRIPTION
Using the `link_to_next_page` method solves the issues of ignoring other parameters when paginating