### PR TITLE
Clean up pipeline

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -19,6 +19,7 @@
 @import 'modules/search';
 @import 'modules/footer-categories';
 @import 'modules/sorting-link';
+@import 'modules/tables';
 
 // From alphagov/static
 @import 'govuk_component/organisation-logo';
@@ -143,11 +144,17 @@ table {
   margin: 0 0 20px 0;
 }
 
-.register-status-table {
-  margin-top: 40px;
+.register_search {
+  @include media(mobile) {
+    margin-bottom: 40px;
+  }
+}
 
-  td:last-of-type {
-    @include media(tablet) {
+.register-status-table {
+  @include media(tablet) {
+    margin-top: 40px;
+
+    td:last-of-type {
       text-align: right;
     }
   }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -144,7 +144,7 @@ table {
   margin: 0 0 20px 0;
 }
 
-.register_search {
+.records-search {
   @include media(mobile) {
     margin-bottom: 40px;
   }

--- a/app/assets/stylesheets/modules/_tables.scss
+++ b/app/assets/stylesheets/modules/_tables.scss
@@ -1,0 +1,206 @@
+// Responsive tables from https://github.com/alphagov/spotlight/blob/master/styles/common/table.scss
+
+table {
+  &.touch-table {
+    margin-left: 1em;
+    margin-right: 1em;
+    width: calc(100% - 2em);
+  }
+
+  @include media(desktop) {
+    &.floated-header {
+      thead {
+        display: block;
+      }
+
+      tbody {
+        display: block;
+        max-height: 28em;
+        overflow-y: auto;
+
+        &::-webkit-scrollbar {
+          -webkit-appearance: none;
+        }
+
+        &::-webkit-scrollbar:vertical {
+          width: 11px;
+        }
+
+        &::-webkit-scrollbar:horizontal {
+          height: 11px;
+        }
+
+        &::-webkit-scrollbar-thumb {
+          border-radius: 8px;
+          border: 2px solid white; /* should match background, can't be transparent */
+          background-color: rgba(0, 0, 0, .5);
+        }
+
+        &::-webkit-scrollbar-track {
+          background-color: #fff;
+          border-radius: 8px;
+        }
+      }
+    }
+  }
+
+  th {
+    width: 25%;
+
+    a {
+      position: relative;
+      text-decoration: none;
+
+      &:hover {
+        text-decoration: underline;
+      }
+    }
+
+    &.descending a:after,
+    &.ascending a:after {
+      content: "\00a0\00a0\25BC";
+      font-size: 8px;
+      position: absolute;
+      top: 0.7em;
+    }
+
+    &.ascending a:after {
+      content: "\00a0\00a0\25B2";
+    }
+
+  }
+
+  .currency, .percent, .integer, .number {
+    text-align: right;
+  }
+
+}
+
+// Tables
+// ==========================================================================
+
+table {
+  border-collapse: collapse;
+  border-spacing: 0;
+  width: 100%;
+}
+
+table th,
+table td {
+  @include core-16;
+  //padding: 0.7em 1em 0.7em 1em;
+  padding: 12px 20px 9px 0; //em(12, 16) em(20, 16) em(9, 16) 0;
+  text-align: left;
+  color: #0b0c0c;
+  border-bottom: 1px solid $border-colour;
+}
+
+table th,
+table thead th:first-child {
+  text-align: left;
+}
+
+table thead th {
+  font-weight: normal;
+  vertical-align: top;
+}
+
+// Right align headings for numeric content
+table th.numeric,
+table th.integer,
+table th.currency,
+table th.percent {
+  text-align: right;
+}
+
+// Use tabular numbers for numeric table cells
+table tbody .integer,
+table tbody .currency,
+table tbody .percent {
+  @include core-16($tabular-numbers: true);
+  text-align: right;
+}
+
+table tbody .url {
+  word-break: break-all;
+}
+
+table thead .sort-column,
+table tbody .sort-column {
+  font-weight: bold;
+}
+
+.table-no-header .sort-column {
+  font-weight: normal;
+}
+
+.table-collapsible {
+  @include media($max-width: 900px) {
+    th, td {
+      padding-right: 10px;
+    }
+  }
+
+  @include media($max-width: 641px) {
+    display: block;
+    width: auto;
+
+    tr {
+      display: block;
+      padding-bottom: 15px;
+      border-bottom: 1px solid $border-colour;
+      margin-bottom: 15px;
+    }
+
+    thead th {
+      display: block;
+      text-align: left;
+      border-bottom: 0;
+      padding: 3px 0;
+      width: 100%;
+
+      &:first-child {
+        width: 100%;
+      }
+    }
+
+    tbody th, tbody td {
+      display: block;
+      text-align: left;
+      border-bottom: 0;
+      padding-top: 5px;
+      padding-bottom: 5px;
+
+      &:before {
+        content: attr(data-title);
+        display: inline-block;
+        font-weight: bold;
+        width: 35%;
+      }
+
+      &:first-child {
+        @include core-19();
+        font-weight: bold;
+        width: 100%;
+
+        .heading-xsmall {
+          display: inline-block;
+        }
+
+        p {
+          font-weight: normal;
+          margin-bottom: 0;
+        }
+
+        &:before {
+          content: none;
+        }
+      }
+    }
+
+    .govuk-organisation-logo {
+      display: inline-block;
+      vertical-align: top;
+    }
+  }
+}

--- a/app/assets/stylesheets/modules/_tables.scss
+++ b/app/assets/stylesheets/modules/_tables.scss
@@ -32,12 +32,12 @@ table {
 
         &::-webkit-scrollbar-thumb {
           border-radius: 8px;
-          border: 2px solid white; /* should match background, can't be transparent */
-          background-color: rgba(0, 0, 0, .5);
+          border: 2px solid $white; // should match background, can't be transparent
+          background-color: rgba($black, 0.5);
         }
 
         &::-webkit-scrollbar-track {
-          background-color: #fff;
+          background-color: $white;
           border-radius: 8px;
         }
       }
@@ -70,7 +70,10 @@ table {
 
   }
 
-  .currency, .percent, .integer, .number {
+  .currency,
+  .percent,
+  .integer,
+  .number {
     text-align: right;
   }
 
@@ -91,7 +94,7 @@ table td {
   //padding: 0.7em 1em 0.7em 1em;
   padding: 12px 20px 9px 0; //em(12, 16) em(20, 16) em(9, 16) 0;
   text-align: left;
-  color: #0b0c0c;
+  color: $black;
   border-bottom: 1px solid $border-colour;
 }
 
@@ -106,11 +109,13 @@ table thead th {
 }
 
 // Right align headings for numeric content
-table th.numeric,
-table th.integer,
-table th.currency,
-table th.percent {
-  text-align: right;
+table th {
+  &.numeric,
+  &.integer,
+  &.currency,
+  &.percent {
+    text-align: right;
+  }
 }
 
 // Use tabular numbers for numeric table cells
@@ -136,7 +141,8 @@ table tbody .sort-column {
 
 .table-collapsible {
   @include media($max-width: 900px) {
-    th, td {
+    th,
+    td {
       padding-right: 10px;
     }
   }
@@ -164,7 +170,8 @@ table tbody .sort-column {
       }
     }
 
-    tbody th, tbody td {
+    tbody th,
+    tbody td {
       display: block;
       text-align: left;
       border-bottom: 0;

--- a/app/views/registers/_register.html.haml
+++ b/app/views/registers/_register.html.haml
@@ -1,6 +1,6 @@
 %tr
   %th{"data-title" => index, }
-    %h4.heading-xsmall= register.name
+    %h4.heading-small= register.name
     - if register.register_phase == 'Backlog'
       %p= register.description
     - else


### PR DESCRIPTION
### Context
We want the table to be responsive and the register name to be separate from the description

### Changes proposed in this pull request
Make table responsive and register name standout

### Guidance to review
View `registers#index` on mobile and desktop

# Before
<img width="836" alt="screen shot 2018-02-09 at 17 12 30" src="https://user-images.githubusercontent.com/3071606/36040107-6daa6196-0dbc-11e8-82ef-669175894fd7.png">
<img width="836" alt="screen shot 2018-02-09 at 17 12 24" src="https://user-images.githubusercontent.com/3071606/36040108-6dcffa50-0dbc-11e8-981b-300404a437fa.png">

# After
<img width="836" alt="screen shot 2018-02-09 at 17 09 28" src="https://user-images.githubusercontent.com/3071606/36040088-56028726-0dbc-11e8-8c78-f165816c76c9.png">
<img width="836" alt="screen shot 2018-02-09 at 17 09 46" src="https://user-images.githubusercontent.com/3071606/36040086-55d40c84-0dbc-11e8-9823-e9d419d35db3.png">
<img width="836" alt="screen shot 2018-02-09 at 17 09 37" src="https://user-images.githubusercontent.com/3071606/36040087-55ebc2d4-0dbc-11e8-9871-38f85375552d.png">