### PR TITLE
Switch queue and scheduler deploy to cf push

### DIFF
--- a/bin/deploy
+++ b/bin/deploy
@@ -2,17 +2,26 @@
 set -e
 
 # Parse app names from manifest to ensure it matches up
-APP_ARRAY=$(ruby -e "require 'yaml'; config = YAML.load_file('manifest.yml'); puts config['applications'].map{|a| a['name']}.join(' ')")
+SINGLE_INSTANCE_APPS=(registers-frontend-queue registers-frontend-scheduler)
+ZERO_DOWNTIME_APPS=registers-frontend
 
-for APP_NAME in $APP_ARRAY
+# $CF env variables are set by Travis and configured in ../.travis.yml
+cf login -a $CF_API -u $CF_USERNAME -p $CF_PASSWORD -o $CF_ORG -s $CF_SPACE
+
+for APP_NAME in $ZERO_DOWNTIME_APPS
 do
   echo "Deploying ${APP_NAME} to ${CF_ORG}/${CF_SPACE}..."
-
-  # $CF env variables are set by Travis and configured in ../.travis.yml
-  cf login -a $CF_API -u $CF_USERNAME -p $CF_PASSWORD -o $CF_ORG -s $CF_SPACE
 
   # Zero downtime push comes from "Autopilot" which is installed in before_deploy
   # step in Travis
   cf zero-downtime-push $APP_NAME -f manifest.yml
+  cf set-env $APP_NAME GIT_COMMIT_HASH $TRAVIS_COMMIT 
+done
+
+for APP_NAME in $SINGLE_INSTANCE_APPS
+do
+  echo "Deploying ${APP_NAME} to ${CF_ORG}/${CF_SPACE}..."
+  # We do not want multiple instances of these apps running so use CF PUSH
+  cf push $APP_NAME -f manifest.yml
   cf set-env $APP_NAME GIT_COMMIT_HASH $TRAVIS_COMMIT 
 done


### PR DESCRIPTION
### Context
Previously we were unnecessarily deploying the `queue` and `scheduler` apps using the zero downtime deploy plugin. This would cause a state where multiple instances were running which may cause unexpected behaviour.

### Changes proposed in this pull request
Switch queue and scheduler to use `cf push` instead of `cf zero-downtime-push`

### Guidance to review
App should still build and deploy from travis