### PR TITLE
Upgrade to use registers-ruby-client:0.8.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,7 @@ gem 'govuk_template'
 gem 'govuk_elements_rails'
 gem 'govspeak', '~> 3.4.0'
 gem 'govuk_elements_form_builder', git: 'https://github.com/ministryofjustice/govuk_elements_form_builder.git'
-gem 'registers-ruby-client', git: 'https://github.com/openregister/registers-ruby-client.git', tag: 'v0.1.0'
+gem 'registers-ruby-client', git: 'https://github.com/openregister/registers-ruby-client.git', tag: 'v0.8.0'
 
 # Spina CMS
 gem 'spina', github: 'denkGroot/Spina', branch: 'master'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -43,10 +43,10 @@ GIT
 
 GIT
   remote: https://github.com/openregister/registers-ruby-client.git
-  revision: fa7af6cb1c2fccc5ae74fcee194840052cbfb90b
-  tag: v0.1.0
+  revision: 2b6cc5e759d8c4002fa626392869cdf25e2c8e5d
+  tag: v0.8.0
   specs:
-    registers-ruby-client (0.1.0)
+    registers-ruby-client (0.8.0)
       mini_cache (~> 1.1.0)
       rest-client (~> 2)
 

--- a/app/controllers/spina/registers_controller.rb
+++ b/app/controllers/spina/registers_controller.rb
@@ -23,15 +23,15 @@ module Spina
       @current_phases = Spina::Register::CURRENT_PHASES
 
       # Fetch the register register for each phase and get records
-      beta_register_register = @@registers_client.get_register('register', 'beta').get_records
-      alpha_register_register = @@registers_client.get_register('register', 'alpha').get_records
-      discovery_register_register = @@registers_client.get_register('register', 'discovery').get_records
+      beta_register_register = @@registers_client.get_register('register', 'beta').get_records.to_a
+      alpha_register_register = @@registers_client.get_register('register', 'alpha').get_records.to_a
+      discovery_register_register = @@registers_client.get_register('register', 'discovery').get_records.to_a
       @register_registers = beta_register_register + alpha_register_register + discovery_register_register
     end
 
     def new_show
       @register = Spina::Register.find_by_slug!(params[:id])
-      @register_data = @@registers_client.get_register(@register.name.parameterize, @register.register_phase)
+      @register_data = @@registers_client.get_register(@register.name.parameterize, @register.register_phase.downcase)
 
       if params[:status]
         case params[:status]
@@ -53,32 +53,32 @@ module Spina
 
     def history
       @register = Spina::Register.find_by_slug!(params[:id])
-      @register_data = @@registers_client.get_register(@register.name.parameterize, @register.register_phase)
+      @register_data = @@registers_client.get_register(@register.name.parameterize, @register.register_phase.downcase)
 
-      fields = @register_data.get_field_definitions.map{ |field| field[:item]['field'] }
+      fields = @register_data.get_field_definitions.map{ |field| field.item.value['field'] }
       all_records = @register_data.get_records_with_history
-      entries_reversed = @register_data.get_entries.reverse
+      entries_reversed = @register_data.get_entries.to_a.reverse
 
       @entries_with_items = entries_reversed.map { |entry|
-        records_for_key = all_records[entry[:key]]
-        current_record = records_for_key.detect{ |record| record[:entry_number] == entry[:entry_number] }
+        records_for_key = all_records.get_records_for_key(entry.key)
+        current_record = records_for_key.detect{ |record| record.entry.entry_number == entry.entry_number }
         previous_record_index = records_for_key.find_index(current_record) - 1
 
         if previous_record_index < 0
           changed_fields = fields
         else
           previous_record = records_for_key[previous_record_index]
-          changed_fields = fields.select { |f| current_record[:item][f] != previous_record[:item][f] }
+          changed_fields = fields.select { |f| current_record.item.value[f] != previous_record.item.value[f] }
         end
 
-        { current_record: current_record, previous_record: previous_record, updated_fields: changed_fields, key: entry[:key] }
+        { current_record: current_record, previous_record: previous_record, updated_fields: changed_fields, key: entry.key }
       }
     end
 
     private
 
     def initialize_client
-      @@registers_client ||= RegistersClient::RegistersClientManager.new({ cache_duration: 600 })
+      @@registers_client ||= RegistersClient::RegisterClientManager.new({ cache_duration: 600 })
     end
   end
 end

--- a/app/decorators/helpers/spina/application_helper_decorator.rb
+++ b/app/decorators/helpers/spina/application_helper_decorator.rb
@@ -32,7 +32,7 @@ module Spina
     end
 
     def registers_client
-      RegistersClient::RegistersClientManager.new({ cache_duration: 600 })
+      RegistersClient::RegisterClientManager.new({ cache_duration: 600 })
     end
 
     def government_organisations

--- a/app/views/default/pages/homepage.html.haml
+++ b/app/views/default/pages/homepage.html.haml
@@ -79,8 +79,8 @@
       %aside.related-items
         %h2.related-items__title Registers ready to use
         %ul.related-items__list
-          - beta_registers.reject{ |r| %w{register datatype field}.include?(r[:item]['register'])}.each do |register|
-            %li= link_to register[:item]['register'], "https://#{register[:item]['register'].parameterize}.register.gov.uk", target: :blank
+          - beta_registers.reject{ |r| %w{register datatype field}.include?(r.item.value['register'])}.each do |register|
+            %li= link_to register.item.value['register'], "https://#{register.item.value['register'].parameterize}.register.gov.uk", target: :blank
         %h2.related-items__title Upcoming registers
         %ul.related-items__list
           %li

