### PR TITLE
remove redundant limit

### DIFF
--- a/app/controllers/registers_controller.rb
+++ b/app/controllers/registers_controller.rb
@@ -29,7 +29,6 @@ class RegistersController < ApplicationController
   def get_last_timestamp
     Record.select('timestamp')
       .where(spina_register_id: @register.id, entry_type: 'user')
-      .limit(1)
       .order(timestamp: :desc)
       .first[:timestamp].to_s
   end


### PR DESCRIPTION
### Changes proposed in this pull request
By calling `.first` the ORM adds `LIMIT 1` so there is no need to specify this.
e.g.
```
Record Load (4.8ms)  SELECT  "records"."timestamp" FROM "records" WHERE "records"."spina_register_id" = $1 AND "records"."entry_type" = $2 ORDER BY "records"."timestamp" DESC LIMIT $3  [["spina_register_id", 8], ["entry_type", "user"], ["LIMIT", 1]]
```

### Guidance to review
Check generated query