### PR TITLE
Populate register data via new PostgresDataStore [DO NOT MERGE yet]

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ gem 'govuk_elements_form_builder', git: 'https://github.com/ministryofjustice/go
 gem 'govuk_elements_rails'
 gem 'govuk_frontend_toolkit'
 gem 'govuk_template'
-gem 'registers-ruby-client', git: 'https://github.com/openregister/registers-ruby-client.git', tag: 'v0.6.0'
+gem 'registers-ruby-client', path: '/Users/karlbaker/work/registers-ruby-client'
 
 # Spina CMS
 gem 'spina', github: 'denkGroot/Spina', branch: 'master'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,12 +41,10 @@ GIT
       govuk_frontend_toolkit (>= 6.0.0)
       rails (>= 4.2)
 
-GIT
-  remote: https://github.com/openregister/registers-ruby-client.git
-  revision: a137543441d517c7aa673bf254d8d34bec600c1e
-  tag: v0.6.0
+PATH
+  remote: /Users/karlbaker/work/registers-ruby-client
   specs:
-    registers-ruby-client (0.6.0)
+    registers-ruby-client (0.7.0)
       mini_cache (~> 1.1.0)
       rest-client (~> 2)
 

--- a/app/jobs/populate_register_data_in_db_job.rb
+++ b/app/jobs/populate_register_data_in_db_job.rb
@@ -17,65 +17,11 @@ class PopulateRegisterDataInDbJob < ApplicationJob
   end
 
   def populate_register(register)
-    register_data = @registers_client.get_register(register.name.parameterize, register.register_phase.downcase)
+    register_data = @registers_client.get_register(register.name.parameterize, register.register_phase.downcase, PostgresDataStore.new(register))
     register_data.refresh_data
-    populate_data(register, register_data, 'user')
-    populate_data(register, register_data, 'system')
 
     register.fields = register_data.get_field_definitions.map { |field| field.item.value['field'] }.join(',')
     register.save
-  end
-
-  def populate_data(register, register_data, entry_type)
-    entries = []
-    records = []
-    count = 0
-
-    latest_entry = Entry.where(spina_register_id: register.id, entry_type: entry_type).order(:entry_number).reverse_order.first
-    latest_entry_number = latest_entry.nil? ? 0 : latest_entry.entry_number
-
-    (entry_type == 'user' ? register_data.get_records_with_history(latest_entry_number) : register_data.get_metadata_records_with_history(latest_entry_number)).each do |record|
-      previous_entry_number = nil
-
-      record[:records].each_with_index do |value, idx|
-        count += 1
-        new_entry = Entry.new(spina_register: register, data: value.item.value, timestamp: value.entry.timestamp, hash_value: value.item.hash, entry_number: value.entry.entry_number, previous_entry_number: previous_entry_number, entry_type: entry_type, key: value.entry.key)
-        entries.push(new_entry)
-
-        if idx == record[:records].length - 1 # The last entry is the record
-          records.push(Record.new(spina_register: register, data: value.item.value, timestamp: value.entry.timestamp, hash_value: value.item.hash, entry_number: value.entry.entry_number, entry_type: entry_type, key: value.entry.key))
-        end
-
-        previous_entry_number = value.entry.entry_number
-      end
-
-      next unless (count / 1000).positive?
-
-      if latest_entry_number.positive?
-        Record.transaction do
-          bulk_remove_existing_records(register, entry_type, records.map(&:key))
-          bulk_save(entries, records)
-        end
-      else
-        bulk_save(entries, records)
-      end
-
-      count = 0
-      entries = []
-      records = []
-    end
-
-    # Remaining objects less than 1000
-    if records.count.positive?
-      if latest_entry_number.positive?
-        Record.transaction do
-          bulk_remove_existing_records(register, entry_type, records.map(&:key))
-          bulk_save(entries, records)
-        end
-      else
-        bulk_save(entries, records)
-      end
-    end
   end
 
   def perform(*)

