### PR TITLE
Use ActiveJob to populate Records & Entries in  DB

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,10 +23,10 @@ gem 'cocoon'
 gem 'haml-rails'
 
 # GDS Frontend Toolkit, templates and elements
+gem 'govuk_elements_form_builder', git: 'https://github.com/ministryofjustice/govuk_elements_form_builder.git'
+gem 'govuk_elements_rails'
 gem 'govuk_frontend_toolkit'
 gem 'govuk_template'
-gem 'govuk_elements_rails'
-gem 'govuk_elements_form_builder', git: 'https://github.com/ministryofjustice/govuk_elements_form_builder.git'
 gem 'registers-ruby-client', git: 'https://github.com/openregister/registers-ruby-client.git', tag: 'v0.6.0'
 
 # Spina CMS

--- a/app/jobs/populate_register_data_in_db_job.rb
+++ b/app/jobs/populate_register_data_in_db_job.rb
@@ -49,7 +49,8 @@ class PopulateRegisterDataInDbJob < ApplicationJob
         previous_entry_number = value.entry.entry_number
       end
 
-      next unless (count % 1000).zero?
+      next unless (count / 1000).positive?
+      
       if latest_entry_number.positive?
         Record.transaction do
           bulk_remove_existing_records(register, entry_type, records.map(&:key))

--- a/app/jobs/populate_register_data_in_db_job.rb
+++ b/app/jobs/populate_register_data_in_db_job.rb
@@ -1,0 +1,82 @@
+class PopulateRegisterDataInDbJob < ApplicationJob
+  queue_as :default
+
+  def initialize
+    @registers_client ||= RegistersClient::RegisterClientManager.new(cache_duration: 60)
+  end
+
+  def bulk_remove_existing_records(register, entry_type, record_keys)
+    unless record_keys.empty?
+      Record.where(spina_register_id: register.id, entry_type: entry_type, key: record_keys).delete_all
+    end
+  end
+
+  def bulk_save(entries, records)
+    Entry.import!(entries)
+    Record.import!(records)
+  end
+
+  def populate_register(register)
+    register_data = @registers_client.get_register(register.name.parameterize, register.register_phase.downcase)
+    register_data.refresh_data
+    populate_data(register, register_data, 'user')
+    populate_data(register, register_data, 'system')
+
+    register.fields = register_data.get_field_definitions.map { |field| field.item.value['field'] }.join(',')
+    register.save
+  end
+
+  def populate_data(register, register_data, entry_type)
+    entries = []
+    records = []
+    count = 0
+
+    latest_entry = Entry.where(spina_register_id: register.id, entry_type: entry_type).order(:entry_number).reverse_order.limit(1).first
+    latest_entry_number = latest_entry.nil? ? 0 : latest_entry.entry_number
+
+    (entry_type == 'user' ? register_data.get_records_with_history(latest_entry_number) : register_data.get_metadata_records_with_history(latest_entry_number)).each do |record|
+      previous_entry_number = nil
+
+      record[:records].each_with_index do |value, idx|
+        count += 1
+        new_entry = Entry.new(spina_register: register, data: value.item.value, timestamp: value.entry.timestamp, hash_value: value.item.hash, entry_number: value.entry.entry_number, previous_entry_number: previous_entry_number, entry_type: entry_type, key: value.entry.key)
+        entries.push(new_entry)
+
+        if idx == record[:records].length - 1 # The last entry is the record
+          records.push(Record.new(spina_register: register, data: value.item.value, timestamp: value.entry.timestamp, hash_value: value.item.hash, entry_number: value.entry.entry_number, entry_type: entry_type, key: value.entry.key))
+        end
+
+        previous_entry_number = value.entry.entry_number
+      end
+
+      next unless (count % 1000).zero?
+      Record.transaction do
+        bulk_remove_existing_records(register, entry_type, records.map{ |record| record.key })
+        bulk_save(entries, records)
+      end
+
+      entries = []
+      records = []
+    end
+
+    # Remaining objects less than 1000
+    if (records.count > 0)
+      Record.transaction do
+        bulk_remove_existing_records(register, entry_type, records.map{ |record| record.key })
+        bulk_save(entries, records)
+      end
+    end
+  end
+
+  def perform(*)
+    Spina::Register.all.each do |register|
+      logger.info("Updating #{register.name} in database")
+      begin
+      populate_register(register)
+    rescue => e
+      logger.error("failed to populate register #{register.name} due to exception #{e}")
+      next
+      end
+    end
+  end
+end

--- a/app/jobs/populate_register_data_in_db_job.rb
+++ b/app/jobs/populate_register_data_in_db_job.rb
@@ -76,7 +76,7 @@ class PopulateRegisterDataInDbJob < ApplicationJob
   end
 
   def perform(*)
