### PR TITLE
only show registers in ready to use for which we have data

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -22,6 +22,6 @@ class PagesController < ApplicationController
 private
 
   def get_ready_to_use_registers
-    @beta_registers = Register.where(register_phase: 'Beta').select { |r| Record.where(register_id: r.id).exists? }
+    @beta_registers = Register.where(register_phase: 'Beta').select(&:records?)
   end
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -22,6 +22,6 @@ class PagesController < ApplicationController
 private
 
   def get_ready_to_use_registers
-    @beta_registers = Register.where(register_phase: 'Beta')
+    @beta_registers = Register.where(register_phase: 'Beta').select { |r| Record.where(register_id: r.id).exists? }
   end
 end

--- a/app/models/register.rb
+++ b/app/models/register.rb
@@ -14,6 +14,10 @@ class Register < ApplicationRecord
   has_many :entries, dependent: :destroy
   has_many :records, dependent: :destroy
 
+  def records?
+    Record.where(register_id: id).exists?
+  end
+
 private
 
   def set_slug


### PR DESCRIPTION
### Context
Previously if register population failed we would still show a link to the register on the homepage

### Changes proposed in this pull request
Only show a link if we have Records in the DB for the register

### Guidance to review
Links should only show for registers where records exist in DB.
