### PR TITLE
Store System Keys in DB and use in view

### DIFF
--- a/app/controllers/registers_controller.rb
+++ b/app/controllers/registers_controller.rb
@@ -35,7 +35,7 @@ class RegistersController < ApplicationController
   end
 
   def get_register_definition
-    @register.slug
+    Record.find_by(spina_register_id: @register.id, key: "register:#{params[:id]}").data
   end
 
   def get_field_definitions
@@ -131,9 +131,9 @@ class RegistersController < ApplicationController
     records = []
 
     register_data.get_metadata_records.each do |record|
-      new_entry = Entry.new(spina_register: register, data: record.item.value, timestamp: record.entry.timestamp, hash_value: record.entry.hash, entry_type: 'system', key: record.item.value['name'])
+      new_entry = Entry.new(spina_register: register, data: record.item.value, timestamp: record.entry.timestamp, hash_value: record.entry.hash, entry_type: 'system', key: record.entry.key)
       entries.push(new_entry)
-      records.push(Record.new(spina_register: register, data: record.item.value, timestamp: record.entry.timestamp, hash_value: record.entry.hash, entry_type: 'system', key: record.item.value['name']))
+      records.push(Record.new(spina_register: register, data: record.item.value, timestamp: record.entry.timestamp, hash_value: record.entry.hash, entry_type: 'system', key: record.entry.key))
     end
 
     bulk_save(entries, records)

--- a/app/controllers/registers_controller.rb
+++ b/app/controllers/registers_controller.rb
@@ -39,9 +39,10 @@ class RegistersController < ApplicationController
   end
 
   def get_field_definitions
+    ordered_field_keys = get_register_definition['fields'].map { |f| "field:#{f}" }
     Record.where(spina_register_id: @register.id)
-      .where("data->> 'field' is not null")
-      .where(entry_type: 'system')
+      .where(key: ordered_field_keys)
+      .order("position(key::text in '#{ordered_field_keys.join(',')}')")
       .map { |entry| entry[:data] }
   end
 

--- a/app/controllers/registers_controller.rb
+++ b/app/controllers/registers_controller.rb
@@ -31,7 +31,8 @@ class RegistersController < ApplicationController
       .where(spina_register_id: @register.id, entry_type: 'user')
       .limit(1)
       .order(timestamp: :desc)
-      .first[:timestamp].to_s
+      .first[:timestamp]
+      .to_s
   end
 
   def get_register_definition
@@ -40,8 +41,7 @@ class RegistersController < ApplicationController
 
   def get_field_definitions
     ordered_field_keys = get_register_definition['fields'].map { |f| "field:#{f}" }
-    Record.where(spina_register_id: @register.id)
-      .where(key: ordered_field_keys)
+    Record.where(spina_register_id: @register.id, key: ordered_field_keys)
       .order("position(key::text in '#{ordered_field_keys.join(',')}')")
       .map { |entry| entry[:data] }
   end

--- a/app/views/registers/show.html.haml
+++ b/app/views/registers/show.html.haml
@@ -43,7 +43,7 @@
             = link_to "See all register updates", history_path(@register.slug)
 
       %h2.heading-medium About this register
-      %p=get_register_definition
+      %p=get_register_definition['text']
 
       %details{role: "group"}
         %summary{"aria-controls" => "details-content-0", "aria-expanded" => "false", :role => "button"}


### PR DESCRIPTION
### Context
Previously we were not correctly storing system entry keys in the DB. This resulted in some placeholders and sub-optimal lookups.

### Changes proposed in this pull request
* Store system entry keys in the DB
* Show register definition text in frontend
* Sort fields according to register definition

#### Before

<img width="1011" alt="screen shot 2017-12-18 at 12 34 56" src="https://user-images.githubusercontent.com/1764158/34106534-7dc714c0-e3f0-11e7-9524-2a6f77195dbe.png">
<img width="332" alt="screen shot 2017-12-18 at 12 34 51" src="https://user-images.githubusercontent.com/1764158/34106535-7ddc1514-e3f0-11e7-920b-fc7e2780b22a.png">

#### After 
<img width="455" alt="screen shot 2017-12-18 at 12 34 27" src="https://user-images.githubusercontent.com/1764158/34106557-8eb7240a-e3f0-11e7-8d11-ddf44c7ada1e.png">
<img width="1006" alt="screen shot 2017-12-18 at 12 34 34" src="https://user-images.githubusercontent.com/1764158/34106556-8ea25386-e3f0-11e7-8f20-5541eb7142d5.png">




### Guidance to review
