### PR TITLE
Add support links and cookie link to footer

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -139,6 +139,33 @@ dl dd {
   margin-top: 40px;
 }
 
+.footer-nav {
+  font-size: 14px;
+  padding: 8px 0;
+  margin-bottom: 20px;
+
+  @include media(tablet) {
+    font-size: 16px;
+    padding: 5px 0;
+  }
+
+  a {
+    display: inline-block;
+    margin-right: 15px
+  }
+}
+
+.footer-categories {
+  border-bottom: 1px solid $grey-2;
+  margin-bottom: 20px;
+  padding-bottom: 40px;
+
+  ul {
+    margin: 0;
+    padding-left: 0;
+  }
+}
+
 .phase {
   background-color: $govuk-blue;
   color: $page-colour;

--- a/app/views/layouts/default/application.html.haml
+++ b/app/views/layouts/default/application.html.haml
@@ -30,4 +30,20 @@
   = javascript_include_tag 'application'
   = yield(:javascript)
 
+- content_for :footer_top do
+  .footer-categories
+    .grid-row
+      .column-one-quarter
+        %ul
+          %li
+            = link_to "Support", spina.support_path
+          %li
+            = link_to "Performance", "https://www.gov.uk/performance/govuk-registers", target: :blank
+          %li
+            = link_to "Slack channel", "https://ukgovernmentdigital.slack.com/messages/govuk-registers", target: :blank
+
+- content_for :footer_support_links do
+  %nav.footer-nav
+    Built by the #{link_to 'Government Digital Service', 'https://www.gov.uk/government/organisations/government-digital-service'} #{link_to 'Cookies', '/cookies'}
+
 = render file: 'layouts/govuk_template'


### PR DESCRIPTION
### Context
https://trello.com/c/8jZRe85e
Help users find support and performance information regarding GOV.UK Registers

### Changes proposed in this pull request
Adding support links and coookie link to our footer

### Guidance to review
Check footer links

# After
<img width="955" alt="screen shot 2017-12-12 at 09 31 42" src="https://user-images.githubusercontent.com/3071606/33877112-48cd26b8-df1f-11e7-8f56-bedd650715c8.png">
