### PR TITLE
Update translation migration from spina

### DIFF
--- a/db/migrate/20170116141113_create_spina_translation_tables.spina.rb
+++ b/db/migrate/20170116141113_create_spina_translation_tables.spina.rb
@@ -1,14 +1,43 @@
-# This migration comes from spina (originally 2)
 class CreateSpinaTranslationTables < ActiveRecord::Migration[4.2]
   def up
-    Spina::Page.create_translation_table! title: :string, menu_title: :string, description: :string, seo_title: :string, materialized_path: :string
-    Spina::Text.create_translation_table! content: :text
-    Spina::Line.create_translation_table! content: :string
+    create_table "spina_page_translations", force: :cascade do |t|
+      t.integer "spina_page_id", null: false
+      t.string "locale", null: false
+      t.string "title"
+      t.string "menu_title"
+      t.string "description"
+      t.string "seo_title"
+      t.string "materialized_path"
+      t.datetime "created_at", null: false
+      t.datetime "updated_at", null: false
+      t.index ["locale"], name: "index_spina_page_translations_on_locale"
+      t.index ["spina_page_id"], name: "index_spina_page_translations_on_spina_page_id"
+    end
+
+    create_table "spina_line_translations", force: :cascade do |t|
+      t.integer "spina_line_id", null: false
+      t.string "locale", null: false
+      t.string "content"
+      t.datetime "created_at", null: false
+      t.datetime "updated_at", null: false
+      t.index ["locale"], name: "index_spina_line_translations_on_locale"
+      t.index ["spina_line_id"], name: "index_spina_line_translations_on_spina_line_id"
+    end
+
+    create_table "spina_text_translations", force: :cascade do |t|
+      t.integer "spina_text_id", null: false
+      t.string "locale", null: false
+      t.text "content"
+      t.datetime "created_at", null: false
+      t.datetime "updated_at", null: false
+      t.index ["locale"], name: "index_spina_text_translations_on_locale"
+      t.index ["spina_text_id"], name: "index_spina_text_translations_on_spina_text_id"
+    end
   end
 
   def down
-    Spina::Page.drop_translation_table!
-    Spina::Text.drop_translation_table!
-    Spina::Line.drop_translation_table!
+    drop_table "spina_page_translations"
+    drop_table "spina_text_translations"
+    drop_table "spina_line_translations"
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -35,8 +35,8 @@ ActiveRecord::Schema.define(version: 20180103105857) do
     t.text "entry_type"
     t.text "key"
     t.datetime "timestamp"
-    t.bigint "spina_register_id"
     t.jsonb "data"
+    t.bigint "spina_register_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "entry_number"
@@ -47,10 +47,11 @@ ActiveRecord::Schema.define(version: 20180103105857) do
   create_table "records", force: :cascade do |t|
     t.text "hash_value"
     t.text "entry_type"
+    t.text "record_type"
     t.text "key"
     t.datetime "timestamp"
-    t.bigint "spina_register_id"
     t.jsonb "data"
+    t.bigint "spina_register_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "entry_number"
@@ -105,12 +106,12 @@ ActiveRecord::Schema.define(version: 20180103105857) do
     t.integer "account_id"
   end
 
-  create_table "spina_line_translations", force: :cascade do |t|
+  create_table "spina_line_translations", id: :serial, force: :cascade do |t|
     t.integer "spina_line_id", null: false
     t.string "locale", null: false
+    t.string "content"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "content"
     t.index ["locale"], name: "index_spina_line_translations_on_locale"
     t.index ["spina_line_id"], name: "index_spina_line_translations_on_spina_line_id"
   end
@@ -163,16 +164,16 @@ ActiveRecord::Schema.define(version: 20180103105857) do
     t.string "page_partable_type"
   end
 
-  create_table "spina_page_translations", force: :cascade do |t|
+  create_table "spina_page_translations", id: :serial, force: :cascade do |t|
     t.integer "spina_page_id", null: false
     t.string "locale", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
     t.string "title"
     t.string "menu_title"
     t.string "description"
     t.string "seo_title"
     t.string "materialized_path"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["locale"], name: "index_spina_page_translations_on_locale"
     t.index ["spina_page_id"], name: "index_spina_page_translations_on_spina_page_id"
   end
@@ -226,7 +227,7 @@ ActiveRecord::Schema.define(version: 20180103105857) do
     t.string "authority"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.text "description"
+    t.string "description"
     t.text "fields"
     t.text "related_registers"
   end
@@ -271,12 +272,12 @@ ActiveRecord::Schema.define(version: 20180103105857) do
     t.datetime "updated_at"
   end
 
-  create_table "spina_text_translations", force: :cascade do |t|
+  create_table "spina_text_translations", id: :serial, force: :cascade do |t|
     t.integer "spina_text_id", null: false
     t.string "locale", null: false
+    t.text "content"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.text "content"
     t.index ["locale"], name: "index_spina_text_translations_on_locale"
     t.index ["spina_text_id"], name: "index_spina_text_translations_on_spina_text_id"
   end


### PR DESCRIPTION
When running `rake db:setup` it was failing because of missing migrations from `spina`. This PR fixes that. 

To test -
`rake db:drop`
`rake db:setup`
