### PR TITLE
Move support and new_register outside of Spina

### DIFF
--- a/app/controllers/new_register_controller.rb
+++ b/app/controllers/new_register_controller.rb
@@ -14,23 +14,23 @@ class NewRegisterController < ApplicationController
   end
 
   def suggest_register
-    @new_register = Spina::NewRegister.new
+    @new_register = NewRegister.new
   end
 
   def request_register
-    @new_register = Spina::NewRegister.new
+    @new_register = NewRegister.new
   end
 
   def thanks
   end
 
   def create
-    @new_register = Spina::NewRegister.new(new_register_params)
+    @new_register = NewRegister.new(new_register_params)
 
     if @new_register.valid?
       @zendeskService = ZendeskFeedback.new
       @response = @zendeskService.send_feedback(new_register_params)
-      redirect_to spina.new_register_thanks_path
+      redirect_to new_register_thanks_path
     else
       flash[:errors] = @new_register.errors
       if params[:new_register][:subject] == '[Request a Register]'

--- a/app/controllers/support_controller.rb
+++ b/app/controllers/support_controller.rb
@@ -16,20 +16,20 @@ class SupportController < ApplicationController
   end
 
   def problem
-    @support = Spina::Support.new
+    @support = Support.new
   end
 
   def question
-    @support = Spina::Support.new
+    @support = Support.new
   end
 
   def create
-    @support = Spina::Support.new(support_params)
+    @support = Support.new(support_params)
 
     if @support.valid?
       @zendeskService = ZendeskFeedback.new
       @response = @zendeskService.send_feedback(support_params)
-      redirect_to spina.support_thanks_path
+      redirect_to support_thanks_path
     else
       flash[:errors] = @support.errors
       if params[:subject] == "problem"

--- a/app/models/new_register.rb
+++ b/app/models/new_register.rb
@@ -1,0 +1,7 @@
+class NewRegister
+  include ActiveModel::Model
+
+  attr_accessor :email, :name, :message, :subject
+
+  validates_presence_of :email, :name, :message
+end

--- a/app/models/spina/new_register.rb
+++ b/app/models/spina/new_register.rb
@@ -1,9 +1,0 @@
-module Spina
-  class NewRegister
-    include ActiveModel::Model
-
-    attr_accessor :email, :name, :message, :subject
-
-    validates_presence_of :email, :name, :message
-  end
-end

--- a/app/models/spina/support.rb
+++ b/app/models/spina/support.rb
@@ -1,9 +1,0 @@
-module Spina
-  class Support
-    include ActiveModel::Model
-
-    attr_accessor :email, :name, :message, :subject
-
-    validates_presence_of :email, :name, :message
-  end
-end

--- a/app/models/support.rb
+++ b/app/models/support.rb
@@ -1,0 +1,7 @@
+class Support
+  include ActiveModel::Model
+
+  attr_accessor :email, :name, :message, :subject
+
+  validates_presence_of :email, :name, :message
+end


### PR DESCRIPTION
### Context
Eventually, we want to move away from Spina as a dependency so this is some more work to make that transition easier.

### Changes proposed in this pull request
Move `support` and `new_rgister` outside of the Spina scope.

### Guidance to review
Check the links still work and the forms still submit to ZenDesk.