### PR TITLE
change gov orgs to db lookup

### DIFF
--- a/app/controllers/spina/admin/registers_controller.rb
+++ b/app/controllers/spina/admin/registers_controller.rb
@@ -60,8 +60,9 @@ module Spina
       end
 
       def set_government_organisations
-        register_data = RegistersClientWrapper.registers_client.get_register('government-organisation', 'beta')
-        @government_organisations = register_data.get_records
+        government_organisation_register = Register.find_by(slug: 'government-organisation')
+        government_organisation_records = Record.where(register_id: government_organisation_register.id, entry_type: 'user')
+        @government_organisations = government_organisation_records.map { |go| go.data['name'] }
       end
 
       def register_params

--- a/app/controllers/spina/admin/registers_controller.rb
+++ b/app/controllers/spina/admin/registers_controller.rb
@@ -61,8 +61,9 @@ module Spina
 
       def set_government_organisations
         @government_organisations = Register.find_by(slug: 'government-organisation')
-                                            .records.select("data -> 'name' as name").where(entry_type: 'user')
-                                            .map(&:name)
+                                            .records
+                                            .where(entry_type: 'user')
+                                            .pluck("data -> 'name' as name")
       end
 
       def register_params

--- a/app/controllers/spina/admin/registers_controller.rb
+++ b/app/controllers/spina/admin/registers_controller.rb
@@ -60,9 +60,9 @@ module Spina
       end
 
       def set_government_organisations
-        government_organisation_register = Register.find_by(slug: 'government-organisation')
-        government_organisation_records = Record.where(register_id: government_organisation_register.id, entry_type: 'user')
-        @government_organisations = government_organisation_records.map { |go| go.data['name'] }
+        @government_organisations = Register.find_by(slug: 'government-organisation')
+                                            .records.select("data -> 'name' as name").where(entry_type: 'user')
+                                            .map(&:name)
       end
 
       def register_params

--- a/app/views/spina/admin/registers/_form.html.haml
+++ b/app/views/spina/admin/registers/_form.html.haml
@@ -48,7 +48,7 @@
         .horizontal-form-label
           Authority
         .horizontal-form-content
-          = f.select :authority, @government_organisations.map{|c| c.item.value['name']}, {data: { "default-value" => @register.authority }}
+          = f.select :authority, @government_organisations, {data: { "default-value" => @register.authority }}
       .horizontal-form-group
         .horizontal-form-label
           = Spina::Page.human_attribute_name :contextual_data


### PR DESCRIPTION
### Context
Previously we used the client library to retrieve the list of gov orgs for the CMS

### Changes proposed in this pull request
Retrieve gov orgs from the DB. This is part of the separation of concerns whereby the population job should be the only thing using the client library.

### Guidance to review
Check Authority select box in CMS `admin/registers/new` is still populated.
