### PR TITLE
Implement root hash checking in Postgres Data Store

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ gem 'govuk_elements_form_builder', git: 'https://github.com/ministryofjustice/go
 gem 'govuk_elements_rails'
 gem 'govuk_frontend_toolkit'
 gem 'govuk_template'
-gem 'registers-ruby-client', git: 'https://github.com/openregister/registers-ruby-client.git', tag: 'v0.9.0'
+gem 'registers-ruby-client', git: 'https://github.com/openregister/registers-ruby-client.git', tag: 'v0.9.1'
 
 # Spina CMS
 gem 'spina', github: 'denkGroot/Spina', branch: 'master'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -53,10 +53,10 @@ GIT
 
 GIT
   remote: https://github.com/openregister/registers-ruby-client.git
-  revision: 2674bb6292d9d6b582c92ac62722bfed8e7a6982
-  tag: v0.9.0
+  revision: a89614647441616ab7f530d846ac88dbe0e98407
+  tag: v0.9.1
   specs:
-    registers-ruby-client (0.9.0)
+    registers-ruby-client (0.9.1)
       mini_cache (~> 1.1.0)
       rest-client (~> 2)
 

--- a/app/services/postgres_data_store.rb
+++ b/app/services/postgres_data_store.rb
@@ -10,6 +10,7 @@ class PostgresDataStore
     @records = { user: {}, system: {} }
     @register = register
     @has_existing_entries_in_db = Entry.where(register_id: @register.id).exists?
+    @root_hash = ''
   end
 
   def add_item(item)
@@ -57,6 +58,15 @@ class PostgresDataStore
     batch_update(:system)
     @items.clear
     @has_existing_entries_in_db = Entry.where(register_id: @register.id).exists?
+  end
+
+  def set_root_hash(root_hash)
+    @register.root_hash = root_hash
+  end
+
+  def get_root_hash
+    empty_root_hash = 'sha-256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
+    @register.root_hash ? @register.root_hash : empty_root_hash
   end
 
 private

--- a/app/services/postgres_data_store.rb
+++ b/app/services/postgres_data_store.rb
@@ -2,6 +2,7 @@ require 'data_store'
 
 class PostgresDataStore
   include DataStore
+  EMPTY_ROOT_HASH = 'sha-256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'.freeze
 
   def initialize(register)
     @page_size = 100
@@ -10,7 +11,6 @@ class PostgresDataStore
     @records = { user: {}, system: {} }
     @register = register
     @has_existing_entries_in_db = Entry.where(register_id: @register.id).exists?
-    @root_hash = ''
   end
 
   def add_item(item)
@@ -65,8 +65,7 @@ class PostgresDataStore
   end
 
   def get_root_hash
-    empty_root_hash = 'sha-256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
-    @register.root_hash ? @register.root_hash : empty_root_hash
+    @register.root_hash ? @register.root_hash : EMPTY_ROOT_HASH
   end
 
 private

--- a/db/migrate/20180216143028_add_root_hash_to_register.rb
+++ b/db/migrate/20180216143028_add_root_hash_to_register.rb
@@ -1,0 +1,5 @@
+class AddRootHashToRegister < ActiveRecord::Migration[5.1]
+  def change
+    add_column :registers, :root_hash, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180214142731) do
+ActiveRecord::Schema.define(version: 20180216143028) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -71,6 +71,7 @@ ActiveRecord::Schema.define(version: 20180214142731) do
     t.text "fields"
     t.text "related_registers"
     t.string "url"
+    t.string "root_hash"
   end
 
   create_table "spina_accounts", id: :serial, force: :cascade do |t|

--- a/spec/controllers/entries_controller_spec.rb
+++ b/spec/controllers/entries_controller_spec.rb
@@ -2,6 +2,7 @@
 
 require 'rails_helper'
 
+
 RSpec.describe EntriesController, type: :controller do
   before(:all) do
     country_data = File.read('./spec/support/country.rsf')
@@ -16,6 +17,8 @@ RSpec.describe EntriesController, type: :controller do
     territory80 = File.read('./spec/support/territory_80.rsf')
     charity_proof = File.read('./spec/support/charity_proof.json')
     territory_proof = File.read('./spec/support/territory_proof.json')
+
+    RegistersClientWrapper.class_variable_set(:@@registers_client, RegistersClient::RegisterClientManager.new(cache_duration: 600))
 
     ObjectsFactory.new.create_register('country', 'Beta', 'Ministry of Justice')
     ObjectsFactory.new.create_register('charity', 'Beta', 'Ministry of Justice')
@@ -70,6 +73,7 @@ RSpec.describe EntriesController, type: :controller do
     stub_request(:get, "https://territory.register.gov.uk/proof/register/merkle:sha-256").
       with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip, deflate', 'Host' => 'territory.register.gov.uk' }).
       to_return(status: 200, body: territory_proof, headers: {})
+
 
     Register.find_each do |register|
       PopulateRegisterDataInDbJob.perform_now(register)

--- a/spec/controllers/registers_controller_spec.rb
+++ b/spec/controllers/registers_controller_spec.rb
@@ -17,6 +17,8 @@ RSpec.describe RegistersController, type: :controller do
     charity_proof = File.read('./spec/support/charity_proof.json')
     territory_proof = File.read('./spec/support/territory_proof.json')
 
+    RegistersClientWrapper.class_variable_set(:@@registers_client, RegistersClient::RegisterClientManager.new(cache_duration: 600))
+
     ObjectsFactory.new.create_register('country', 'Beta', 'Ministry of Justice')
     ObjectsFactory.new.create_register('charity', 'Beta', 'Ministry of Justice')
     ObjectsFactory.new.create_register('territory', 'Beta', 'Ministry of Justice')

--- a/spec/jobs/handle_invalid_register_spec.rb
+++ b/spec/jobs/handle_invalid_register_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe PopulateRegisterDataInDbJob, type: :job do
       with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip, deflate', 'Host' => 'country.register.gov.uk' }).
       to_return({ body: country_proof }, body: country_proof_update)
 
-      @@registers_client = RegistersClient::RegisterClientManager.new(cache_duration: 600) # rubocop:disable Style/ClassVars
+      RegistersClientWrapper.class_variable_set(:@@registers_client, RegistersClient::RegisterClientManager.new(cache_duration: 600))
     end
 
     it 'throws exception when register invalid and deletes records and entries' do


### PR DESCRIPTION
### Context
sister PR to https://github.com/openregister/registers-ruby-client/pull/31

### Changes proposed in this pull request
Implement `get_root_hash` and `set_root_hash` in postgres datastore.

### Guidance to review
Note that the first time this is run existing registers will be deleted and reloaded as they do not yet have their current root hash set. After that they should incrementally update successfully.
