### PR TITLE
fix pagination offset counts on show page

### DIFF
--- a/app/controllers/registers_controller.rb
+++ b/app/controllers/registers_controller.rb
@@ -108,8 +108,7 @@ private
     page = params[:page] ||= 1
     sort_by = params[:sort_by]
     sort_direction = params[:sort_direction]
-    params[:page_size] = page_size
-    
+
     query = Record.where(spina_register_id: register_id, entry_type: 'user')
 
     count_query = Record.select(1).where(spina_register_id: register_id, entry_type: 'user')
@@ -141,8 +140,8 @@ private
     end
 
     @page_count = count_query.length
-    params[:offset] = params[:page_size] * (params[:page].to_i - 1) + 1
-    params[:offset_end] = [@page_count, (params[:page_size]) * params[:page].to_i].min
+    params[:offset] = page_size * (params[:page].to_i - 1) + 1
+    params[:offset_end] = [@page_count, page_size * params[:page].to_i].min
 
     @total_pages = (@page_count / 100) + (@page_count % 100 == 0 ? 0 : 1)
 

--- a/app/controllers/registers_controller.rb
+++ b/app/controllers/registers_controller.rb
@@ -64,7 +64,7 @@ class RegistersController < ApplicationController
     @entries_with_items = Kaminari::paginate_array(@entries_with_items, total_count: @page_count).page(@current_page).per(100)
   end
 
-  private
+private
 
 
   def recover_entries_history(register_id, fields, params)
@@ -87,11 +87,11 @@ class RegistersController < ApplicationController
       count_query = Entry.select(1).where(spina_register_id: register_id, entry_type: 'user')
     end
 
-    previous_entries_numbers = query.reject{ |entry| entry.previous_entry_number.nil? }.map{ |entry| entry.previous_entry_number }
+    previous_entries_numbers = query.reject { |entry| entry.previous_entry_number.nil? }.map(&:previous_entry_number)
     previous_entries_query = Entry.where(spina_register_id: register_id, entry_number: previous_entries_numbers)
 
     result = query.map do |entry|
-      previous_entry = previous_entries_query.select{ |previous_entry| previous_entry.entry_number == entry.previous_entry_number }.first
+      previous_entry = previous_entries_query.select { |previous_entry| previous_entry.entry_number == entry.previous_entry_number }.first
       { current_entry: entry, previous_entry: previous_entry }
     end
 
@@ -102,9 +102,14 @@ class RegistersController < ApplicationController
     result
   end
 
-  def recover_records(register_id, fields, params)
-    literal, status, page, sort_by, sort_direction = params[:q], params[:status], params[:page], params[:sort_by], params[:sort_direction]
-
+  def recover_records(register_id, fields, params, page_size = 100)
+    literal = params[:q]
+    status = params[:status]
+    page = params[:page] ||= 1
+    sort_by = params[:sort_by]
+    sort_direction = params[:sort_direction]
+    params[:page_size] = page_size
+    
     query = Record.where(spina_register_id: register_id, entry_type: 'user')
 
     count_query = Record.select(1).where(spina_register_id: register_id, entry_type: 'user')
@@ -136,10 +141,12 @@ class RegistersController < ApplicationController
     end
 
     @page_count = count_query.length
+    params[:offset] = params[:page_size] * (params[:page].to_i - 1) + 1
+    params[:offset_end] = [@page_count, (params[:page_size]) * params[:page].to_i].min
 
     @total_pages = (@page_count / 100) + (@page_count % 100 == 0 ? 0 : 1)
 
-    query.page(page).per(100).without_count
+    query.page(page).per(page_size).without_count
   end
 
   def filter(entries, query)

--- a/app/views/registers/_showing.html.haml
+++ b/app/views/registers/_showing.html.haml
@@ -1,0 +1,3 @@
+Showing <strong>#{params[:offset]} &ndash; #{params[:offset_end]}</strong> of <strong>#{@page_count}</strong> records
+- if params[:q].present?
+  for <strong>"#{params[:q]}"</strong>

--- a/app/views/registers/show.html.haml
+++ b/app/views/registers/show.html.haml
@@ -127,9 +127,7 @@
       - if @records.present?
         %p
           %span#records-count
-            Showing <strong>1 &ndash; #{@records.count}</strong> of <strong>#{@page_count}</strong> records
-            - if params[:q].present?
-              &nbsp; for <strong>"#{params[:q]}"</strong>
+            = render partial: 'showing'
           = link_to 'Reset', register_path(@register.slug, anchor: 'search_wrapper'), class: 'reset-link'
 
         .table-scroll
@@ -145,7 +143,7 @@
           .pager-controls
             = paginate @records, total_pages: @total_pages, outer_window: 0, window: 3
           .pager-summary
-            Showing <strong>1 &ndash; #{@records.count}</strong> of <strong>#{@page_count}</strong> records
+            = render partial: 'showing'
 
         - unless @records.last_page?
           = link_to_next_page @records, 'Load more', id: 'load-more-records', class: 'js-hidden', remote: true

--- a/app/views/registers/show.js.erb
+++ b/app/views/registers/show.js.erb
@@ -1,5 +1,5 @@
 $("#records-tbody").append("<%= j(render(partial: 'record', collection: @records)) %>");
-$("#records-count").html('Showing <strong>1 &ndash; <%= @records.count%></strong> of <strong><%= @page_count %></strong> records <% if params[:q].present? %>for <strong>"<%= params[:q] %>"</strong><% end %>')
+$("#records-count").html('Showing <strong>1 &ndash; <%= params[:offset_end] %></strong> of <strong><%= @page_count %></strong> records <% if params[:q].present? %>for <strong>"<%= params[:q] %>"</strong><% end %>')
 
 <% if @records.last_page? %>
   $("#load-more-records").hide();


### PR DESCRIPTION
### Context
Previously the offset counts were incorrect as this was not implemented when we switched to an ActiveRecord model. 

### Changes proposed in this pull request
Restore offset counts. Note as we are not using Kaminari to produce the total count (for performance reasons) we have do some manual calculations to work the values out.

__Non-JS__
<img width="988" alt="screen shot 2018-01-17 at 09 58 44" src="https://user-images.githubusercontent.com/1764158/35037650-134a4058-fb70-11e7-83e1-cea7678007ab.png">

__JS__
<img width="380" alt="screen shot 2018-01-17 at 09 59 31" src="https://user-images.githubusercontent.com/1764158/35037694-2e3573d8-fb70-11e7-9bf5-5dc3a8c96f31.png">

### Guidance to review
Offsets should work as-per `beta-assessment` branch.
