### PR TITLE
 catch InvalidRegisterError thrown by client library and delete records and entries

### DIFF
--- a/app/jobs/populate_register_data_in_db_job.rb
+++ b/app/jobs/populate_register_data_in_db_job.rb
@@ -13,8 +13,10 @@ class PopulateRegisterDataInDbJob < ApplicationJob
       register_client.refresh_data
     rescue InvalidRegisterError
       # If register data is invalid we want to delete existing entries and records to force a full reload
-      Record.where(register_id: register.id).destroy_all
-      Entry.where(register_id: register.id).destroy_all
+      ActiveRecord::Base.transaction do
+        Record.where(register_id: register.id).destroy_all
+        Entry.where(register_id: register.id).destroy_all
+      end
       raise Exceptions::FrontendInvalidRegisterError
     end
 

--- a/app/jobs/populate_register_data_in_db_job.rb
+++ b/app/jobs/populate_register_data_in_db_job.rb
@@ -11,13 +11,13 @@ class PopulateRegisterDataInDbJob < ApplicationJob
     # Initialize client and download / update data
       register_client = @@registers_client.get_register(register.name.parameterize, register.register_phase.downcase, PostgresDataStore.new(register))
       register_client.refresh_data
-    rescue InvalidRegisterError
+    rescue InvalidRegisterError => e
       # If register data is invalid we want to delete existing entries and records to force a full reload
       ActiveRecord::Base.transaction do
         Record.where(register_id: register.id).destroy_all
         Entry.where(register_id: register.id).destroy_all
       end
-      raise Exceptions::FrontendInvalidRegisterError
+      raise Exceptions::FrontendInvalidRegisterError, e
     end
 
     metadata_records = Record.where(register_id: register.id, entry_type: :system)

--- a/app/jobs/populate_register_data_in_db_job.rb
+++ b/app/jobs/populate_register_data_in_db_job.rb
@@ -1,35 +1,22 @@
 class PopulateRegisterDataInDbJob < ApplicationJob
   queue_as :default
 
-
   module Exceptions
     class FrontendInvalidRegisterError < StandardError; end
   end
 
-  module RegisterClientExtensions
-    include Exceptions
-    def refresh_data
-      begin
-        super
-      rescue InvalidRegisterError
-        # If register data is invalid we want to delete existing entries and records to force a full reload
-        register_id = @data_store.instance_variable_get(:@register).id
-        Record.where(register_id: register_id).destroy_all
-        Entry.where(register_id: register_id).destroy_all
-        raise Exceptions::FrontendInvalidRegisterError
-      end
-    end
-  end
-
-  RegistersClient::RegisterClient.module_eval do
-    prepend RegisterClientExtensions
-  end
-
   def perform(register)
     Delayed::Worker.logger.info("Updating #{register.name} in database")
+    begin
     # Initialize client and download / update data
-    register_client = @@registers_client.get_register(register.name.parameterize, register.register_phase.downcase, PostgresDataStore.new(register))
-    register_client.refresh_data
+      register_client = @@registers_client.get_register(register.name.parameterize, register.register_phase.downcase, PostgresDataStore.new(register))
+      register_client.refresh_data
+    rescue InvalidRegisterError
+      # If register data is invalid we want to delete existing entries and records to force a full reload
+      Record.where(register_id: register.id).destroy_all
+      Entry.where(register_id: register.id).destroy_all
+      raise Exceptions::FrontendInvalidRegisterError
+    end
 
     metadata_records = Record.where(register_id: register.id, entry_type: :system)
     fields = metadata_records.select { |record| record.key.start_with?("field:") }

--- a/app/jobs/populate_register_data_in_db_job.rb
+++ b/app/jobs/populate_register_data_in_db_job.rb
@@ -1,7 +1,21 @@
 class PopulateRegisterDataInDbJob < ApplicationJob
   queue_as :default
 
+  module RegisterClientExtensions
+    def refresh_data
+      begin
+      super
+    rescue InvalidRegisterError
+      puts("IN RESCUE")
+    end
+    end
+  end
+
   def perform(register)
+    RegistersClient::RegisterClient.module_eval do
+      prepend RegisterClientExtensions
+    end
+
     Delayed::Worker.logger.info("Updating #{register.name} in database")
     # Initialize client and download / update data
     register_client = @@registers_client.get_register(register.name.parameterize, register.register_phase.downcase, PostgresDataStore.new(register))

--- a/app/jobs/populate_register_data_in_db_job.rb
+++ b/app/jobs/populate_register_data_in_db_job.rb
@@ -6,7 +6,11 @@ class PopulateRegisterDataInDbJob < ApplicationJob
       begin
       super
     rescue InvalidRegisterError
-      puts("IN RESCUE")
+      slug = @register_url.host.split('.')[0]
+      register = Register.find_by(slug: slug)
+      Record.where(register_id: register.id).destroy_all
+      Entry.where(register_id: register.id).destroy_all
+      raise StandardError.new('FrontendInvalidRegisterException')
     end
     end
   end

