### PR TITLE
fix conflicting method name

### DIFF
--- a/app/decorators/helpers/spina/application_helper_decorator.rb
+++ b/app/decorators/helpers/spina/application_helper_decorator.rb
@@ -58,7 +58,7 @@ module Spina
       DateTime.parse(date).strftime('%d/%m/%Y')
     end
 
-    def sort_link(field_value, query_parameters)
+    def records_table_sort_link(field_value, query_parameters)
       direction = params[:sort_direction] == 'asc' && params[:sort_by] == field_value ? 'desc' : 'asc'
       css_class = params[:sort_by] == field_value ? "sort-link #{direction}" : nil
 

--- a/app/views/spina/registers/show.html.haml
+++ b/app/views/spina/registers/show.html.haml
@@ -115,7 +115,7 @@
             %thead
               %tr
                 - @register_data.get_field_definitions.each do |field|
-                  %th= field[:item]['cardinality'] == '1' ? sort_link(field[:item]['field'], request.query_parameters) : field[:item]['field']
+                  %th= field[:item]['cardinality'] == '1' ? records_table_sort_link(field[:item]['field'], request.query_parameters) : field[:item]['field']
             %tbody#records-tbody
               = render partial: 'record', collection: @records
 


### PR DESCRIPTION
The pipeline page was throwing an exception because our method name was conflicting with the `sort_link` helper provided by ransack.