### PR TITLE
pipeline page should not 500 if records not populated in DB

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -22,6 +22,6 @@ class PagesController < ApplicationController
 private
 
   def get_ready_to_use_registers
-    @beta_registers = Register.where(register_phase: 'Beta').select(&:records?)
+    @beta_registers = Register.has_records.where(register_phase: 'Beta')
   end
 end

--- a/app/controllers/registers_controller.rb
+++ b/app/controllers/registers_controller.rb
@@ -6,17 +6,16 @@ class RegistersController < ApplicationController
   layout 'layouts/default/application'
 
   def index
-    @search = Register.ransack(params[:q])
+    @search = Register.available.ransack(params[:q])
 
-    @registers = if params[:phase] == 'ready to use'
+    @registers = case params[:phase]
+                 when 'ready to use'
                    @search.result.where(register_phase: 'Beta').sort_by_phase_name_asc.by_name
-                 elsif params[:phase] == 'in progress'
+                 when 'in progress'
                    @search.result.where.not(register_phase: 'Beta').sort_by_phase_name_asc.by_name
                  else
                    @search.result.sort_by_phase_name_asc.by_name
                  end
-
-    @current_phases = Register::CURRENT_PHASES
   end
 
   def get_last_timestamp

--- a/app/models/register.rb
+++ b/app/models/register.rb
@@ -18,6 +18,10 @@ class Register < ApplicationRecord
     Record.where(register_id: id).exists?
   end
 
+  def available?
+    register_phase == 'Backlog' || records?
+  end
+
 private
 
   def set_slug

--- a/app/models/register.rb
+++ b/app/models/register.rb
@@ -10,17 +10,11 @@ class Register < ApplicationRecord
   scope :by_name, -> { order name: :asc }
   scope :sort_by_phase_name_asc, -> { order("CASE register_phase WHEN 'Beta' THEN 2 WHEN 'Alpha' THEN 3 WHEN 'Discovery' THEN 4 WHEN 'Backlog' THEN 5 END") }
   scope :sort_by_phase_name_desc, -> { order("CASE register_phase WHEN 'Backlog' THEN 1 WHEN 'Discovery' THEN 2 WHEN 'Alpha' THEN 3 WHEN 'Beta' THEN 4 END") }
+  scope :has_records, -> { where(id: Record.select(:register_id)) }
+  scope :available, -> { has_records.or(Register.where(register_phase: 'Backlog')) }
 
   has_many :entries, dependent: :destroy
   has_many :records, dependent: :destroy
-
-  def records?
-    Record.where(register_id: id).exists?
-  end
-
-  def available?
-    register_phase == 'Backlog' || records?
-  end
 
 private
 

--- a/app/views/registers/index.html.haml
+++ b/app/views/registers/index.html.haml
@@ -48,7 +48,7 @@
   - else
     .grid-row
       .column-full
-        %h1 Registers pipeline
+        %h1.heading-xlarge Registers pipeline
     .grid-row
       .column-one-quarter
         .data
@@ -87,7 +87,7 @@
                 = sort_link(@search, :register_authority, "Managed by", default_order: :asc, hide_indicator: true)
               %th{role: "columnheader", scope: "col"}
           %tbody
-            - @registers.select(&:available?).each_with_index do |register, index|
+            - @registers.each_with_index do |register, index|
               - index = index + 1
               = render partial: 'registers/register', object: register, locals: { index: index }
       - else

--- a/app/views/registers/index.html.haml
+++ b/app/views/registers/index.html.haml
@@ -87,7 +87,7 @@
                 = sort_link(@search, :register_authority, "Managed by", default_order: :asc, hide_indicator: true)
               %th{role: "columnheader", scope: "col"}
           %tbody
-            - @registers.each_with_index do |register, index|
+            - @registers.select(&:available?).each_with_index do |register, index|
               - index = index + 1
               = render partial: 'registers/register', object: register, locals: { index: index }
       - else


### PR DESCRIPTION
### Context
Previously the pipeline page would 500 on `get_register_definition` if any of the non-backlog registers were not populated in the database

### Changes proposed in this pull request
Pipeline page should only show registers where data is populated PLUS registers in backlog

### Guidance to review
Pipeline page should still load (e.g. if Charity has not been populated)
