### PR TITLE
refactor get description for more safety

### DIFF
--- a/app/models/register.rb
+++ b/app/models/register.rb
@@ -25,7 +25,9 @@ class Register < ApplicationRecord
   end
 
   def register_description
-    Record.find_by(register_id: id, key: "register:#{name.parameterize}").data['text']
+    Record.where(register_id: id, key: "register:#{name.parameterize}")
+    .pluck("data -> 'text' as text")
+    .first
   end
 
   def register_fields


### PR DESCRIPTION
### Context
Previously `get_description` could throw an exception as it was querying inside a potentially `nil` object.

### Changes proposed in this pull request
Refactor the query such that it will return `nil` rather than throw an exception if the description text is not found.

### Guidance to review
Description should still render on pipeline and register page.