### PR TITLE
Only lookup previous entry number from DB where has existing entries

### DIFF
--- a/app/services/postgres_data_store.rb
+++ b/app/services/postgres_data_store.rb
@@ -65,7 +65,7 @@ private
     entry_type = entry.entry_type.to_sym
     existing_latest_entry_for_key =
       if @has_existing_entries_in_db
-        @records[entry_type].key?(entry.key) ? @records[entry_type][entry.key].last : Entry.where(register_id: @register.id, entry_type: entry.entry_type.to_s, key: entry.key.to_s).order(entry_number: :desc).first
+        @records[entry_type].key?(entry.key) ? @records[entry_type][entry.key].last : Record.find_by(register_id: @register.id, entry_type: entry.entry_type.to_s, key: entry.key.to_s)
       else
         @records[entry_type].key?(entry.key) ? @records[entry_type][entry.key].last : nil
       end

--- a/app/services/postgres_data_store.rb
+++ b/app/services/postgres_data_store.rb
@@ -9,6 +9,7 @@ class PostgresDataStore
     @entries = { user: [], system: [] }
     @records = { user: {}, system: {} }
     @register = register
+    @has_existing_entries_in_db = Entry.where(register_id: @register.id).exists?
   end
 
   def add_item(item)
@@ -55,16 +56,22 @@ class PostgresDataStore
     batch_update(:user)
     batch_update(:system)
     @items.clear
+    @has_existing_entries_in_db = Entry.where(register_id: @register.id).exists?
   end
 
 private
 
   def get_previous_entry_number(entry)
     entry_type = entry.entry_type.to_sym
-    existing_latest_entry_for_key = @records[entry_type].key?(entry.key) ? @records[entry_type][entry.key].last : Record.where(register_id: @register.id, entry_type: entry.entry_type, key: entry.key).first
+    existing_latest_entry_for_key =
+      if @has_existing_entries_in_db
+        @records[entry_type].key?(entry.key) ? @records[entry_type][entry.key].last : Entry.where(register_id: @register.id, entry_type: entry.entry_type.to_s, key: entry.key.to_s).order(entry_number: :desc).first
+      else
+        @records[entry_type].key?(entry.key) ? @records[entry_type][entry.key].last : nil
+      end
 
     previous_entry_number =
-      if existing_latest_entry_for_key != nil
+      unless existing_latest_entry_for_key.nil?
         existing_latest_entry_for_key[:entry_number]
       end
 


### PR DESCRIPTION
### Context
Previously we were looking up the previous entry number in the DB, even if it was the first population and thus no entries existed in the DB. 

### Changes proposed in this pull request
Add an additional check on existence of entries before checking DB for each new entry.

### Guidance to review
Both initial population and subsequent updates should correctly populate previous entry number.