### PR TITLE
check database for previous entry number

### DIFF
--- a/app/services/postgres_data_store.rb
+++ b/app/services/postgres_data_store.rb
@@ -9,7 +9,7 @@ class PostgresDataStore
     @entries = { user: [], system: [] }
     @records = { user: {}, system: {} }
     @register = register
-    @has_existing_entries_in_db = Entry.where(spina_register_id: @register.id).exists?
+    @has_existing_entries_in_db = Entry.where(register_id: @register.id).exists?
   end
 
   def add_item(item)
@@ -23,13 +23,13 @@ class PostgresDataStore
 
     previous_entry_number_from_db =
       if @has_existing_entries_in_db
-        latest_entry_from_db = Entry.where(spina_register_id: @register.id, entry_type: entry.entry_type.to_s, key: entry.key.to_s).order(entry_number: :desc).first
+        latest_entry_from_db = Entry.where(register_id: @register.id, entry_type: entry.entry_type.to_s, key: entry.key.to_s).order(entry_number: :desc).first
         latest_entry_from_db ? latest_entry_from_db[:entry_number] : nil
       end
 
     previous_entry_number = previous_entry_number_from_memory || previous_entry_number_from_db
 
-    db_entry = Entry.new(spina_register: @register, data: item.value, timestamp: entry.timestamp, hash_value: item.hash, entry_number: entry.entry_number, previous_entry_number: previous_entry_number, entry_type: entry_type, key: entry.key)
+    db_entry = Entry.new(register: @register, data: item.value, timestamp: entry.timestamp, hash_value: item.hash, entry_number: entry.entry_number, previous_entry_number: previous_entry_number, entry_type: entry_type, key: entry.key)
 
     @entries[entry_type] << db_entry
 

--- a/app/services/postgres_data_store.rb
+++ b/app/services/postgres_data_store.rb
@@ -22,13 +22,11 @@ class PostgresDataStore
     previous_entry_number_from_memory = @records[entry_type].key?(entry.key) ? @records[entry_type][entry.key].last[:entry_number] : nil
 
     previous_entry_number_from_db =
-    if @has_existing_entries_in_db
-      latest_entry_from_db = Entry.where(spina_register_id: @register.id, entry_type: entry.entry_type.to_s, key: entry.key.to_s).order(entry_number: :desc).first
-      latest_entry_from_db ? latest_entry_from_db[:entry_number] : nil
-    else
-      nil
-    end
-    
+      if @has_existing_entries_in_db
+        latest_entry_from_db = Entry.where(spina_register_id: @register.id, entry_type: entry.entry_type.to_s, key: entry.key.to_s).order(entry_number: :desc).first
+        latest_entry_from_db ? latest_entry_from_db[:entry_number] : nil
+      end
+
     previous_entry_number = previous_entry_number_from_memory || previous_entry_number_from_db
 
     db_entry = Entry.new(spina_register: @register, data: item.value, timestamp: entry.timestamp, hash_value: item.hash, entry_number: entry.entry_number, previous_entry_number: previous_entry_number, entry_type: entry_type, key: entry.key)
@@ -40,8 +38,7 @@ class PostgresDataStore
     end
 
     @records[entry_type][entry.key] << db_entry
-    end
-
+  end
 
   def get_item(item_hash); end
 

--- a/app/services/postgres_data_store.rb
+++ b/app/services/postgres_data_store.rb
@@ -9,7 +9,6 @@ class PostgresDataStore
     @entries = { user: [], system: [] }
     @records = { user: {}, system: {} }
     @register = register
-    @has_existing_entries_in_db = Entry.where(register_id: @register.id).exists?
   end
 
   def add_item(item)
@@ -20,9 +19,9 @@ class PostgresDataStore
     entry_type = entry.entry_type.to_sym
     item = @items[entry.item_hash]
     previous_entry_number_from_memory = @records[entry_type].key?(entry.key) ? @records[entry_type][entry.key].last[:entry_number] : nil
-
+    has_existing_entries_in_db = Entry.where(register_id: @register.id).exists?
     previous_entry_number_from_db =
-      if @has_existing_entries_in_db
+      if has_existing_entries_in_db
         latest_entry_from_db = Entry.where(register_id: @register.id, entry_type: entry.entry_type.to_s, key: entry.key.to_s).order(entry_number: :desc).first
         latest_entry_from_db ? latest_entry_from_db[:entry_number] : nil
       end

--- a/spec/jobs/populate_register_data_in_db_job_spec.rb
+++ b/spec/jobs/populate_register_data_in_db_job_spec.rb
@@ -31,8 +31,6 @@ RSpec.describe PopulateRegisterDataInDbJob, type: :job do
     with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip, deflate', 'Host' => 'country.beta.openregister.org' }).
     to_return({ body: country_proof }, body: country_proof_update)
 
-
-
     @@registers_client = RegistersClient::RegisterClientManager.new(cache_duration: 600) # rubocop:disable Style/ClassVars
 
     ObjectsFactory.new.create_register('country', 'beta', 'Ministry of Justice')
@@ -51,6 +49,10 @@ RSpec.describe PopulateRegisterDataInDbJob, type: :job do
 
     it 'retains existing entries' do
       expect(Entry.where(key: 'CI').first.data['citizen-names']).to eq('Citizen of the Ivory Coast')
+    end
+
+    it 'populates previous entry number from current RSF' do
+      expect(Entry.where(key: 'CZ').order(entry_number: :desc).first[:previous_entry_number]).to eq(52)
     end
 
     it 'populates previous entry number from database' do

--- a/spec/jobs/populate_register_data_in_db_job_spec.rb
+++ b/spec/jobs/populate_register_data_in_db_job_spec.rb
@@ -52,6 +52,10 @@ RSpec.describe PopulateRegisterDataInDbJob, type: :job do
     it 'retains existing entries' do
       expect(Entry.where(key: 'CI').first.data['citizen-names']).to eq('Citizen of the Ivory Coast')
     end
+
+    it 'populates previous entry number from database' do
+      expect(Entry.where(key: 'CI').order(entry_number: :desc).first[:previous_entry_number]).to eq(207)
+    end
   end
 
   after(:all) do


### PR DESCRIPTION
### Context
Previously when doing an incremental update we were only looking in the in-memory store for the `previous_entry_number`. 

### Changes proposed in this pull request
If there are existing entries, look in the database and the in-memory store for `previous_entry_number`

### Guidance to review
running `rake registers_frontend:populate_db:fetch_now`  on an existing DB should populate previous entry number, for entries have a previous version in the database.