### PR TITLE
add number delimiter

### DIFF
--- a/app/views/spina/registers/show.html.haml
+++ b/app/views/spina/registers/show.html.haml
@@ -70,7 +70,7 @@
   .grid-row
     .column-one-whole
       .search-records-wrapper#search_wrapper
-        %h3.heading-medium There are #{pluralize(@register_data.get_records.count, 'Record')} in this register
+        %h3.heading-medium There are #{number_with_delimiter(@register_data.get_records.count)} #{'record'.pluralize(@register_data.get_records.count)} in this register
         .grid-row
           = form_tag register_path(@register.slug, anchor: 'search_wrapper'), method: :get, id: 'search_records' do
             .column-one-third


### PR DESCRIPTION
### Context
We were not formatting the records header nicely before.

### Changes proposed in this pull request

#### Before
<img width="498" alt="screen shot 2017-12-08 at 16 59 34" src="https://user-images.githubusercontent.com/1764158/33776412-3607fbe0-dc39-11e7-87ab-e0a089f97833.png">


#### After
<img width="468" alt="screen shot 2017-12-08 at 16 51 26" src="https://user-images.githubusercontent.com/1764158/33776364-0cf5ffb8-dc39-11e7-820d-89961c21f4c4.png">


### Guidance to review
Load large register