-    Spina::Register.all.find_each do |register|
+    Spina::Register.find_each do |register|
       logger.info("Updating #{register.name} in database")
       begin
       populate_register(register)

--- a/app/jobs/populate_register_data_in_db_job.rb
+++ b/app/jobs/populate_register_data_in_db_job.rb
@@ -50,7 +50,7 @@ class PopulateRegisterDataInDbJob < ApplicationJob
       end
 
       next unless (count / 1000).positive?
-      
+
       if latest_entry_number.positive?
         Record.transaction do
           bulk_remove_existing_records(register, entry_type, records.map(&:key))
@@ -59,6 +59,8 @@ class PopulateRegisterDataInDbJob < ApplicationJob
       else
         bulk_save(entries, records)
       end
+
+      count = 0
       entries = []
       records = []
     end

--- a/app/jobs/populate_register_data_in_db_job.rb
+++ b/app/jobs/populate_register_data_in_db_job.rb
@@ -31,7 +31,7 @@ class PopulateRegisterDataInDbJob < ApplicationJob
     records = []
     count = 0
 
-    latest_entry = Entry.where(spina_register_id: register.id, entry_type: entry_type).order(:entry_number).reverse_order.limit(1).first
+    latest_entry = Entry.where(spina_register_id: register.id, entry_type: entry_type).order(:entry_number).reverse_order.first
     latest_entry_number = latest_entry.nil? ? 0 : latest_entry.entry_number
 
     (entry_type == 'user' ? register_data.get_records_with_history(latest_entry_number) : register_data.get_metadata_records_with_history(latest_entry_number)).each do |record|

--- a/app/jobs/populate_register_data_in_db_job.rb
+++ b/app/jobs/populate_register_data_in_db_job.rb
@@ -55,8 +55,8 @@ class PopulateRegisterDataInDbJob < ApplicationJob
           bulk_remove_existing_records(register, entry_type, records.map(&:key))
           bulk_save(entries, records)
         end
-        else
-          bulk_save(entries, records)
+      else
+        bulk_save(entries, records)
       end
       entries = []
       records = []
@@ -79,10 +79,10 @@ class PopulateRegisterDataInDbJob < ApplicationJob
     Spina::Register.find_each do |register|
       logger.info("Updating #{register.name} in database")
       begin
-      populate_register(register)
-    rescue => e
-      logger.error("failed to populate register #{register.name} due to exception #{e}")
-      next
+        populate_register(register)
+      rescue StandardError => e
+        logger.error("failed to populate register #{register.name} due to exception #{e}")
+        next
       end
     end
   end

--- a/config/initializers/job_runner.rb
+++ b/config/initializers/job_runner.rb
@@ -1,3 +1,3 @@
-unless Rails.env.test?
+unless Rails.env.test? || !ActiveRecord::Base.connection.table_exists?('spina_registers') || File.basename($0) == 'rake'
   PopulateRegisterDataInDbJob.perform_now
 end

--- a/config/initializers/job_runner.rb
+++ b/config/initializers/job_runner.rb
@@ -1,4 +1,4 @@
 #TODO: Replace this with a scheduled job
-unless Rails.env.test? || !ActiveRecord::Base.connection.table_exists?('spina_registers') || File.basename($0) == 'rake'
+if File.basename($0) == 'rails'
   PopulateRegisterDataInDbJob.perform_now
 end

--- a/config/initializers/job_runner.rb
+++ b/config/initializers/job_runner.rb
@@ -1,3 +1,4 @@
+#TODO: Replace this with a scheduled job
 unless Rails.env.test? || !ActiveRecord::Base.connection.table_exists?('spina_registers') || File.basename($0) == 'rake'
   PopulateRegisterDataInDbJob.perform_now
 end

