### PR TITLE
flip arrows

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -576,11 +576,11 @@ dl dd {
     top: 7px;
   }
 
-  &.asc:after {
+  &.desc:after {
     border-bottom: 8px solid $govuk-blue;
   }
 
-  &.desc:after {
+  &.asc:after {
     border-top: 8px solid $govuk-blue;
   }
 }


### PR DESCRIPTION
### Context
We have decided sorting arrows were the wrong way round

### Changes proposed in this pull request
Flip sorting arrows 
<img width="144" alt="screen shot 2017-12-14 at 11 19 16" src="https://user-images.githubusercontent.com/1764158/33989799-b23149fc-e0c0-11e7-9a87-b1f9a358ecb0.png">
<img width="134" alt="screen shot 2017-12-14 at 11 19 23" src="https://user-images.githubusercontent.com/1764158/33989802-b479b528-e0c0-11e7-92e8-975ea92a2c02.png">


### Guidance to review
Load register and click on column heading