### PR TITLE
Add Register 'Links to' links

### DIFF
--- a/app/models/register.rb
+++ b/app/models/register.rb
@@ -36,7 +36,8 @@ class Register < ApplicationRecord
   end
 
   def links_to
-    register_fields.select { |f| f['register'] && f['register'] != slug }
+    linked_register_names = register_fields.select { |f| f['register'] && f['register'] != slug }.map { |f| f['register'] }
+    Register.where(slug: linked_register_names)
   end
 
 

--- a/app/models/register.rb
+++ b/app/models/register.rb
@@ -35,6 +35,11 @@ class Register < ApplicationRecord
           .map { |entry| entry[:data] }
   end
 
+  def links_to
+    register_fields.select { |f| f['register'] && f['register'] != slug }
+  end
+
+
 private
 
   def set_slug

--- a/app/views/registers/show.html.haml
+++ b/app/views/registers/show.html.haml
@@ -44,6 +44,10 @@
             %dt Related registers:
             %dd
               != @register.related_registers
+          - if @register.links_to.present?
+            %dt Links to:
+            %dd
+              != @register.links_to.map {|r| link_to r.name, register_path(r.slug)}.join(', ')
           - if @register.contextual_data.present?
             %dt Contextual data:
             %dd


### PR DESCRIPTION
### Context
Implements the 'Links to' metadata links (as previously implemented in ORJ)

### Changes proposed in this pull request
_Linked to_ registers in this context means fields with a register property (excluding itself)
This is based on the [implementation in ORJ](https://github.com/openregister/openregister-java/blob/9df5498a67568869ab9f5de0ed54d51e466e94b2/src/main/java/uk/gov/register/service/RegisterLinkService.java#L56)
<img width="448" alt="screen shot 2018-02-16 at 13 39 41" src="https://user-images.githubusercontent.com/1764158/36310563-67196dea-1320-11e8-9362-e3f4d4a7bcad.png">


### Guidance to review
Note: in order to test this locally you will have to add in the CMS a linked register (e.g. `school-type-eng`)