### PR TITLE
add task to populate previous_entry_number

### DIFF
--- a/lib/tasks/populate_previous_entry.rake
+++ b/lib/tasks/populate_previous_entry.rake
@@ -2,12 +2,12 @@ namespace :registers_frontend do
   desc "populate previous entries"
   task populate_previous_entry: :environment do
     Spina::Register.find_each do |register|
-      entries_by_key =  Entry.where(spina_register_id: register.id).group_by(&:key)
+      entries_by_key = Entry.where(spina_register_id: register.id).group_by(&:key)
       entries_by_key.each do |key, entries|
-        entries.sort_by(&:entry_number).reverse.each_cons(2) { |current, previous|
+        entries.sort_by(&:entry_number).reverse.each_cons(2) do |current, previous|
           puts "register #{register.name} setting key #{key}, entry #{current.entry_number} previous entry to #{previous.entry_number}"
           Entry.update(current.id, previous_entry_number: previous.entry_number)
-        }
+        end
       end
     end
   end

--- a/lib/tasks/populate_previous_entry.rake
+++ b/lib/tasks/populate_previous_entry.rake
@@ -4,8 +4,8 @@ namespace :registers_frontend do
     Spina::Register.find_each do |register|
       entries_by_key =  Entry.where(spina_register_id: register.id).group_by(&:key)
       entries_by_key.each do |key, entries|
-        entries.each_cons(2) { |current, previous|
-          puts "register #{register.name} setting key #{key} #{current.entry_number} previous entry to #{previous.entry_number}"
+        entries.sort_by(&:entry_number).reverse.each_cons(2) { |current, previous|
+          puts "register #{register.name} setting key #{key}, entry #{current.entry_number} previous entry to #{previous.entry_number}"
           Entry.update(current.id, previous_entry_number: previous.entry_number)
         }
       end

--- a/lib/tasks/populate_previous_entry.rake
+++ b/lib/tasks/populate_previous_entry.rake
@@ -3,9 +3,9 @@ namespace :registers_frontend do
   task populate_previous_entry: :environment do
     Spina::Register.find_each do |register|
       entries_by_key =  Entry.where(spina_register_id: register.id).group_by(&:key)
-      entries_with_history = entries_by_key.select {|key,entries| entries.length > 1}
+      entries_with_history = entries_by_key.select { |_key, entries| entries.length > 1 }
       entries_with_history.each do |key, entries|
-        entries.each_cons(2) {|current, previous|
+        entries.each_cons(2) { |current, previous|
           puts "register #{register.name} setting key #{key} #{current.entry_number} previous entry to #{previous.entry_number}"
           Entry.update(current.id, previous_entry_number: previous.entry_number)
         }

--- a/lib/tasks/populate_previous_entry.rake
+++ b/lib/tasks/populate_previous_entry.rake
@@ -3,8 +3,7 @@ namespace :registers_frontend do
   task populate_previous_entry: :environment do
     Spina::Register.find_each do |register|
       entries_by_key =  Entry.where(spina_register_id: register.id).group_by(&:key)
-      entries_with_history = entries_by_key.select { |_key, entries| entries.length > 1 }
-      entries_with_history.each do |key, entries|
+      entries_by_key.each do |key, entries|
         entries.each_cons(2) { |current, previous|
           puts "register #{register.name} setting key #{key} #{current.entry_number} previous entry to #{previous.entry_number}"
           Entry.update(current.id, previous_entry_number: previous.entry_number)

--- a/lib/tasks/registers_frontend.rake
+++ b/lib/tasks/registers_frontend.rake
@@ -1,0 +1,15 @@
+namespace :registers_frontend do
+  desc "populate previous entries"
+  task populate_previous_entry: :environment do
+    Spina::Register.find_each do |register|
+      entries_by_key =  Entry.where(spina_register_id: register.id).group_by(&:key)
+      entries_with_history = entries_by_key.select {|key,entries| entries.length > 1}
+      entries_with_history.each do |key, entries|
+        entries.each_cons(2) {|current, previous|
+          puts "register #{register.name} setting key #{key} #{current.entry_number} previous entry to #{previous.entry_number}"
+          Entry.update(current.id, previous_entry_number: previous.entry_number)
+        }
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context
Sister PR to https://github.com/openregister/registers-frontend/pull/131 

### Changes proposed in this pull request
this task will re-populate the missing `previous_entry_number` for existing entries
once merged I will run this manually once on the production database to correct the data

### Guidance to review
run `rake registers_frontend:populate_previous_entry` locally
check history page now has current previous entry data