### PR TITLE
Fix population of previous_entry_number

### DIFF
--- a/app/services/postgres_data_store.rb
+++ b/app/services/postgres_data_store.rb
@@ -18,7 +18,7 @@ class PostgresDataStore
   def append_entry(entry)
     entry_type = entry.entry_type.to_sym
     item = @items[entry.item_hash]
-    previous_entry_number = @records[entry_type].has_key?(entry.key) ? @records[entry_type][entry.key].last : nil
+    previous_entry_number = @records[entry_type].has_key?(entry.key) ? @records[entry_type][entry.key].last[:entry_number] : nil
     db_entry = Entry.new(spina_register: @register, data: item.value, timestamp: entry.timestamp, hash_value: item.hash, entry_number: entry.entry_number, previous_entry_number: previous_entry_number, entry_type: entry_type, key: entry.key)
 
     @entries[entry_type] << db_entry

--- a/spec/controllers/registers_controller_spec.rb
+++ b/spec/controllers/registers_controller_spec.rb
@@ -264,4 +264,19 @@ RSpec.describe RegistersController, type: :controller do
       expect(assigns(:records).last.data['start-date']).to be_nil
     end
   end
+
+  describe 'History should show current and previous value' do
+    subject { get :history, params: { id: 'country' } }
+
+    it { is_expected.to have_http_status :success }
+
+    it { is_expected.to render_template :history }
+
+    it do
+      subject
+      expect(assigns(:entries_with_items).first[:current_record].data['official-name']).to eq("The Republic of Côte D’Ivoire")
+      expect(assigns(:entries_with_items).first[:previous_record].data['official-name']).to eq("The Republic of Cote D'Ivoire")
+      expect(assigns(:entries_with_items).first[:updated_fields]).to eq(["official-name"])
+    end
+  end
 end


### PR DESCRIPTION
### Context
When we changed the database population in https://github.com/openregister/registers-frontend/pull/124 the `previous_entry_number` was always `nil` this meant on the history page the Previous version was not shown.

### Changes proposed in this pull request
Fix population of `previous_entry_number`. Note in order for this to work on production we will need to force a repopulation of all records, I am interested in hearing ways to do this without downtime!

### Guidance to review
Locally, start from blank DB and run 
```
$ rails db:setup
$ rake registers_frontend:populate_db:fetch_now
```

`previous_entry_number` should be populated.
