### PR TITLE
Fix gov orgs within CMS

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,10 +3,4 @@ class ApplicationController < Spina::ApplicationController
 
   protect_from_forgery with: :exception
   http_basic_authenticate_with name: ENV['HTTP_AUTH_USERNAME'], password: ENV['HTTP_AUTH_PASSWORD'] if Rails.env.production?
-
-  before_action :initialize_client
-
-  def initialize_client
-    @@registers_client ||= RegistersClient::RegisterClientManager.new(cache_duration: 600)
-  end
 end

--- a/app/controllers/spina/admin/registers_controller.rb
+++ b/app/controllers/spina/admin/registers_controller.rb
@@ -3,7 +3,6 @@ module Spina
     class RegistersController < AdminController
 
       before_action :set_breadcrumb, :set_register, only: [:edit, :update, :destroy]
-      before_action :initialize_client
       before_action :set_government_organisations, only: [:new, :edit]
 
       layout "spina/admin/admin"
@@ -53,10 +52,6 @@ module Spina
 
       def set_breadcrumb
         add_breadcrumb t('spina.registers.scaffold_name_plural'), spina.admin_registers_path
-      end
-
-      def initialize_client
-        @@registers_client ||= RegistersClient::RegisterClientManager.new(cache_duration: 600)
       end
 
       def set_government_organisations

--- a/app/controllers/spina/admin/registers_controller.rb
+++ b/app/controllers/spina/admin/registers_controller.rb
@@ -3,6 +3,8 @@ module Spina
     class RegistersController < AdminController
 
       before_action :set_breadcrumb, :set_register, only: [:edit, :update, :destroy]
+      before_action :initialize_client
+      before_action :set_government_organisations, only: [:new, :edit]
 
       layout "spina/admin/admin"
 
@@ -51,6 +53,15 @@ module Spina
 
       def set_breadcrumb
         add_breadcrumb t('spina.registers.scaffold_name_plural'), spina.admin_registers_path
+      end
+
+      def initialize_client
+        @@registers_client ||= RegistersClient::RegisterClientManager.new(cache_duration: 600)
+      end
+
+      def set_government_organisations
+        register_data = @@registers_client.get_register('government-organisation', 'beta')
+        @government_organisations = register_data.get_records
       end
 
       def register_params

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -24,11 +24,6 @@ module ApplicationHelper
     end
   end
 
-  def government_organisations
-    register_data = @@registers_client.get_register('government-organisation', 'beta')
-    register_data.get_records
-  end
-
   def phase_label(phase)
     case phase
     when 'Beta'

--- a/app/views/spina/admin/registers/_form.html.haml
+++ b/app/views/spina/admin/registers/_form.html.haml
@@ -53,7 +53,7 @@
         .horizontal-form-label
           Authority
         .horizontal-form-content
-          = f.select :authority, government_organisations.map{|c| c[:item]['name']}, {data: { "default-value" => @register.authority }}
+          = f.select :authority, @government_organisations.map{|c| c.item.value['name']}, {data: { "default-value" => @register.authority }}
       .horizontal-form-group
         .horizontal-form-label
           = Spina::Page.human_attribute_name :custodian

--- a/config/initializers/registers_client.rb
+++ b/config/initializers/registers_client.rb
@@ -1,0 +1,1 @@
+@@registers_client ||= RegistersClient::RegisterClientManager.new(cache_duration: 600)


### PR DESCRIPTION
This was broken during the upgrade to v4 of the client library.

The CMS doesn't have access to the application_controller so we need to initialize separately.