--- a/app/services/postgres_data_store.rb
+++ b/app/services/postgres_data_store.rb
@@ -1,0 +1,103 @@
+require 'data_store'
+
+class PostgresDataStore
+  include DataStore
+
+  def initialize(register)
+    @page_size = 100
+    @items = {}
+    @entries = { user: [], system: [] }
+    @records = { user: {}, system: {} }
+    @register = register
+  end
+
+  def add_item(item)
+    @items[item.hash.to_s] = item
+  end
+
+  def append_entry(entry)
+    entry_type = entry.entry_type.to_sym
+    item = @items[entry.item_hash]
+    previous_entry_number = @records[entry_type].has_key?(entry.key) ? @records[entry_type][entry.key].last : nil
+    db_entry = Entry.new(spina_register: @register, data: item.value, timestamp: entry.timestamp, hash_value: item.hash, entry_number: entry.entry_number, previous_entry_number: previous_entry_number, entry_type: entry_type, key: entry.key)
+
+    @entries[entry_type] << db_entry
+
+    unless @records[entry_type].key?(entry.key)
+      @records[entry_type][entry.key] = []
+    end
+
+    @records[entry_type][entry.key] << db_entry
+  end
+
+  def get_item(item_hash)
+  end
+
+  def get_items
+  end
+
+  def get_entry(entry_type, entry_number)
+  end
+
+  def get_entries(entry_type)
+  end
+
+  def get_record(entry_type, key)
+  end
+
+  def get_records(entry_type)
+  end
+
+  def get_latest_entry_number(entry_type)
+    latest_entry = Entry.where(spina_register_id: @register.id, entry_type: entry_type).order(:entry_number).reverse_order.first
+    unless (latest_entry.nil?)
+      latest_entry.entry_number
+    else
+      latest_entry = @entries[entry_type].last
+      latest_entry.nil? ? 0 : latest_entry.entry_number
+    end
+  end
+
+  def after_load
+    batch_update(:user)
+    batch_update(:system)
+    @items.clear
+  end
+
+  private
+
+  def batch_update(entry_type)
+    if (@entries[entry_type].length > 0)
+      @entries[entry_type].each_slice(1000) do |entries|
+        Entry.import!(entries)
+      end
+    end
+
+    if (@records[entry_type].length > 0)
+      bulk_remove_existing_records(@register, entry_type, @records[entry_type].keys)
+
+      records = []
+      @records[entry_type].each_value do |record_entries|
+        entry_for_record = record_entries.last
+
+        records << Record.new(spina_register: @register, data: entry_for_record.data, timestamp: entry_for_record.timestamp, hash_value: entry_for_record.hash_value, entry_number: entry_for_record.entry_number, entry_type: entry_for_record.entry_type, key: entry_for_record.key)
+      end
+
+      Record.import!(records)
+    end
+
+    @entries[entry_type].clear
+    @records[entry_type].clear
+  end
+
+  def bulk_remove_existing_records(register, entry_type, record_keys)
+    unless record_keys.empty?
+      Record.where(spina_register_id: register.id, entry_type: entry_type, key: record_keys).delete_all
+    end
+  end
+
+  def bulk_save(entries, records)
+    Entry.import!(entries)
+    Record.import!(records)
+  end
+end


### PR DESCRIPTION
### Context

The updated version of the client library (as yet not merged) allows a data store to be passed into the `get_register` method, giving the caller the option of implementing their own data store which `includes DataStore` module. This PR implements a new `PostgresDataStore`, meaning that no data is stored within the client library but instead directly to the Postgres DB the frontend uses (via temporary, in-memory data structures necessary for calculating correct entries and records).

### Changes proposed in this pull request

Populate register data in Postgres DB without storing data in the registers client library.

### Guidance to review

Client library PR (https://github.com/openregister/registers-ruby-client/pull/16) is not yet approved and merged, so this PR cannot be merged until this happens. Expect tests to fail until then too.
