### PR TITLE
Set default filter to 'current'

### DIFF
--- a/app/controllers/registers_controller.rb
+++ b/app/controllers/registers_controller.rb
@@ -104,19 +104,19 @@ private
 
   def recover_records(register_id, fields, params, page_size = 100)
     literal = params[:q]
-    status = params[:status]
+    status = params[:status] ||= 'current'
     page = params[:page] ||= 1
     sort_by = params[:sort_by]
     sort_direction = params[:sort_direction]
 
     query = Record.where(spina_register_id: register_id, entry_type: 'user')
-
     count_query = Record.select(1).where(spina_register_id: register_id, entry_type: 'user')
 
-    if status == 'archived'
+    case status
+    when 'archived'
       query = query.where("data->> 'end-date' is not null")
       count_query = query.where("data->> 'end-date' is not null")
-    elsif status == 'current'
+    when 'current'
       query = query.where("data->> 'end-date' is null")
       count_query = query.where("data->> 'end-date' is null")
     end

--- a/spec/controllers/registers_controller_spec.rb
+++ b/spec/controllers/registers_controller_spec.rb
@@ -167,8 +167,8 @@ RSpec.describe RegistersController, type: :controller do
     end
   end
 
-  describe 'Request: GET #show. Descr: Check with filter. Params: Search param, default status. Result: 1 rows' do
-    subject { get :show, params: { id: 'country', q: 'Germany' } }
+  describe 'Request: GET #show. Descr: Check with filter. Params: Search param, default status. Result: 2 rows' do
+    subject { get :show, params: { id: 'country', q: 'Germany', status: 'all' } }
 
     it { is_expected.to have_http_status :success }
 
@@ -210,7 +210,7 @@ RSpec.describe RegistersController, type: :controller do
   end
 
   describe 'Request: GET #show. Descr: Check with filter and cardinality N. Params: Search param. Result: 1 rows' do
-    subject { get :show, params: { id: 'charity', q: '306' } }
+    subject { get :show, params: { id: 'charity', q: '306', status: 'all' } }
 
     it { is_expected.to have_http_status :success }
 


### PR DESCRIPTION
### Context
https://trello.com/c/ikQGz2w8/1688-should-default-to-filter-by-current-records

### Changes proposed in this pull request
Default show filter to 'current' to match UI

### Guidance to review
Country register should show 195 records by default 