### PR TITLE
Upgrade register-ruby-client to 0.9.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,7 @@ gem 'govuk_template'
 gem 'govuk_elements_rails'
 gem 'govspeak', '~> 3.4.0'
 gem 'govuk_elements_form_builder', git: 'https://github.com/ministryofjustice/govuk_elements_form_builder.git'
-gem 'registers-ruby-client', git: 'https://github.com/openregister/registers-ruby-client.git', tag: 'v0.8.0'
+gem 'registers-ruby-client', git: 'https://github.com/openregister/registers-ruby-client.git', tag: 'v0.9.0'
 
 # Spina CMS
 gem 'spina', github: 'denkGroot/Spina', branch: 'master'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -43,10 +43,10 @@ GIT
 
 GIT
   remote: https://github.com/openregister/registers-ruby-client.git
-  revision: 2b6cc5e759d8c4002fa626392869cdf25e2c8e5d
-  tag: v0.8.0
+  revision: 2674bb6292d9d6b582c92ac62722bfed8e7a6982
+  tag: v0.9.0
   specs:
-    registers-ruby-client (0.8.0)
+    registers-ruby-client (0.9.0)
       mini_cache (~> 1.1.0)
       rest-client (~> 2)
 


### PR DESCRIPTION
### Context
The discovery environment has moved location. The frontend uses data from the discovery registers.

### Changes proposed in this pull request
This increment means that the frontend will be using the discovery
environment from the new location *.cloudapps.digital.

### Guidance to review
Check everything still works.