### PR TITLE
Add non js submit button for filtering records

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -518,3 +518,13 @@ dl dd {
 .text-spacing {
   margin: 0 5px;
 }
+
+.filter-search-submit {
+  body.js-enabled & {
+    display: none;
+  }
+
+  @include media(tablet) {
+    margin-top: 26px;
+  }
+}

--- a/app/views/spina/registers/show.html.haml
+++ b/app/views/spina/registers/show.html.haml
@@ -79,9 +79,11 @@
                 = search_field_tag 'q', nil, class: 'search-input', value: params[:q]
                 = submit_tag 'Search', class: 'search-submit', name: nil
             .column-one-third
-              .form-group.js-enabled
+              .form-group
                 = label_tag 'Show', nil, class: 'form-label', for: 'record_status'
                 = select_tag "status", options_for_select([['Existing records', 'current'], ['Closed records', 'closed'], ['Existing and closed records', 'all']], selected: params[:status]), class: "form-control", id: 'record_status'
+            .column-one-third
+              = submit_tag 'Search', name: nil, class: 'button filter-search-submit'
 
         %details{role: "group"}
           %summary{"aria-controls" => "details-content-0", "aria-expanded" => "false", :role => "button"}


### PR DESCRIPTION
Story - https://trello.com/c/ytl59CF0

Allow users to filter records when JS is not enabled

# After without JS enabled
![screen shot 2017-12-05 at 15 29 48](https://user-images.githubusercontent.com/3071606/33615117-2746cd1c-d9d1-11e7-910f-8d2bc1a29342.png)

# After with JS enabled
![screen shot 2017-12-05 at 15 30 20](https://user-images.githubusercontent.com/3071606/33615143-37175c98-d9d1-11e7-9929-387529ddcf55.png)

