### PR TITLE
add rake task to delete duplicate entries

### DIFF
--- a/lib/tasks/delete_duplicate_entries.rake
+++ b/lib/tasks/delete_duplicate_entries.rake
@@ -1,0 +1,8 @@
+namespace :registers_frontend do
+  desc "delete duplicate entries"
+  task delete_duplicate_entries: :environment do
+    sql = "DELETE FROM entries WHERE id IN (SELECT id FROM (SELECT id, ROW_NUMBER() OVER (partition BY spina_register_id, timestamp, entry_type, hash_value, key ORDER BY id DESC) AS rnum FROM entries) t WHERE t.rnum > 1);"
+    ActiveRecord::Base.connection.execute(sql)
+  end
+
+end

--- a/lib/tasks/delete_duplicate_entries.rake
+++ b/lib/tasks/delete_duplicate_entries.rake
@@ -4,5 +4,4 @@ namespace :registers_frontend do
     sql = "DELETE FROM entries WHERE id IN (SELECT id FROM (SELECT id, ROW_NUMBER() OVER (partition BY spina_register_id, timestamp, entry_type, hash_value, key ORDER BY id DESC) AS rnum FROM entries) t WHERE t.rnum > 1);"
     ActiveRecord::Base.connection.execute(sql)
   end
-
 end


### PR DESCRIPTION
### Context
Previously due to a combination of #134 and not having any constraints on the table we have acquired many duplicate entries. These caused unexpected behaviour for example when computing entry number and previous entry number.

### Changes proposed in this pull request
adds rake task which executes SQL to delete duplicates. The SQL is modelled after the example in https://wiki.postgresql.org/wiki/Deleting_duplicates

### Guidance to review
Running this task should delete duplicate entries from DB. (I can provide a dump with duplicates to demonstrate this)