### PR TITLE
restore previous sorting and default sort behaviour

### DIFF
--- a/spec/controllers/registers_controller_spec.rb
+++ b/spec/controllers/registers_controller_spec.rb
@@ -251,7 +251,7 @@ RSpec.describe RegistersController, type: :controller do
     end
   end
 
-  describe 'Request: GET #show. Descr: Sort by start date descending where some values are nil' do
+  describe 'Request: GET #show. Descr: Sort by start date descending where some values are nil should show nil values last' do
     subject { get :show, params: { id: 'country', sort_by: 'start-date', sort_direction: 'desc' } }
 
     it { is_expected.to have_http_status :success }
@@ -260,7 +260,7 @@ RSpec.describe RegistersController, type: :controller do
 
     it do
       subject
-      expect(assigns(:records).first.data['start-date']).to be_nil
+      expect(assigns(:records).first.data['start-date']).to eq('2011-07-09')
       expect(assigns(:records).last.data['start-date']).to be_nil
     end
   end


### PR DESCRIPTION
### Context
https://trello.com/c/2unPv8Q1/1695-restore-default-sort-and-null-value-ordering-in-activerecord

### Changes proposed in this pull request
Re-implement previous sorting behaviour in ActiveRecord, namely:
* Default sort by `name` if present else primary key ascending
* When sorting show null values last

### Guidance to review
Sorting behaviour should be as described above
