### PR TITLE
replace length with count to derive total record count

### DIFF
--- a/app/controllers/registers_controller.rb
+++ b/app/controllers/registers_controller.rb
@@ -94,7 +94,6 @@ private
       previous_entry = previous_entries_query.select { |previous_entry| previous_entry.entry_number == entry.previous_entry_number }.first
       { current_entry: entry, previous_entry: previous_entry }
     end
-
     @page_count = count_query.length
     @current_page = page
     @total_pages = (@page_count / 100) + (@page_count % 100 == 0 ? 0 : 1)
@@ -143,8 +142,7 @@ private
     if sort_by.present? && sort_direction.present?
       query = query.order("data->> '#{sort_by}' #{sort_direction.upcase} nulls last")
     end
-
-    @page_count = count_query.length
+    @page_count = count_query.count
     @offset = page_size * (params[:page].to_i - 1) + 1
     @offset_end = [@page_count, page_size * params[:page].to_i].min
 


### PR DESCRIPTION
### Context
Previously we were erroneously calling an unbounded query for all data when `.length` was called.

### Changes proposed in this pull request
Call `.count` to perform a `COUNT` query, rather than the previous unbounded query for all data

### Guidance to review
Total count should be derived from a `COUNT` query visible in debug level logs e.g. 
```
(295.2ms)  SELECT COUNT(*) FROM "records" WHERE "records"."spina_register_id" = $1 AND "records"."entry_type" = $2 AND (data->> 'end-date' is null) AND (data->> 'end-date' is null)  [["spina_register_id", 9], ["entry_type", "user"]]
```
H/T @arnau for helping identify the cause of the slow query