### PR TITLE
Fix in progress phase banner

### DIFF
--- a/app/assets/stylesheets/modules/_phase-banner.scss
+++ b/app/assets/stylesheets/modules/_phase-banner.scss
@@ -15,5 +15,6 @@
 
   @include screen {
     background: $govuk-blue;
+    color: $white;
   }
 }

--- a/app/views/registers/show.html.haml
+++ b/app/views/registers/show.html.haml
@@ -19,7 +19,7 @@
     .grid-row
       .column-two-thirds
         .panel.panel-border-wide
-          %span.phase-badge In progress
+          %span.phase-banner In progress
           %p This data is in progress and it’s not ready for use. #{link_to 'Contact the team', 'https://registers.cloudapps.digital/support', target: :blank} to give us feedback.
 
   .grid-row


### PR DESCRIPTION
### Context
We have an in progress phase banner but the label is missing the stylin

### Changes proposed in this pull request
Fix styling

### Guidance to review
Visit `registers#show` for a register not in `beta`

# Before
<img width="1392" alt="screen shot 2018-02-07 at 14 57 03" src="https://user-images.githubusercontent.com/3071606/35923144-510ebdb2-0c17-11e8-9899-0731d3fe7ee7.png">

# After
<img width="1392" alt="screen shot 2018-02-07 at 14 56 49" src="https://user-images.githubusercontent.com/3071606/35923145-51260a26-0c17-11e8-8828-250f7a2c0ce9.png">
