### PR TITLE
log to logit in production

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -67,3 +67,8 @@ group :test do
   gem 'rails-controller-testing'
   gem 'webmock'
 end
+
+group :production do
+  gem 'lograge', '~> 0.9.0'
+  gem 'logstash-event', '~> 1.2', '>= 1.2.02'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -243,6 +243,12 @@ GEM
     listen (3.0.8)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
+    lograge (0.9.0)
+      actionpack (>= 4)
+      activesupport (>= 4)
+      railties (>= 4)
+      request_store (~> 1.0)
+    logstash-event (1.2.02)
     loofah (2.1.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -438,6 +444,8 @@ DEPENDENCIES
   jquery-rails
   kaminari
   listen (~> 3.0.5)
+  lograge (~> 0.9.0)
+  logstash-event (~> 1.2, >= 1.2.02)
   pg (~> 0.18)
   pry-byebug
   puma (~> 3.0)

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -39,7 +39,7 @@ Rails.application.configure do
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.
-  config.log_level = :debug
+  config.log_level = :info
 
   # Prepend all log lines with the following tags.
   config.log_tags = [ :request_id ]
@@ -69,11 +69,14 @@ Rails.application.configure do
   # Use a different logger for distributed setups.
   # require 'syslog/logger'
   # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new 'app-name')
+  config.lograge.enabled = true
+
+  config.lograge.formatter = Lograge::Formatters::Logstash.new
 
   if ENV["RAILS_LOG_TO_STDOUT"].present?
-    logger           = ActiveSupport::Logger.new(STDOUT)
+    logger = ActiveSupport::Logger.new(STDOUT)
     logger.formatter = config.log_formatter
-    config.logger = ActiveSupport::TaggedLogging.new(logger)
+    config.logger = ActiveSupport::Logger.new(STDOUT)
   end
 
   # Do not dump schema after migrations.

--- a/manifest.yml
+++ b/manifest.yml
@@ -13,3 +13,5 @@ applications:
     - registers-frontend
     # environment variables (persisted for blue/green deploys)
     - registers-product-site-environment-variables
+    # logging
+    - logit-ssl-drain


### PR DESCRIPTION
### Context
Previously we were not shipping logs from `registers-frontend`

### Changes proposed in this pull request
Implement log shipping using the same setup as `managing-registers`

### Guidance to review
Logs in production should be in Logstash format e.g.
```
{"method":"GET","path":"/health_check/standard","format":"text","controller":"HealthCheck::HealthCheckController","action":"index","status":200,"duration":5.76,"view":0.14,"db":2.56,"@timestamp":"2018-01-17T18:01:39.036Z","@version":"1","message":"[200] GET /health_check/standard (HealthCheck::HealthCheckController#index)"}
```
Logs should appear in Logit
