### PR TITLE
add task to set first entry previous to nil

### DIFF
--- a/lib/tasks/set_first_entry_previous_to_nil.rake
+++ b/lib/tasks/set_first_entry_previous_to_nil.rake
@@ -1,0 +1,15 @@
+namespace :registers_frontend do
+  desc 'set previous entry number to nil for first entry for key'
+  task first_entry_previous_nullify: :environment do
+    Spina::Register.find_each do |register|
+      entries_by_key = Entry.where(spina_register_id: register.id).group_by(&:key)
+      entries_by_key.each do |key, entries|
+        first_entry_for_key = entries.sort_by(&:entry_number).first
+        if first_entry_for_key.previous_entry_number != nil
+          puts("setting entry #{first_entry_for_key.entry_number} for key #{key} previous entry number to nil")
+          Entry.update(first_entry_for_key.id, previous_entry_number: nil)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context
follow-up to https://github.com/openregister/registers-frontend/pull/133

### Changes proposed in this pull request
Enforce that first entry number for key is `nil`. This is Yet Another Cleanup task to fix existing bad data in the DB.

### Guidance to review
First entry for key should always have `previous_entry_number` `nil`.
