### PR TITLE
set git commit hash env var in deploy script

### DIFF
--- a/bin/deploy
+++ b/bin/deploy
@@ -12,3 +12,4 @@ cf login -a $CF_API -u $CF_USERNAME -p $CF_PASSWORD -o $CF_ORG -s $CF_SPACE
 # Zero downtime push comes from "Autopilot" which is installed in before_deploy
 # step in Travis
 cf zero-downtime-push $APP_NAME -f manifest.yml
+cf set-env $APP_NAME GIT_COMMIT_HASH $TRAVIS_COMMIT


### PR DESCRIPTION
### Context
It is useful when debugging to know which version of the software is running on an environment. Furthermore, this may be useful in future for production monitoring (e.g. checking deploys were successful)

### Changes proposed in this pull request
Set git commit hash env var in deploy script. Note this will only be set if you deploy through Travis, but we should be doing this anyway so tests run etc.
![screen shot 2017-12-11 at 15 42 44](https://user-images.githubusercontent.com/1764158/33841130-c1368e96-de8e-11e7-9b2c-08987cee50a3.png)

### Guidance to review
When deploying through Travis `cf env` should show git commit hash.