### PR TITLE
No longer need get_ready_to_use_registers on home page

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -2,7 +2,7 @@
 class PagesController < ApplicationController
   layout 'layouts/application'
 
-  before_action :get_ready_to_use_registers, only: [:home, :avaliable_registers]
+  before_action :get_ready_to_use_registers, only: :avaliable_registers
 
   def home
     @registers = Spina::Register.all


### PR DESCRIPTION
We no longer have a list of beta registers on the home page so we don't need to load them.