--- a/lib/tasks/populate_register_data_in_db.rake
+++ b/lib/tasks/populate_register_data_in_db.rake
@@ -13,7 +13,12 @@ namespace :registers_frontend do
     task fetch_now: :environment do
       Register.find_each do |register|
         begin
+          retries ||= 0
           PopulateRegisterDataInDbJob.perform_now(register)
+        rescue PopulateRegisterDataInDbJob::Exceptions::FrontendInvalidRegisterError => e
+          retry if (retries += 1) < 2
+          puts "[Error] #{e.message}"
+          next
         rescue StandardError => e
           puts "[Error] #{e.message}"
           next

--- a/lib/tasks/populate_register_data_in_db.rake
+++ b/lib/tasks/populate_register_data_in_db.rake
@@ -14,6 +14,7 @@ namespace :registers_frontend do
       Register.find_each do |register|
         begin
           retries ||= 0
+          puts("populating register #{register.name}")
           PopulateRegisterDataInDbJob.perform_now(register)
         rescue PopulateRegisterDataInDbJob::Exceptions::FrontendInvalidRegisterError => e
           retry if (retries += 1) < 2

--- a/spec/jobs/handle_invalid_register_spec.rb
+++ b/spec/jobs/handle_invalid_register_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe PopulateRegisterDataInDbJob, type: :job do
 
     it 'throws exception when register invalid and deletes records and entries' do
       country = ObjectsFactory.new.create_register('country', 'beta', 'Ministry of Justice')
-      expect { PopulateRegisterDataInDbJob.perform_now(country) }.to raise_error(PopulateRegisterDataInDbJob::Exceptions::FrontendInvalidRegisterError)
+      expect { PopulateRegisterDataInDbJob.perform_now(country) }.to raise_error(PopulateRegisterDataInDbJob::Exceptions::FrontendInvalidRegisterError, 'Register has been reloaded with different data - root hashes do not match')
       expect(Record.where(register_id: country.id).count).to equal(0)
       expect(Entry.where(register_id: country.id).count).to equal(0)
     end

--- a/spec/jobs/handle_invalid_register_spec.rb
+++ b/spec/jobs/handle_invalid_register_spec.rb
@@ -20,21 +20,15 @@ RSpec.describe PopulateRegisterDataInDbJob, type: :job do
       to_return({ body: country_proof }, body: country_proof_update)
 
       @@registers_client = RegistersClient::RegisterClientManager.new(cache_duration: 600) # rubocop:disable Style/ClassVars
-      @country = ObjectsFactory.new.create_register('country', 'beta', 'Ministry of Justice')
     end
 
-
-
-    it 'throws exception when register invalid' do
-      expect { PopulateRegisterDataInDbJob.perform_now(@country) }.to raise_error(PopulateRegisterDataInDbJob::Exceptions::FrontendInvalidRegisterError)
-    end
-
-    it 'deletes records and entries when register invalid' do
-      expect(Record.where(register_id: @country.id).count).to equal(0)
-      expect(Entry.where(register_id: @country.id).count).to equal(0)
+    it 'throws exception when register invalid and deletes records and entries' do
+      country = ObjectsFactory.new.create_register('country', 'beta', 'Ministry of Justice')
+      expect { PopulateRegisterDataInDbJob.perform_now(country) }.to raise_error(PopulateRegisterDataInDbJob::Exceptions::FrontendInvalidRegisterError)
+      expect(Record.where(register_id: country.id).count).to equal(0)
+      expect(Entry.where(register_id: country.id).count).to equal(0)
     end
   end
-
 
   after(:all) do
     DatabaseCleaner.clean_with(:truncation)

--- a/spec/jobs/handle_invalid_register_spec.rb
+++ b/spec/jobs/handle_invalid_register_spec.rb
@@ -1,12 +1,5 @@
 require 'rails_helper'
 
-RSpec.configure do |config|
-  config.before(:suite) do
-    DatabaseCleaner.strategy = :transaction
-    DatabaseCleaner.clean_with(:truncation)
-  end
-end
-
 RSpec.describe PopulateRegisterDataInDbJob, type: :job do
   describe 'handle invalid register exception' do
     before(:all) do

