### PR TITLE
Use local DB to render history page

### DIFF
--- a/app/views/registers/_timeline_record.html.haml
+++ b/app/views/registers/_timeline_record.html.haml
@@ -1,8 +1,8 @@
 %li.entries__item
   %p.entries__date
     Last updated:
-    = DateTime.parse(timeline_record[:current_record].entry.timestamp).strftime('%d/%m/%Y')
-  %h3.heading-medium= timeline_record[:current_record].entry.key
+    = DateTime.parse(timeline_record[:current_record].timestamp.to_s).strftime('%d/%m/%Y')
+  %h3.heading-medium= timeline_record[:current_record].key
   %table
     %thead
       %tr
@@ -15,9 +15,9 @@
           %td
             = field_name
           %td
-            = timeline_record[:previous_record].present? ? timeline_record[:previous_record].item.value[field_name] : "<span class='unknown'>No data found</span>".html_safe
+            = timeline_record[:previous_record].present? ? timeline_record[:previous_record].data[field_name] : "<span class='unknown'>No data found</span>".html_safe
           %td
-            - if timeline_record[:current_record].item.value[field_name].present?
-              %span.panel.panel-change-notification= timeline_record[:current_record].item.value[field_name]
+            - if timeline_record[:current_record].data[field_name].present?
+              %span.panel.panel-change-notification= timeline_record[:current_record].data[field_name]
             - else
               %span.unknown No data found

--- a/app/views/registers/history.html.haml
+++ b/app/views/registers/history.html.haml
@@ -38,7 +38,7 @@
 
       .pager
         .pager-controls
-          = paginate @entries_with_items, outer_window: 0, window: 3
+          = paginate @entries_with_items, total_pages: @total_pages, outer_window: 0, window: 3
         .pager-summary
           Showing #{@entries_with_items.offset_value + 1} &ndash; #{@entries_with_items.offset_value + @entries_with_items.length} of #{@entries_with_items.total_count} records
 

--- a/db/migrate/20171206102006_create_entries.rb
+++ b/db/migrate/20171206102006_create_entries.rb
@@ -2,6 +2,8 @@ class CreateEntries < ActiveRecord::Migration[5.1]
   def change
     create_table :entries do |t|
       t.text :hash_value
+      t.integer :entry_number
+      t.integer :previous_entry_number
       t.text :entry_type
       t.text :key
       t.datetime :timestamp

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -17,6 +17,8 @@ ActiveRecord::Schema.define(version: 20171207145923) do
 
   create_table "entries", force: :cascade do |t|
     t.text "hash_value"
+    t.integer "entry_number"
+    t.integer "previous_entry_number"
     t.text "entry_type"
     t.text "key"
     t.datetime "timestamp"
@@ -29,6 +31,7 @@ ActiveRecord::Schema.define(version: 20171207145923) do
 
   create_table "records", force: :cascade do |t|
     t.text "hash_value"
+    t.integer "entry_number"
     t.text "entry_type"
     t.text "key"
     t.datetime "timestamp"

--- a/spec/controllers/registers_controller_spec.rb
+++ b/spec/controllers/registers_controller_spec.rb
@@ -95,20 +95,6 @@ RSpec.describe RegistersController, type: :controller do
     end
   end
 
-  describe 'Request: GET #history. Descr: Check with filter. Params: Search param (field name). Result: 3 rows' do
-    subject { get :history, params: { id: 'territory', q: 'official-name' } }
-
-    it { is_expected.to have_http_status :success }
-
-    it { is_expected.to render_template :history }
-
-    it do
-      subject
-
-      expect(assigns(:entries_with_items).length).to eq(3)
-    end
-  end
-
   describe 'Request: GET #history. Descr: Check with filter. Params: Search param (changed field). Result: 1 rows' do
     subject { get :history, params: { id: 'territory', q: 'The New' } }
 


### PR DESCRIPTION
### Context

This PR changes the history page to get data from the local database instance, rather than via the client library. It does this by adding `entry_number` and `previous_entry_number` to the `Entry` model. Three queries are made to the database: one query to get a set of 100 entries ordered descending on entry number, another query to get the total number of entries and the third to get the required previous entries.

### Changes proposed in this pull request

Use local database to build-up the history page, rather than the client library.
