### PR TITLE
link to url if datatype url

### DIFF
--- a/app/views/spina/registers/_record.html.haml
+++ b/app/views/spina/registers/_record.html.haml
@@ -2,4 +2,4 @@
   - @register_data.get_field_definitions.each do |field|
     - field_value = record[:item][field[:item]['field']]
     %td{class: field[:item]['field']}
-      = field_value.is_a?(Array) ? field_value.join(', ') : field_value || "<span class='unknown'>No data found</span>".html_safe
+      = field_value.is_a?(Array) ? field_value.join(', ') : link_to_if(field[:item]['datatype'] == 'url', field_value, field_value) || "<span class='unknown'>No data found</span>".html_safe


### PR DESCRIPTION
### Context
As requested by custodian

### Changes proposed in this pull request
If datatype is URL link to URL 
<img width="778" alt="screen shot 2017-12-11 at 17 19 26" src="https://user-images.githubusercontent.com/1764158/33844229-8e42f9da-de97-11e7-8ec5-9a71824dd447.png">

### Guidance to review
View register with URL datatype field