### PR TITLE
Upgrade registers-ruby-client to 0.9.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ gem 'govuk_elements_form_builder', git: 'https://github.com/ministryofjustice/go
 gem 'govuk_elements_rails'
 gem 'govuk_frontend_toolkit'
 gem 'govuk_template'
-gem 'registers-ruby-client', git: 'https://github.com/openregister/registers-ruby-client.git', tag: 'v0.8.1'
+gem 'registers-ruby-client', git: 'https://github.com/openregister/registers-ruby-client.git', tag: 'v0.9.0'
 
 # Spina CMS
 gem 'spina', github: 'denkGroot/Spina', branch: 'master'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -53,10 +53,10 @@ GIT
 
 GIT
   remote: https://github.com/openregister/registers-ruby-client.git
-  revision: 96266d52bdd8a19458936a2d3039973e31014e9b
-  tag: v0.8.1
+  revision: 2674bb6292d9d6b582c92ac62722bfed8e7a6982
+  tag: v0.9.0
   specs:
-    registers-ruby-client (0.8.1)
+    registers-ruby-client (0.9.0)
       mini_cache (~> 1.1.0)
       rest-client (~> 2)
 

--- a/spec/controllers/registers_controller_spec.rb
+++ b/spec/controllers/registers_controller_spec.rb
@@ -22,20 +22,20 @@ RSpec.describe RegistersController, type: :controller do
     ObjectsFactory.new.create_register('territory', 'Beta', 'Ministry of Justice')
 
     # RSF stubs
-    stub_request(:get, 'https://country.beta.openregister.org/download-rsf/0')
+    stub_request(:get, 'https://country.register.gov.uk/download-rsf/0')
     .with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip, deflate' })
     .to_return(status: 200, body: country_data, headers: {})
 
-    stub_request(:get, 'https://charity.beta.openregister.org/download-rsf/0')
+    stub_request(:get, 'https://charity.register.gov.uk/download-rsf/0')
       .with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip, deflate' })
       .to_return(status: 200, body: register_charity_data, headers: {})
 
-    stub_request(:get, 'https://territory.beta.openregister.org/download-rsf/0')
+    stub_request(:get, 'https://territory.register.gov.uk/download-rsf/0')
       .with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip, deflate' })
       .to_return(status: 200, body: register_territory_data, headers: {})
 
   # Index stubs
-    stub_request(:get, 'https://register.beta.openregister.org/download-rsf/0')
+    stub_request(:get, 'https://register.register.gov.uk/download-rsf/0')
       .with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip, deflate' })
       .to_return(status: 200, body: register_beta_data, headers: {})
 
@@ -43,32 +43,32 @@ RSpec.describe RegistersController, type: :controller do
       .with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip, deflate' })
       .to_return(status: 200, body: register_alpha_data, headers: {})
 
-    stub_request(:get, 'https://register.discovery.openregister.org/download-rsf/0')
+    stub_request(:get, 'https://register.cloudapps.digital/download-rsf/0')
       .with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip, deflate' })
       .to_return(status: 200, body: register_discovery_data, headers: {})
 
-    stub_request(:get, "https://country.beta.openregister.org/download-rsf/207").
-      with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip, deflate', 'Host' => 'country.beta.openregister.org' }).
+    stub_request(:get, "https://country.register.gov.uk/download-rsf/207").
+      with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip, deflate', 'Host' => 'country.register.gov.uk' }).
       to_return(status: 200, body: country207, headers: {})
 
-    stub_request(:get, "https://charity.beta.openregister.org/download-rsf/10").
-      with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip, deflate', 'Host' => 'charity.beta.openregister.org' }).
+    stub_request(:get, "https://charity.register.gov.uk/download-rsf/10").
+      with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip, deflate', 'Host' => 'charity.register.gov.uk' }).
       to_return(status: 200, body: charity10, headers: {})
 
-    stub_request(:get, "https://territory.beta.openregister.org/download-rsf/80").
-      with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip, deflate', 'Host' => 'territory.beta.openregister.org' }).
+    stub_request(:get, "https://territory.register.gov.uk/download-rsf/80").
+      with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip, deflate', 'Host' => 'territory.register.gov.uk' }).
       to_return(status: 200, body: territory80, headers: {})
 
-    stub_request(:get, "https://country.beta.openregister.org/proof/register/merkle:sha-256").
-      with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip, deflate', 'Host' => 'country.beta.openregister.org' }).
+    stub_request(:get, "https://country.register.gov.uk/proof/register/merkle:sha-256").
+      with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip, deflate', 'Host' => 'country.register.gov.uk' }).
       to_return(status: 200, body: country_proof, headers: {})
 
-    stub_request(:get, "https://charity.beta.openregister.org/proof/register/merkle:sha-256").
-      with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip, deflate', 'Host' => 'charity.beta.openregister.org' }).
+    stub_request(:get, "https://charity.register.gov.uk/proof/register/merkle:sha-256").
+      with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip, deflate', 'Host' => 'charity.register.gov.uk' }).
       to_return(status: 200, body: charity_proof, headers: {})
 
-    stub_request(:get, "https://territory.beta.openregister.org/proof/register/merkle:sha-256").
-      with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip, deflate', 'Host' => 'territory.beta.openregister.org' }).
+    stub_request(:get, "https://territory.register.gov.uk/proof/register/merkle:sha-256").
+      with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip, deflate', 'Host' => 'territory.register.gov.uk' }).
       to_return(status: 200, body: territory_proof, headers: {})
 
     Register.find_each do |register|

--- a/spec/jobs/populate_register_data_in_db_job_spec.rb
+++ b/spec/jobs/populate_register_data_in_db_job_spec.rb
@@ -16,19 +16,19 @@ end
 RSpec.describe PopulateRegisterDataInDbJob, type: :job do
   before(:all) do
     country_data = File.read('./spec/support/country.rsf')
-    stub_request(:get, "https://country.beta.openregister.org/download-rsf/0").
-    with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip, deflate', 'Host' => 'country.beta.openregister.org' }).
+    stub_request(:get, "https://country.register.gov.uk/download-rsf/0").
+    with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip, deflate', 'Host' => 'country.register.gov.uk' }).
     to_return(status: 200, body: country_data, headers: {})
 
     country_update = File.read('./spec/support/country_update.rsf')
-    stub_request(:get, "https://country.beta.openregister.org/download-rsf/207").
-    with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip, deflate', 'Host' => 'country.beta.openregister.org' }).
+    stub_request(:get, "https://country.register.gov.uk/download-rsf/207").
+    with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip, deflate', 'Host' => 'country.register.gov.uk' }).
     to_return(status: 200, body: country_update, headers: {})
 
     country_proof = File.read('./spec/support/country_proof.json')
     country_proof_update = File.read('./spec/support/country_proof_update.json')
-    stub_request(:get, "https://country.beta.openregister.org/proof/register/merkle:sha-256").
-    with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip, deflate', 'Host' => 'country.beta.openregister.org' }).
+    stub_request(:get, "https://country.register.gov.uk/proof/register/merkle:sha-256").
+    with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip, deflate', 'Host' => 'country.register.gov.uk' }).
     to_return({ body: country_proof }, body: country_proof_update)
 
 


### PR DESCRIPTION
### Context
The discovery environment changed location.

### Changes proposed in this pull request
This makes sure the frontend is using the discovery environment from the correct location *.cloudapps.digital (via the latest version of the client library). Some tests have also been updated to stub the correct URLs. registers-ruby-client-v0.9.0 also ensures we are using *.register.gov.uk for the beta environment instead of *.beta.openregister.org.

### Guidance to review
Make sure everything still works.