### PR TITLE
Revert "move cups service name to config"

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -22,7 +22,7 @@ module RegisterStatus
     # -- all .rb files in that directory are automatically loaded.
 
     if ENV.key?('VCAP_SERVICES')
-      cups_env = CF::App::Credentials.find_by_service_name(Rails.configiration.cups_environment_variables_service_name)
+      cups_env = CF::App::Credentials.find_by_service_name('registers-product-site-environment-variables')
       if cups_env.present?
         cups_env.each { |k, v| ENV[k] = v }
       end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -80,5 +80,4 @@ Rails.application.configure do
   config.active_record.dump_schema_after_migration = false
 
   config.action_mailer.default_url_options = { host: 'https://registers.cloudapps.digital' }
-  config.cups_environment_variables_service_name = 'registers-product-site-environment-variables'
 end

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -80,5 +80,4 @@ Rails.application.configure do
   config.active_record.dump_schema_after_migration = false
 
   config.action_mailer.default_url_options = { host: 'https://registers-staging.herokuapp.com/' }
-  config.cups_environment_variables_service_name = 'registers-product-site-environment-variables'
 end


### PR DESCRIPTION
Reverts openregister/registers-frontend#73

Didn't work :-( deploy is failing with 

```
 undefined method `configiration' for Rails:Module
```

I guess something to do with the initialisation order.