### PR TITLE
move client manager class var into wrapper class

### DIFF
--- a/app/controllers/spina/admin/registers_controller.rb
+++ b/app/controllers/spina/admin/registers_controller.rb
@@ -60,7 +60,7 @@ module Spina
       end
 
       def set_government_organisations
-        register_data = @@registers_client.get_register('government-organisation', 'beta')
+        register_data = RegistersClientWrapper.registers_client.get_register('government-organisation', 'beta')
         @government_organisations = register_data.get_records
       end
 

--- a/app/jobs/populate_register_data_in_db_job.rb
+++ b/app/jobs/populate_register_data_in_db_job.rb
@@ -9,10 +9,10 @@ class PopulateRegisterDataInDbJob < ApplicationJob
     Delayed::Worker.logger.info("Updating #{register.name} in database")
     begin
     # Initialize client and download / update data
-      register_client = @@registers_client.get_register(register.name.parameterize, register.register_phase.downcase, PostgresDataStore.new(register))
+      register_client = RegistersClientWrapper.registers_client.get_register(register.name.parameterize, register.register_phase.downcase, PostgresDataStore.new(register))
       register_client.refresh_data
     rescue InvalidRegisterError => e
-      # If register data is invalid we want to delete existing entries and records to force a full reload
+    # If register data is invalid we want to delete existing entries and records to force a full reload
       ActiveRecord::Base.transaction do
         Record.where(register_id: register.id).destroy_all
         Entry.where(register_id: register.id).destroy_all

--- a/config/initializers/registers_client.rb
+++ b/config/initializers/registers_client.rb
@@ -1,1 +1,8 @@
-@@registers_client ||= RegistersClient::RegisterClientManager.new(cache_duration: 600) # rubocop:disable Style/ClassVars
+class RegistersClientWrapper
+  @@registers_client ||= RegistersClient::RegisterClientManager.new(cache_duration: 600) # rubocop:disable Style/ClassVars
+  def self.registers_client
+    @@registers_client
+  end
+end
+
+RegistersClientWrapper.registers_client

--- a/spec/jobs/populate_register_data_in_db_job_spec.rb
+++ b/spec/jobs/populate_register_data_in_db_job_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe PopulateRegisterDataInDbJob, type: :job do
     with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip, deflate', 'Host' => 'country.register.gov.uk' }).
     to_return({ body: country_proof }, body: country_proof_update)
 
-    @@registers_client = RegistersClient::RegisterClientManager.new(cache_duration: 600) # rubocop:disable Style/ClassVars
+    RegistersClientWrapper.class_variable_set(:@@registers_client, RegistersClient::RegisterClientManager.new(cache_duration: 600))
 
     ObjectsFactory.new.create_register('country', 'beta', 'Ministry of Justice')
     Register.find_each do |register|


### PR DESCRIPTION
### Context
Previously on startup we had the Ruby warning: 
```
config/initializers/registers_client.rb:1: warning: class variable access from toplevel
```

### Changes proposed in this pull request
Wrap the access to the class var in a class to stop this warning, similar to the pattern described in: 
http://ruby-doc.org/core-2.5.0/Module.html#method-i-class_variable_set

### Guidance to review
Warning should no longer show on startup. 
