### PR TITLE
Add user research manifest file for paas

### DIFF
--- a/manifest-research.yml
+++ b/manifest-research.yml
@@ -1,0 +1,24 @@
+---
+defaults: &defaults
+  buildpack: ruby_buildpack
+  memory: 1GB
+  services:
+    # postgres database
+    - registers-frontend-research
+    # environment variables (persisted for blue/green deploys)
+    - registers-product-site-environment-variables
+
+applications:
+- name: registers-frontend-research
+  <<: *defaults
+  instances: 2
+- name: registers-frontend-queue
+  <<: *defaults
+  instances: 1
+  command: bundle exec 'rake environment jobs:work'
+  health-check-type: process
+- name: registers-frontend-scheduler
+  <<: *defaults
+  instances: 1
+  command: bundle exec clockwork 'lib/clock.rb'
+  health-check-type: process


### PR DESCRIPTION
Context
We want to have a user research environment

Changes proposed in this pull request
Add manifest for a research environment on paas

Guidance to review
```
cf target -s target sandbox
cf push registers-frontend-research -f manifest-research.yml
```