### PR TITLE
Allow stored register data to be updated

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,7 @@ gem 'govuk_frontend_toolkit'
 gem 'govuk_template'
 gem 'govuk_elements_rails'
 gem 'govuk_elements_form_builder', git: 'https://github.com/ministryofjustice/govuk_elements_form_builder.git'
-gem 'registers-ruby-client', git: 'https://github.com/openregister/registers-ruby-client.git', tag: 'v0.4.0'
+gem 'registers-ruby-client', git: 'https://github.com/openregister/registers-ruby-client.git', tag: 'v0.6.0'
 
 # Spina CMS
 gem 'spina', github: 'denkGroot/Spina', branch: 'master'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -43,10 +43,10 @@ GIT
 
 GIT
   remote: https://github.com/openregister/registers-ruby-client.git
-  revision: 072453b3993127f4c3e5adeab25d438d107c394d
-  tag: v0.4.0
+  revision: a137543441d517c7aa673bf254d8d34bec600c1e
+  tag: v0.6.0
   specs:
-    registers-ruby-client (0.4.0)
+    registers-ruby-client (0.6.0)
       mini_cache (~> 1.1.0)
       rest-client (~> 2)
 

--- a/db/migrate/20171221112035_add_entry_number_and_previous_entry_number_to_entries.rb
+++ b/db/migrate/20171221112035_add_entry_number_and_previous_entry_number_to_entries.rb
@@ -1,0 +1,6 @@
+class AddEntryNumberAndPreviousEntryNumberToEntries < ActiveRecord::Migration[5.1]
+  def change
+    add_column :entries, :entry_number, :integer
+    add_column :entries, :previous_entry_number, :integer
+  end
+end

--- a/db/migrate/20171221113436_add_entry_number_to_records.rb
+++ b/db/migrate/20171221113436_add_entry_number_to_records.rb
@@ -1,0 +1,5 @@
+class AddEntryNumberToRecords < ActiveRecord::Migration[5.1]
+  def change
+    add_column :records, :entry_number, :integer
+  end
+end

--- a/db/migrate/20180102122243_remove_populated_from_registers.rb
+++ b/db/migrate/20180102122243_remove_populated_from_registers.rb
@@ -1,0 +1,5 @@
+class RemovePopulatedFromRegisters < ActiveRecord::Migration[5.1]
+  def change
+    remove_column :spina_registers, :populated
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,15 +10,13 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171207145923) do
+ActiveRecord::Schema.define(version: 20180102122243) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "entries", force: :cascade do |t|
     t.text "hash_value"
-    t.integer "entry_number"
-    t.integer "previous_entry_number"
     t.text "entry_type"
     t.text "key"
     t.datetime "timestamp"
@@ -26,12 +24,13 @@ ActiveRecord::Schema.define(version: 20171207145923) do
     t.jsonb "data"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "entry_number"
+    t.integer "previous_entry_number"
     t.index ["spina_register_id"], name: "index_entry_on_spina_register_id"
   end
 
   create_table "records", force: :cascade do |t|
     t.text "hash_value"
-    t.integer "entry_number"
     t.text "entry_type"
     t.text "key"
     t.datetime "timestamp"
@@ -39,6 +38,7 @@ ActiveRecord::Schema.define(version: 20171207145923) do
     t.jsonb "data"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "entry_number"
     t.index ["spina_register_id"], name: "index_record_on_spina_register_id"
   end
 
@@ -217,7 +217,6 @@ ActiveRecord::Schema.define(version: 20171207145923) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.text "description"
-    t.boolean "populated", default: false
     t.text "fields"
   end
 

--- a/spec/controllers/registers_controller_spec.rb
+++ b/spec/controllers/registers_controller_spec.rb
@@ -31,28 +31,28 @@ RSpec.describe RegistersController, type: :controller do
             .and_return(@territory_register)
 
     # History stubs
-    stub_request(:get, 'https://country.backlog.openregister.org/download-rsf')
+    stub_request(:get, 'https://country.backlog.openregister.org/download-rsf/0')
       .with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip, deflate', 'Host' => 'country.Backlog.openregister.org' })
       .to_return(status: 200, body: country_data, headers: {})
 
-    stub_request(:get, 'https://charity.backlog.openregister.org/download-rsf')
+    stub_request(:get, 'https://charity.backlog.openregister.org/download-rsf/0')
       .with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip, deflate', 'Host' => 'charity.Backlog.openregister.org' })
       .to_return(status: 200, body: register_charity_data, headers: {})
 
-    stub_request(:get, 'https://territory.backlog.openregister.org/download-rsf')
+    stub_request(:get, 'https://territory.backlog.openregister.org/download-rsf/0')
       .with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip, deflate', 'Host' => 'territory.Backlog.openregister.org' })
       .to_return(status: 200, body: register_territory_data, headers: {})
 
     # Index stubs
-    stub_request(:get, 'https://register.beta.openregister.org/download-rsf')
+    stub_request(:get, 'https://register.beta.openregister.org/download-rsf/0')
       .with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip, deflate', 'Host' => 'register.beta.openregister.org' })
       .to_return(status: 200, body: register_beta_data, headers: {})
 
-    stub_request(:get, 'https://register.alpha.openregister.org/download-rsf')
+    stub_request(:get, 'https://register.alpha.openregister.org/download-rsf/0')
       .with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip, deflate', 'Host' => 'register.alpha.openregister.org' })
       .to_return(status: 200, body: register_alpha_data, headers: {})
 
-    stub_request(:get, 'https://register.discovery.openregister.org/download-rsf')
+    stub_request(:get, 'https://register.discovery.openregister.org/download-rsf/0')
       .with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip, deflate', 'Host' => 'register.discovery.openregister.org', 'User-Agent' => 'rest-client/2.0.2 (darwin15.6.0 x86_64) ruby/2.4.2p198' })
       .to_return(status: 200, body: register_discovery_data, headers: {})
   end


### PR DESCRIPTION
### Context

This commit makes use of the new optional `since_entry_number` parameter in the client library when calling `get_records_with_history` and `get_metadata_records_with_history` to specify the point at which to get any new register data from. This allows the frontend to check for new records / entries on a regular basis without needing to recompute all of the stored local data about a particular register.

### Changes proposed in this pull request

Use new method signature of `get_records_with_history` and `get_metadata_records_with_history` from the client library to get only updated data, allowing the local store to be kept up-to-date. 

Refactor `populate_user_data` and `populate_system_data` into a more generic `populate_data` method, which accepts an `entry_type`.

### Guidance to review

Point `registers-ruby-client` in the Gemfile to commit `4651abd327b96954fd198ff0440b7bb3c845bbd1` on GitHub, then choose a register and progressively load data into it whilst at the same time loading the `show` page of the frontend. At each point, inspect the records count for the particular register and entry type you are interested in to verify the correct data is being populated.

**This branch will fail to build as it's pointing to `master` branch of the client library** (once the client library PR is merged, this won't the case any more).