### PR TITLE
Add and enable prometheus metrics endpoint

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ gem 'uglifier', '>= 1.3.0'
 gem 'jquery-rails'
 gem 'jbuilder', '~> 2.5'
 gem 'http', '2.2.1'
+gem 'gds_metrics'
 
 # Nested forms
 gem 'cocoon'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -281,6 +281,8 @@ GEM
       fog-core
       nokogiri (>= 1.5.11, < 2.0.0)
     formatador (0.2.5)
+    gds_metrics (0.0.1)
+      prometheus-client-mmap (= 0.9.1)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
     globalize (5.1.0.beta2)
@@ -400,6 +402,7 @@ GEM
     polyamorous (1.3.1)
       activerecord (>= 3.0)
     powerpack (0.1.1)
+    prometheus-client-mmap (0.9.1)
     pry (0.11.3)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
@@ -534,6 +537,7 @@ DEPENDENCIES
   cf-app-utils
   cocoon
   fog
+  gds_metrics
   govspeak (~> 3.4.0)
   govuk-lint (~> 3.3)
   govuk_elements_form_builder!
@@ -564,4 +568,4 @@ RUBY VERSION
    ruby 2.4.2p198
 
 BUNDLED WITH
-   1.16.0
+   1.16.1


### PR DESCRIPTION
### Context
Add and enable Prometheus metrics endpoint to be able to have consistent information about the application.

### Changes proposed in this pull request
Addition of the instrumentation gem

### Guidance to review
https://github.com/alphagov/gds_metrics_ruby