### PR TITLE
Refactor methods calling api

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,10 +3,4 @@ class ApplicationController < Spina::ApplicationController
 
   protect_from_forgery with: :exception
   http_basic_authenticate_with name: ENV['HTTP_AUTH_USERNAME'], password: ENV['HTTP_AUTH_PASSWORD'] if Rails.env.production?
-
-  before_action :initialize_client
-
-  def initialize_client
-    @registers_client ||= RegistersClient::RegisterClientManager.new(cache_duration: 600)
-  end
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -25,7 +25,6 @@ class PagesController < ApplicationController
   private
 
   def get_ready_to_use_registers
-    register_data = @registers_client.get_register('register', 'beta')
-    @beta_registers = register_data.get_records
+    @beta_registers = Spina::Register.where(register_phase: 'Beta')
   end
 end

--- a/app/controllers/registers_controller.rb
+++ b/app/controllers/registers_controller.rb
@@ -18,12 +18,6 @@ class RegistersController < ApplicationController
 
     @page = Spina::Page.find_by(name: 'registerspage')
     @current_phases = Spina::Register::CURRENT_PHASES
-
-    # Fetch the register register for each phase and get records
-    beta_register_register = @registers_client.get_register('register', 'beta').get_records
-    alpha_register_register = @registers_client.get_register('register', 'alpha').get_records
-    discovery_register_register = @registers_client.get_register('register', 'discovery').get_records
-    @register_registers = beta_register_register.to_a + alpha_register_register.to_a + discovery_register_register.to_a
   end
 
   def get_last_timestamp
@@ -34,12 +28,12 @@ class RegistersController < ApplicationController
       .to_s
   end
 
-  def get_register_definition
-    Record.find_by(spina_register_id: @register.id, key: "register:#{params[:id]}").data
+  def get_register_definition(register_id, key)
+    Record.find_by(spina_register_id: register_id, key: key).data
   end
 
   def get_field_definitions
-    ordered_field_keys = get_register_definition['fields'].map { |f| "field:#{f}" }
+    ordered_field_keys = get_register_definition(@register.id, "register:#{params[:id]}")['fields'].map { |f| "field:#{f}" }
     Record.where(spina_register_id: @register.id, key: ordered_field_keys)
       .order("position(key::text in '#{ordered_field_keys.join(',')}')")
       .map { |entry| entry[:data] }

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -25,8 +25,8 @@ module ApplicationHelper
   end
 
   def government_organisations
-    register_data = @@registers_client.get_register('government-organisation', 'beta')
-    register_data.get_records
+    register = Spina::Register.find_by(name: 'Government organisation')
+    Record.where(spina_register_id: register.id, entry_type: 'user')
   end
 
   def phase_label(phase)

--- a/app/views/pages/avaliable_registers.html.haml
+++ b/app/views/pages/avaliable_registers.html.haml
@@ -6,6 +6,6 @@
       = render partial: 'pages/sidebar_nav'
     .column-two-thirds
       %h1.heading-large Avaliable registers
-      %ul.list-bullet
-        - @beta_registers.reject{ |r| %w{register datatype field}.include?(r[:item]['register'])}.each do |register|
-          %li= link_to register[:item]['register'], "/registers/#{register[:item]['register'].parameterize}"
+      %ul.list.list-bullet
+        - @beta_registers.reject{ |r| %w{register datatype field}.include?(r.name.parameterize)}.each do |register|
+          %li= link_to register.name, "/registers/#{register.name.parameterize}"

--- a/app/views/pages/home.html.haml
+++ b/app/views/pages/home.html.haml
@@ -75,8 +75,8 @@
       %aside.related-items
         %h2.related-items__title Registers ready to use
         %ul.related-items__list
-          - @beta_registers.reject{ |r| %w{register datatype field}.include?(r.item.value['register'])}.each do |register|
-            %li= link_to register.item.value['register'], "/registers/#{register.item.value['register'].parameterize}"
+          - @beta_registers.reject{ |r| %w{register datatype field}.include?(r.name.parameterize)}.each do |register|
+            %li= link_to register.name, "/registers/#{register.name.parameterize}"
         %h2.related-items__title Upcoming registers
         %ul.related-items__list
           %li

--- a/app/views/registers/_register.html.haml
+++ b/app/views/registers/_register.html.haml
@@ -4,7 +4,7 @@
     - if register.register_phase == 'Backlog'
       %p= register.description
     - else
-      %p= @register_registers.select{ |r| r.entry.key == register.name.parameterize }.first.item.value['text']
+      %p= get_register_definition(register.id, "register:#{register.name.parameterize}")['text']
   %td{"data-title" => "Phase: "}
     = phase_label(register.register_phase)
   %td{"data-title" => "Managed by: "}

--- a/app/views/registers/show.html.haml
+++ b/app/views/registers/show.html.haml
@@ -43,7 +43,7 @@
             = link_to "See all register updates", history_path(@register.slug)
 
       %h2.heading-medium About this register
-      %p=get_register_definition['text']
+      %p= get_register_definition(@register.id, "register:#{params[:id]}")['text']
 
       %details{role: "group"}
         %summary{"aria-controls" => "details-content-0", "aria-expanded" => "false", :role => "button"}

--- a/app/views/spina/admin/registers/_form.html.haml
+++ b/app/views/spina/admin/registers/_form.html.haml
@@ -53,7 +53,7 @@
         .horizontal-form-label
           Authority
         .horizontal-form-content
-          = f.select :authority, government_organisations.map{|c| c[:item]['name']}, {data: { "default-value" => @register.authority }}
+          = f.select :authority, government_organisations.map{|c| c.data['name']}, {data: { "default-value" => @register.authority }}
       .horizontal-form-group
         .horizontal-form-label
           = Spina::Page.human_attribute_name :custodian


### PR DESCRIPTION
### Context
There were a few methods that pulls data directly from the API but as all data is now stored in active records we can replace that dependency 

### Changes proposed in this pull request
Replace client gem methods with active record look ups

### Guidance to review
- visit `registers#index` to check description, 
- visit `pages#home` & `pages#avaliable_registers` to check beta registers, 
- visit `registers#edit` to check gov orgs dropdown