### PR TITLE
Update gds_metrics

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem 'uglifier', '>= 1.3.0'
 gem 'jquery-rails'
 gem 'jbuilder', '~> 2.5'
 gem 'http', '2.2.1'
-gem 'gds_metrics'
+gem 'gds_metrics', '~> 0.0.2'
 
 # Nested forms
 gem 'cocoon'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -281,7 +281,7 @@ GEM
       fog-core
       nokogiri (>= 1.5.11, < 2.0.0)
     formatador (0.2.5)
-    gds_metrics (0.0.1)
+    gds_metrics (0.0.2)
       prometheus-client-mmap (= 0.9.1)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
@@ -537,7 +537,7 @@ DEPENDENCIES
   cf-app-utils
   cocoon
   fog
-  gds_metrics
+  gds_metrics (~> 0.0.2)
   govspeak (~> 3.4.0)
   govuk-lint (~> 3.3)
   govuk_elements_form_builder!


### PR DESCRIPTION
### Context

We’ve updated the names of some of the metrics to
be more consistent with the Prometheus naming
conventions. Updating this gem will mean we can
get the dashboards setup more quickly.

### Changes proposed in this pull request

Updates gds_metrics from version 0.0.1 to 0.0.2

### Guidance to review

You're welcome to review [recent commits to the gem](https://github.com/alphagov/gds_metrics_ruby/commits/master).