### PR TITLE
fix deploy script array syntax

### DIFF
--- a/bin/deploy
+++ b/bin/deploy
@@ -11,14 +11,13 @@ cf login -a $CF_API -u $CF_USERNAME -p $CF_PASSWORD -o $CF_ORG -s $CF_SPACE
 for APP_NAME in $ZERO_DOWNTIME_APPS
 do
   echo "Deploying ${APP_NAME} to ${CF_ORG}/${CF_SPACE}..."
-
   # Zero downtime push comes from "Autopilot" which is installed in before_deploy
   # step in Travis
   cf zero-downtime-push $APP_NAME -f manifest.yml
   cf set-env $APP_NAME GIT_COMMIT_HASH $TRAVIS_COMMIT 
 done
 
-for APP_NAME in $SINGLE_INSTANCE_APPS
+for APP_NAME in ${SINGLE_INSTANCE_APPS[@]}
 do
   echo "Deploying ${APP_NAME} to ${CF_ORG}/${CF_SPACE}..."
   # We do not want multiple instances of these apps running so use CF PUSH


### PR DESCRIPTION
### Context
Following changes in #134 `registers-frontend-scheduler` stopped deploying due to a syntax error in the deploy script

### Changes proposed in this pull request
Fix array syntax in deploy script


### Guidance to review
In Travis you should see `registers-frontend`,`registers-frontend-scheduler` and `registers-frontend-queue` being deployed.
