### PR TITLE
Update database service

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -10,6 +10,6 @@ applications:
   health-check-http-endpoint: /health_check/standard
   services:
     # postgres database
-    - registers-prod
+    - registers-frontend
     # environment variables (persisted for blue/green deploys)
     - registers-product-site-environment-variables


### PR DESCRIPTION
The current register-trial domain uses the same database as registers.cloudapps.digital but we want to separate these now to enable further development.