--- a/config/initializers/job_runner.rb
+++ b/config/initializers/job_runner.rb
@@ -1,0 +1,3 @@
+unless Rails.env.test?
+  PopulateRegisterDataInDbJob.perform_now
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -24,7 +24,7 @@ puts "Created Territory Register"
 
 Spina::Register.create(
   name: "Local authority eng",
-  register_phase: "Alpha",
+  register_phase: "Beta",
   authority: "Department for Communities and Local Government",
   custodian: "Mark Coram",
   url: "https://local-authority-eng.register.gov.uk/",

--- a/spec/controllers/registers_controller_spec.rb
+++ b/spec/controllers/registers_controller_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe RegistersController, type: :controller do
-  before do
+  before(:all) do
     country_data = File.read('./spec/support/country.rsf')
     register_beta_data = File.read('./spec/support/register_beta.rsf')
     register_alpha_data = File.read('./spec/support/register_alpha.rsf')
@@ -11,51 +11,58 @@ RSpec.describe RegistersController, type: :controller do
     register_charity_data = File.read('./spec/support/charity_card_n.rsf')
     register_territory_data = File.read('./spec/support/territory_short.rsf')
 
-    @country_register = ObjectsFactory.new.create_register('country', 'Backlog', 'Ministry of Justice')
-    @charity_register = ObjectsFactory.new.create_register('charity', 'Backlog', 'Ministry of Justice')
-    @territory_register = ObjectsFactory.new.create_register('territory', 'Backlog', 'Ministry of Justice')
+    ObjectsFactory.new.create_register('country', 'Beta', 'Ministry of Justice')
+    ObjectsFactory.new.create_register('charity', 'Beta', 'Ministry of Justice')
+    ObjectsFactory.new.create_register('territory', 'Beta', 'Ministry of Justice')
 
-    allow(Spina::Register)
-      .to receive(:find_by_slug!)
-            .with('country')
-            .and_return(@country_register)
+    # RSF stubs
+    stub_request(:get, 'https://country.beta.openregister.org/download-rsf/0')
+    .with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip, deflate' })
+    .to_return(status: 200, body: country_data, headers: {})
 
-    allow(Spina::Register)
-      .to receive(:find_by_slug!)
-            .with('charity')
-            .and_return(@charity_register)
+  stub_request(:get, 'https://charity.beta.openregister.org/download-rsf/0')
+    .with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip, deflate' })
+    .to_return(status: 200, body: register_charity_data, headers: {})
 
-    allow(Spina::Register)
-      .to receive(:find_by_slug!)
-            .with('territory')
-            .and_return(@territory_register)
+  stub_request(:get, 'https://territory.beta.openregister.org/download-rsf/0')
+    .with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip, deflate' })
+    .to_return(status: 200, body: register_territory_data, headers: {})
 
-    # History stubs
-    stub_request(:get, 'https://country.backlog.openregister.org/download-rsf/0')
-      .with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip, deflate', 'Host' => 'country.Backlog.openregister.org' })
-      .to_return(status: 200, body: country_data, headers: {})
+  # Index stubs
+  stub_request(:get, 'https://register.beta.openregister.org/download-rsf/0')
+    .with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip, deflate'})
+    .to_return(status: 200, body: register_beta_data, headers: {})
 
-    stub_request(:get, 'https://charity.backlog.openregister.org/download-rsf/0')
-      .with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip, deflate', 'Host' => 'charity.Backlog.openregister.org' })
-      .to_return(status: 200, body: register_charity_data, headers: {})
+  stub_request(:get, 'https://register.alpha.openregister.org/download-rsf/0')
+    .with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip, deflate'})
+    .to_return(status: 200, body: register_alpha_data, headers: {})
 
-    stub_request(:get, 'https://territory.backlog.openregister.org/download-rsf/0')
-      .with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip, deflate', 'Host' => 'territory.Backlog.openregister.org' })
-      .to_return(status: 200, body: register_territory_data, headers: {})
+  stub_request(:get, 'https://register.discovery.openregister.org/download-rsf/0')
+    .with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip, deflate'})
+    .to_return(status: 200, body: register_discovery_data, headers: {})
 
-    # Index stubs
-    stub_request(:get, 'https://register.beta.openregister.org/download-rsf/0')
-      .with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip, deflate', 'Host' => 'register.beta.openregister.org' })
-      .to_return(status: 200, body: register_beta_data, headers: {})
+  stub_request(:get, "https://country.beta.openregister.org/download-rsf/207").
+    with(headers: {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip, deflate', 'Host'=>'country.beta.openregister.org'}).
+    to_return(status: 200, body: "", headers: {})
 
-    stub_request(:get, 'https://register.alpha.openregister.org/download-rsf/0')
-      .with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip, deflate', 'Host' => 'register.alpha.openregister.org' })
-      .to_return(status: 200, body: register_alpha_data, headers: {})
+  stub_request(:get, "https://charity.beta.openregister.org/download-rsf/10").
+    with(headers: {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip, deflate', 'Host'=>'charity.beta.openregister.org'}).
+    to_return(status: 200, body: "", headers: {})
 
-    stub_request(:get, 'https://register.discovery.openregister.org/download-rsf/0')
-      .with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip, deflate', 'Host' => 'register.discovery.openregister.org', 'User-Agent' => 'rest-client/2.0.2 (darwin15.6.0 x86_64) ruby/2.4.2p198' })
-      .to_return(status: 200, body: register_discovery_data, headers: {})
+  stub_request(:get, "https://territory.beta.openregister.org/download-rsf/3").
+    with(headers: {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip, deflate', 'Host'=>'territory.beta.openregister.org'}).
+    to_return(status: 200, body: "", headers: {})
+
+    PopulateRegisterDataInDbJob.perform_now
+
+
   end
+
+  after(:all) do
+    DatabaseCleaner.clean_with(:truncation)
+  end
+
+
 
   describe 'Request: GET #history. Descr: Check register consistency. Params: --. Result: Success' do
     subject { get :history, params: { id: 'country' } }
@@ -104,7 +111,6 @@ RSpec.describe RegistersController, type: :controller do
 
     it do
       subject
-
       expect(assigns(:entries_with_items).length).to eq(1)
     end
   end
@@ -155,8 +161,8 @@ RSpec.describe RegistersController, type: :controller do
     it { is_expected.to render_template :show }
 
     it do
-      subject
 
+      subject
       expect(assigns(:records).length).to eq(100)
     end
   end

--- a/spec/jobs/populate_register_data_in_db_job_spec.rb
+++ b/spec/jobs/populate_register_data_in_db_job_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+
+RSpec.configure do |config|
+  config.before(:suite) do
+    DatabaseCleaner.strategy = :transaction
+    DatabaseCleaner.clean_with(:truncation)
+  end
+
+  config.around(:each) do |example|
+    DatabaseCleaner.cleaning do
+      example.run
+    end
+  end
+end
+
+RSpec.describe PopulateRegisterDataInDbJob, type: :job do
+  before(:each) do
+    country_data = File.read('./spec/support/country.rsf')
+    stub_request(:get, "https://country.beta.openregister.org/download-rsf/0").
+    with(headers: { 'Accept'=>'*/*', 'Accept-Encoding'=>'gzip, deflate', 'Host'=>'country.beta.openregister.org' }).
+    to_return(status: 200, body: country_data, headers: {})
+
+    country_update = File.read('./spec/support/country_update.rsf')
+    stub_request(:get, "https://country.beta.openregister.org/download-rsf/207").
+    with(headers: { 'Accept'=>'*/*', 'Accept-Encoding'=>'gzip, deflate', 'Host'=>'country.beta.openregister.org' }).
+    to_return(status: 200, body: country_update, headers: {})
+
+    ObjectsFactory.new.create_register('country', 'beta', 'Ministry of Justice')
+    PopulateRegisterDataInDbJob.perform_now
+  end
+
+  describe 'populate register data job' do
+    it 'incrementally updates data' do
+      expect(Spina::Register.count).to eq(1)
+      expect(Entry.where(spina_register_id: Spina::Register.find_by(name: 'country').id).count).to eq(220)
+      expect(Record.find_by(key: 'CI').data['citizen-names']).to eq('Citizen of the Ivory Coast EDIT')
+      expect(Entry.where(key: 'CI').last.data['citizen-names']).to eq('Citizen of the Ivory Coast EDIT')
+    end
+
+    it 'retains existing entries' do
+      expect(Entry.where(key: 'CI').first.data['citizen-names']).to eq('Citizen of the Ivory Coast')
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -7,6 +7,9 @@ require File.expand_path('../../config/environment', __FILE__)
 # Prevent database truncation if the environment is production
 abort('The Rails environment is running in production mode!') if Rails.env.production?
 require 'rspec/rails'
+require 'database_cleaner'
+
+DatabaseCleaner.strategy = :truncation
 # Add additional requires below this line. Rails is not loaded until this point!
 
 # Requires supporting ruby files with custom matchers and macros, etc, in

--- a/spec/support/country_update.rsf
+++ b/spec/support/country_update.rsf
@@ -1,0 +1,2 @@
+add-item	{"citizen-names":"Citizen of the Ivory Coast EDIT","country":"CI","name":"Ivory Coast","official-name":"The Republic of Côte D’Ivoire"}
+append-entry	user	CI	2017-10-25T09:52:52Z	sha-256:1df6042a333b18c5f65de37709990fe9d79ee12a15e2d00ad0a59988eaaff4ee


### PR DESCRIPTION
### Context
Previously we were only populating the DB when certain controller methods were hit. This had a number of downsides including slow loads on first request and inability to apply updates after first load.

### Changes proposed in this pull request
Move all database population to an ActiveJob. Note this PR only triggers the job at upon startup. The intention is that a subsequent PR will change this to a scheduled job and introduce a queuing backend. 

### Guidance to review
All registers which are defined in the CMS should be loaded upon startup. Any registers that fail to load e.g. Charity should not prevent other registers loading.