### PR TITLE
Extend register meta data

### DIFF
--- a/app/controllers/spina/admin/registers_controller.rb
+++ b/app/controllers/spina/admin/registers_controller.rb
@@ -60,7 +60,7 @@ module Spina
       end
 
       def register_params
-        params.require(:register).permit(:name, :slug, :history, :register_phase, :authority, :description)
+        params.require(:register).permit(:name, :slug, :register_phase, :authority, :description, :contextual_data, :related_registers)
       end
     end
   end

--- a/app/views/registers/_register.html.haml
+++ b/app/views/registers/_register.html.haml
@@ -11,6 +11,8 @@
     %div{class: "govuk-organisation-logo #{register.authority.parameterize}"}
       %div{class: "logo-container #{crest_class_name(register.authority.parameterize)}"}
         %span= register.authority
-  %td{class: "links", "data-title" => "View more: "}
-    = link_to "View register", register_path(register.slug)
-
+  - if register.register_phase != 'Backlog'
+    %td{class: "links", "data-title" => "View more: "}
+      = link_to "View register", register_path(register.slug)
+  - else
+    %td

--- a/app/views/registers/show.html.haml
+++ b/app/views/registers/show.html.haml
@@ -44,9 +44,20 @@
             = formatted_date(Array(@register_data.get_entries).last.timestamp)
             %strong.text-spacing -
             = link_to "See all register updates", history_path(@register.slug)
+          - if @register.related_registers.present?
+            %dt Related registers:
+            %dd
+              != @register.related_registers
+          - if @register.contextual_data.present?
+            %dt Contextual data:
+            %dd
+              != @register.contextual_data
 
       %h2.heading-medium About this register
-      %p= @register_data.get_register_definition.item.value['text']
+      - if @register.register_phase == 'Backlog'
+        != @register.description
+      - else
+        %p= @register_data.get_register_definition.item.value['text']
 
       %details{role: "group"}
         %summary{"aria-controls" => "details-content-0", "aria-expanded" => "false", :role => "button"}

--- a/app/views/registers/show.html.haml
+++ b/app/views/registers/show.html.haml
@@ -55,7 +55,7 @@
 
       %h2.heading-medium About this register
       - if @register.register_phase == 'Backlog'
-        != @register.description
+        = @register.description
       - else
         %p= @register_data.get_register_definition.item.value['text']
 

--- a/app/views/spina/admin/registers/_form.html.haml
+++ b/app/views/spina/admin/registers/_form.html.haml
@@ -37,7 +37,7 @@
         .horizontal-form-label
           Description
         .horizontal-form-content
-          = f.text_area :description, rows: "2"
+          = render 'spina/admin/shared/rich_text_field', f: f, field: :description
       .horizontal-form-group
         .horizontal-form-label
           = Spina::Page.human_attribute_name :register_phase
@@ -51,9 +51,15 @@
           = f.select :authority, @government_organisations.map{|c| c.item.value['name']}, {data: { "default-value" => @register.authority }}
       .horizontal-form-group
         .horizontal-form-label
-          Introduction
+          = Spina::Page.human_attribute_name :contextual_data
         .horizontal-form-content
-          = f.text_area :history, rows: "6"
+          = render 'spina/admin/shared/rich_text_field', f: f, field: :contextual_data
+      .horizontal-form-group
+        .horizontal-form-label
+          = Spina::Page.human_attribute_name :related_registers
+        .horizontal-form-content
+          = render 'spina/admin/shared/rich_text_field', f: f, field: :related_registers
+
 
   - unless @register.new_record?
     .pull-right= link_to t('spina.permanently_delete'), spina.admin_register_path(@register), method: :delete, data: {confirm: t('spina.pages.delete_confirmation', subject: @register.name) }, class: 'button button-link button-danger'

--- a/app/views/spina/admin/registers/_form.html.haml
+++ b/app/views/spina/admin/registers/_form.html.haml
@@ -37,7 +37,7 @@
         .horizontal-form-label
           Description
         .horizontal-form-content
-          = render 'spina/admin/shared/rich_text_field', f: f, field: :description
+          = f.text_field :description
       .horizontal-form-group
         .horizontal-form-label
           = Spina::Page.human_attribute_name :register_phase

--- a/db/migrate/20171219102921_add_related_registers_to_spina_registers.rb
+++ b/db/migrate/20171219102921_add_related_registers_to_spina_registers.rb
@@ -1,0 +1,5 @@
+class AddRelatedRegistersToSpinaRegisters < ActiveRecord::Migration[5.1]
+  def change
+    add_column :spina_registers, :related_registers, :text
+  end
+end

--- a/db/migrate/20171219103147_rename_history_to_contextual_data_in_spina_registers.rb
+++ b/db/migrate/20171219103147_rename_history_to_contextual_data_in_spina_registers.rb
@@ -1,0 +1,5 @@
+class RenameHistoryToContextualDataInSpinaRegisters < ActiveRecord::Migration[5.1]
+  def change
+    rename_column :spina_registers, :history, :contextual_data
+  end
+end

--- a/db/migrate/20171220104627_change_spina_register_description_to_string.rb
+++ b/db/migrate/20171220104627_change_spina_register_description_to_string.rb
@@ -1,0 +1,9 @@
+class ChangeSpinaRegisterDescriptionToString < ActiveRecord::Migration[5.1]
+  def self.up
+    change_column :spina_registers, :description, :string
+  end
+
+  def self.down
+    change_column :spina_registers, :description, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171215143047) do
+ActiveRecord::Schema.define(version: 20171219103147) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -172,13 +172,14 @@ ActiveRecord::Schema.define(version: 20171215143047) do
 
   create_table "spina_registers", id: :serial, force: :cascade do |t|
     t.string "name"
-    t.text "history"
+    t.text "contextual_data"
     t.string "register_phase"
     t.string "slug"
     t.string "authority"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.text "description"
+    t.text "related_registers"
   end
 
   create_table "spina_rewrite_rules", id: :serial, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171219103147) do
+ActiveRecord::Schema.define(version: 20171220104627) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -178,7 +178,7 @@ ActiveRecord::Schema.define(version: 20171219103147) do
     t.string "authority"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.text "description"
+    t.string "description"
     t.text "related_registers"
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -27,7 +27,6 @@ Spina::Register.create(
   name: "School eng",
   register_phase: "Alpha",
   authority: "Department for Education",
-  history: "https://registers.cloudapps.digital/registers/school-eng",
 )
 puts "Created School eng Register"
 


### PR DESCRIPTION
### Context
Give users context of the register and data

### Changes proposed in this pull request
Add information to meta data section

### Guidance to review
Edit a register in the CMS, add `related_registers` and `contextual_data`, visit register on frontend and look in the meta data section  

<img width="1380" alt="screen shot 2017-12-19 at 12 01 37" src="https://user-images.githubusercontent.com/3071606/34156274-62a7dd90-e4b4-11e7-8912-6133ad9d5fea.png">
