### PR TITLE
Fix wrapping header links in register table

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -191,9 +191,13 @@ dl dd {
     vertical-align: middle;
     word-wrap: break-word;
     white-space: normal;
+
+    a {
+      white-space: nowrap;
+    }
   }
 
-    tr {
+  tr {
     width: 100%;
   }
 

--- a/app/views/spina/registers/_record.html.haml
+++ b/app/views/spina/registers/_record.html.haml
@@ -1,5 +1,5 @@
 %tr
   - @register_data.get_field_definitions.each do |field|
     - field_value = record[:item][field[:item]['field']]
-    %td{class: field[:item]['field']}
+    %td
       = field_value.is_a?(Array) ? field_value.join(', ') : link_to_if(field[:item]['datatype'] == 'url', field_value, field_value) || "<span class='unknown'>No data found</span>".html_safe


### PR DESCRIPTION
### Context
Long header titles wrap which breaks the position of the sorting arrow

### Changes proposed in this pull request
Don't wrap header links

### Guidance to review
#### Before

<img width="1382" alt="screen shot 2017-12-12 at 14 43 46" src="https://user-images.githubusercontent.com/3071606/33890349-e4b430b4-df4a-11e7-8187-fb1df4c0171b.png">
<img width="1382" alt="screen shot 2017-12-12 at 16 24 28" src="https://user-images.githubusercontent.com/3071606/33895688-f83340b8-df58-11e7-8317-dfea1750e62d.png">

#### After

<img width="1382" alt="screen shot 2017-12-12 at 14 43 30" src="https://user-images.githubusercontent.com/3071606/33890350-e5160f50-df4a-11e7-947f-6740ba2ca24a.png">
<img width="1382" alt="screen shot 2017-12-12 at 16 25 37" src="https://user-images.githubusercontent.com/3071606/33895750-1ae0d6e8-df59-11e7-97c7-bc6f9730a4bc.png">
