### PR TITLE
Fix Docker link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ You can access the CMS via http://localhost:3000/admin
 
 ## Running with Docker
 
-Instead of the above, you can use [Docker][https://docs.docker.com] as
+Instead of the above, you can use [Docker](https://docs.docker.com) as
 follows:
 
 ```bash


### PR DESCRIPTION
### Context

#103 introduced a broken link in the README

### Changes proposed in this pull request

Fix the broken link.

### Guidance to review

Check the README has a functional link to the Docker documentation website.
