### PR TITLE
Dockerised development environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM ruby:2.4.2
+
+RUN apt-get update -qq \
+  && apt-get install -y --no-install-recommends \
+    build-essential \
+    libpq-dev \
+    nodejs \
+    postgresql-client \
+  && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /usr/src/app
+
+COPY Gemfile /usr/src/app/Gemfile
+COPY Gemfile.lock /usr/src/app/Gemfile.lock
+COPY .ruby-version /usr/src/app/.ruby-version
+
+RUN bundle install
+COPY . /usr/src/app
+
+RUN sed -i "s/default: \&default/default: \&default\n  username: openregister-info\n  host: db\n  password:/" /usr/src/app/config/database.yml
+
+EXPOSE 3000
+CMD ["bundle", "exec", "rails", "server", "-b", "0.0.0.0"]

--- a/README.md
+++ b/README.md
@@ -24,6 +24,26 @@ $ rails server
 
 You can access the CMS via http://localhost:3000/admin
 
+## Running with Docker
+
+Instead of the above, you can use [Docker][https://docs.docker.com] as
+follows:
+
+```bash
+$ docker-compose build
+$ docker-compose run --rm web rails db:setup
+$ docker-compose up -d
+```
+
+And access it normally via http://localhost:3000
+
+To stop it, run `docker-compose stop`.
+
+NOTE: If you have changed your working directory (e.g. checkout a branch, edit
+a file) you have to rerun `docker-compose build` before running
+`docker-compose up -d` to ensure all changes are picked up.
+
+
 ## Zendesk
 
 If you need to use the Zendesk service you need to add 3 environment variables

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+version: '3'
+services:
+  db:
+    image: postgres:9.6-alpine
+    volumes:
+      - data:/var/lib/postgresql/data/pgdata
+    environment:
+      POSTGRES_PASSWORD:
+      POSTGRES_USER: openregister-info
+      POSTGRES_DB: openregister-info_development
+      PGDATA: /var/lib/postgresql/data/pgdata
+  web:
+    build: .
+    ports:
+      - "3000:3000"
+    depends_on:
+      - db
+
+volumes:
+  data: {}


### PR DESCRIPTION
### Context

PR reviews might require you to put on hold what you are doing, change environment (e.g. reset database) and after that, recover your previous state. Some other people, like me, might want to review a PR without having to install lots of dependencies at the machine level. Docker is a clean answer to solve that.

### Changes proposed in this pull request

Defines a non-optimised Docker image with Ruby, node.js, Rails and the
frontend application; and a Docker Compose file with Postgres so the
only dependencies required are Docker and Docker Compose.

The Dockerfile has a hack to overwrite the database configuration so
Rails is able to connect to the dockerised Postgres.


### Guidance to review

1. Ensure you have Docker and Docker Compose installed. https://docs.docker.com/
2. `docker-compose build`
3. `docker-compose run web rails db:setup`
4. `docker-compose up -d`
5. Open `localhost:3000` on your preferred browser.