--- a/app/views/spina/admin/registers/_form.html.haml
+++ b/app/views/spina/admin/registers/_form.html.haml
@@ -53,7 +53,7 @@
         .horizontal-form-label
           Authority
         .horizontal-form-content
-          = f.select :authority, government_organisations.map{|c| c[:item]['name']}, {data: { "default-value" => @register.authority }}
+          = f.select :authority, government_organisations.map{|c| c.item.value['name']}, {data: { "default-value" => @register.authority }}
       .horizontal-form-group
         .horizontal-form-label
           = Spina::Page.human_attribute_name :custodian

--- a/app/views/spina/registers/_record.html.haml
+++ b/app/views/spina/registers/_record.html.haml
@@ -1,4 +1,4 @@
 %tr
   - @register_data.get_field_definitions.each do |field|
-    %td{class: field[:item]['field']}
-      = record[:item][field[:item]['field']] || "<span class='unknown'>No data found</span>".html_safe
+    %td{class: field.item.value['field']}
+      = record.item.value[field.item.value['field']] || "<span class='unknown'>No data found</span>".html_safe

--- a/app/views/spina/registers/_register.html.haml
+++ b/app/views/spina/registers/_register.html.haml
@@ -4,7 +4,7 @@
     - if register.register_phase == 'Backlog'
       %p= govspeak(register.description)
     - else
-      %p= @register_registers.select{ |r| r[:key] == register.name.parameterize }.first[:item]['text']
+      %p= @register_registers.select{ |r| r.entry.key == register.name.parameterize }.first.item.value['text']
   %td{"data-title" => "Phase: "}
     = phase_label(register.register_phase)
   %td{"data-title" => "Managed by: "}

--- a/app/views/spina/registers/_timeline_record.html.haml
+++ b/app/views/spina/registers/_timeline_record.html.haml
@@ -1,8 +1,8 @@
-%li.entries__item.js-filter-item{ "data-filter-terms" => timeline_record[:current_record][:item].map { |key, value| value }.uniq }
+%li.entries__item.js-filter-item{ "data-filter-terms" => timeline_record[:current_record].item.value.map { |key, value| value }.uniq }
   %p.entries__date
     Last updated:
-    = DateTime.parse(timeline_record[:current_record][:timestamp]).strftime('%d/%m/%Y')
-  %h3.heading-medium= timeline_record[:current_record][:key]
+    = DateTime.parse(timeline_record[:current_record].entry.timestamp).strftime('%d/%m/%Y')
+  %h3.heading-medium= timeline_record[:current_record].entry.key
   %table
     %thead
       %tr
@@ -15,6 +15,6 @@
           %td
             = field_name
           %td
-            = timeline_record[:previous_record].present? ? timeline_record[:previous_record][:item][field_name] : "<span class='unknown'>No data found</span>".html_safe
+            = timeline_record[:previous_record].present? ? timeline_record[:previous_record].item.value[field_name] : "<span class='unknown'>No data found</span>".html_safe
           %td
-            = timeline_record[:current_record][:item][field_name].present? ? timeline_record[:current_record][:item][field_name] : "<span class='unknown'>No data found</span>".html_safe
+            = timeline_record[:current_record].item.value[field_name].present? ? timeline_record[:current_record].item.value[field_name] : "<span class='unknown'>No data found</span>".html_safe

--- a/app/views/spina/registers/new_show.html.haml
+++ b/app/views/spina/registers/new_show.html.haml
@@ -35,12 +35,12 @@
         %dl
           %dt Updated:
           %dd
-            = DateTime.parse(@register_data.get_entries.last[:timestamp]).strftime('%d/%m/%Y')
+            = DateTime.parse(@register_data.get_entries.to_a.last.value[:timestamp]).strftime('%d/%m/%Y')
           %dt Managed by:
           %dd
             = link_to @register.authority, "https://www.gov.uk/government/organisations/#{@register.authority.parameterize}", target: :blank
 
-      %p= @register_data.get_register_definition[:item]['text']
+      %p= @register_data.get_register_definition.item.value['text']
 
       %details{:role => "group"}
         %summary{"aria-controls" => "details-content-0", "aria-expanded" => "false", :role => "button"}
@@ -99,15 +99,15 @@
           #details-content-0.panel.panel-border-narrow{"aria-hidden" => "true"}
             %dl
               - @register_data.get_field_definitions.each do |field|
-                %dt= field[:item]['field']
-                %dd= field[:item]['text']
+                %dt= field.item.value['field']
+                %dd= field.item.value['text']
 
       .table-scroll
         %table.register-data-table
           %thead
             %tr
               - @register_data.get_field_definitions.each do |field|
-                %th= field[:item]['field']
+                %th= field.item.value['field']
 
           %tbody
             = render partial: 'record', collection: @records

--- a/config/application.rb
+++ b/config/application.rb
@@ -8,7 +8,7 @@ require "action_controller/railtie"
 require "action_mailer/railtie"
 require "action_view/railtie"
 require "sprockets/railtie"
-require "registers_client"
+require "register_client_manager"
 require "cf-app-utils"
 
 # Require the gems listed in Gemfile, including any gems


### PR DESCRIPTION
### Context
The discovery environment has moved domain. Currently the domain is hardcoded in the client library and we therefore need to deploy a fix. The fix will be in version 0.9.0 (not yet merged). This PR is the first step towards this upgrade by applying changes to upgrade to version 0.8.0. This is to stop the pipeline page falling over when we remove the *.discovery.openregister.org endpoints.

### Changes proposed in this pull request
Upgrade to registers-ruby-client:0.8.0 and apply breaking changes.

### Guidance to review
Run and check all pages including /registers, /registers/country/new and /registers/country/history.