--- a/spec/jobs/handle_invalid_register_spec.rb
+++ b/spec/jobs/handle_invalid_register_spec.rb
@@ -1,0 +1,50 @@
+require 'rails_helper'
+
+RSpec.configure do |config|
+  config.before(:suite) do
+    DatabaseCleaner.strategy = :transaction
+    DatabaseCleaner.clean_with(:truncation)
+  end
+
+  # config.around(:each) do |example|
+  #   DatabaseCleaner.cleaning do
+  #     example.run
+  #   end
+  # end
+end
+
+RSpec.describe PopulateRegisterDataInDbJob, type: :job do
+  describe 'handle invalid register exception' do
+    before(:all) do
+      country_data = File.read('./spec/support/country.rsf')
+      stub_request(:get, "https://country.register.gov.uk/download-rsf/0").
+      with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip, deflate', 'Host' => 'country.register.gov.uk' }).
+      to_return(status: 200, body: country_data, headers: {})
+
+      country_invalid_hash = File.read('./spec/support/country_invalid_hash.rsf')
+      stub_request(:get, "https://country.register.gov.uk/download-rsf/207").
+      with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip, deflate', 'Host' => 'country.register.gov.uk' }).
+      to_return(status: 200, body: country_invalid_hash, headers: {})
+
+      country_proof = File.read('./spec/support/country_proof.json')
+      country_proof_update = File.read('./spec/support/country_proof_update.json')
+      stub_request(:get, "https://country.register.gov.uk/proof/register/merkle:sha-256").
+      with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip, deflate', 'Host' => 'country.register.gov.uk' }).
+      to_return({ body: country_proof }, body: country_proof_update)
+
+      @@registers_client = RegistersClient::RegisterClientManager.new(cache_duration: 600) # rubocop:disable Style/ClassVars
+    end
+
+
+
+    it 'deletes entries and records when register invalid' do
+      country = ObjectsFactory.new.create_register('country', 'beta', 'Ministry of Justice')
+      PopulateRegisterDataInDbJob.perform_now(country)
+    end
+  end
+
+
+  after(:all) do
+    DatabaseCleaner.clean_with(:truncation)
+  end
+end

--- a/spec/jobs/handle_invalid_register_spec.rb
+++ b/spec/jobs/handle_invalid_register_spec.rb
@@ -27,13 +27,18 @@ RSpec.describe PopulateRegisterDataInDbJob, type: :job do
       to_return({ body: country_proof }, body: country_proof_update)
 
       @@registers_client = RegistersClient::RegisterClientManager.new(cache_duration: 600) # rubocop:disable Style/ClassVars
+      @country = ObjectsFactory.new.create_register('country', 'beta', 'Ministry of Justice')
     end
 
 
 
-    it 'deletes entries and records when register invalid' do
-      country = ObjectsFactory.new.create_register('country', 'beta', 'Ministry of Justice')
-      PopulateRegisterDataInDbJob.perform_now(country)
+    it 'throws exception when register invalid' do
+      expect { PopulateRegisterDataInDbJob.perform_now(@country) }.to raise_error(PopulateRegisterDataInDbJob::Exceptions::FrontendInvalidRegisterError)
+    end
+
+    it 'deletes records and entries when register invalid' do
+      expect(Record.where(register_id: @country.id).count).to equal(0)
+      expect(Entry.where(register_id: @country.id).count).to equal(0)
     end
   end
 

--- a/spec/jobs/handle_invalid_register_spec.rb
+++ b/spec/jobs/handle_invalid_register_spec.rb
@@ -5,12 +5,6 @@ RSpec.configure do |config|
     DatabaseCleaner.strategy = :transaction
     DatabaseCleaner.clean_with(:truncation)
   end
-
-  # config.around(:each) do |example|
-  #   DatabaseCleaner.cleaning do
-  #     example.run
-  #   end
-  # end
 end
 
 RSpec.describe PopulateRegisterDataInDbJob, type: :job do

--- a/spec/jobs/populate_register_data_in_db_job_spec.rb
+++ b/spec/jobs/populate_register_data_in_db_job_spec.rb
@@ -1,11 +1,6 @@
 require 'rails_helper'
 
 RSpec.configure do |config|
-  config.before(:suite) do
-    DatabaseCleaner.strategy = :transaction
-    DatabaseCleaner.clean_with(:truncation)
-  end
-
   config.around(:each) do |example|
     DatabaseCleaner.cleaning do
       example.run

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,6 +19,11 @@ WebMock.disable_net_connect!(allow_localhost: true)
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|
+  config.before(:suite) do
+    DatabaseCleaner.strategy = :transaction
+    DatabaseCleaner.clean_with(:truncation)
+  end
+
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest
   # assertions if you prefer.

--- a/spec/support/country_invalid_hash.rsf
+++ b/spec/support/country_invalid_hash.rsf
@@ -1,0 +1,1 @@
+assert-root-hash	sha-256:725bf37d0ee609f7a9cb3e42af574443df9215c85772a1626eaa93cdd505e71fß


### PR DESCRIPTION
### Context
The ruby client library, as of v0.8.0, has the ability to detect when the data held in memory (whether in memory, postgres etc) conflicts with the data that is held by the register. Specifically, when a register has been reloaded or when the downloaded RSF file does not yield the correct root hash that the register holds, it will raise an `InvalidRegisterError`. Currently the frontend does not have any special handling for this exception which means that registers in this state will never be updated in the frontend (for example when alpha registers are reloaded)

### Changes proposed in this pull request
catch `InvalidRegisterError` exception from client library, delete records and entries and throw a new exception. We then rely on the queue retry system to re-populate the register from scratch.

### Guidance to review
When a register is has invalid data its records and entries should be deleted from the frontend db. On a subsequent run, the data should be re-populated.
