### PR TITLE
add prometheus env var

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -9,3 +9,5 @@ applications:
     - registers-prod
     # environment variables (persisted for blue/green deploys)
     - registers-product-site-environment-variables
+  env:
+    PROMETHEUS_METRICS_PATH: /metrics


### PR DESCRIPTION
### Context
This is required for GDS Metrics app discovery

### Changes proposed in this pull request
add `PROMETHEUS_METRICS_PATH` environment variable

### Guidance to review
Prerequisite to using GDS Metrics
