### PR TITLE
Add condition around description when register not found

### DIFF
--- a/app/views/spina/registers/_register.html.haml
+++ b/app/views/spina/registers/_register.html.haml
@@ -1,7 +1,7 @@
 %tr{class: "js-filter-item", "data-filter-terms" => "#{register.name}"}
   %th{"data-title" => index, }
     %h4.heading-xsmall= register.name
-    - if register.register_phase == 'Backlog'
+    - if register.register_phase == 'Backlog' || @register_registers.select{ |r| r.entry.key == register.name.parameterize }.first.nil?
       %p= govspeak(register.description)
     - else
       %p= @register_registers.select{ |r| r.entry.key == register.name.parameterize }.first.item.value['text']


### PR DESCRIPTION
When registers are not available(either down or looking in a different phase) we don't want to throw a server error so we revert to the description from the CMS.