### PR TITLE
async populate register on save

### DIFF
--- a/app/controllers/spina/admin/registers_controller.rb
+++ b/app/controllers/spina/admin/registers_controller.rb
@@ -24,6 +24,7 @@ module Spina
         add_breadcrumb("New #{t('spina.registers.scaffold_name')}")
         @register = Spina::Register.new(register_params)
         if @register.save
+          PopulateRegisterDataInDbJob.perform_later(@register)
           flash.now[:success] = "Successfull saved"
           redirect_to spina.edit_admin_register_url(@register)
         else


### PR DESCRIPTION
### Context
Currently new registers created in the CMS will only be populated when the next scheduled job runs. This means that in the intervening time, links from the homepage or rendering the pipeline page will be broken.

### Changes proposed in this pull request
Kick off a population job when a new register is added

### Guidance to review
Add a new register in the CMS. It should be available from the frontend, without manually running the population rake task.
Note: locally you will need to run `rake jobs:work` alongside the frontend to perform the async job.
