### PR TITLE
add healthcheck

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,7 @@ gem 'zendesk_api'
 
 # Cloudfoundry ruby helper
 gem 'cf-app-utils'
+gem 'health_check', '~> 2.7'
 
 # Email and Text Notifications
 gem 'govuk_notify_rails'
@@ -60,7 +61,6 @@ group :development do
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
   gem 'web-console', '>= 3.3.0'
-  
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -198,6 +198,8 @@ GEM
       railties (>= 4.0.1)
     hashdiff (0.3.7)
     hashie (3.5.6)
+    health_check (2.7.0)
+      rails (>= 4.0)
     html2haml (2.2.0)
       erubis (~> 2.7.0)
       haml (>= 4.0, < 6)
@@ -442,6 +444,7 @@ DEPENDENCIES
   govuk_notify_rails
   govuk_template
   haml-rails
+  health_check (~> 2.7)
   http (= 2.2.1)
   jbuilder (~> 2.5)
   jquery-rails

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  health_check_routes
   mount Spina::Engine => '/'
 
   Spina::Engine.routes.draw do

--- a/manifest.yml
+++ b/manifest.yml
@@ -6,6 +6,8 @@ applications:
   instances: 2
   domain: registers-trial.service.gov.uk
   no-hostname: true
+  health-check-type: http
+  health-check-http-endpoint: /health_check/standard
   services:
     # postgres database
     - registers-prod


### PR DESCRIPTION
### Context
Add a healthcheck as this is a requirement of the [Production checklist](https://docs.cloud.service.gov.uk/#production-checklist)

### Changes proposed in this pull request
Add `health_check` gem, this is the same as we use on `managing-registers`. Though in this case we need to add a line to the routes file to stop Spina attempting to resolve this route, so we cannot scope the dependency just to `production`. As basic auth is added just to the Spina routes, it will not apply to the healthcheck.

### Guidance to review
GET `/health_check/standard` should return `success`