### PR TITLE
use delete_all rather than destroy_all in full re-index

### DIFF
--- a/app/jobs/populate_register_data_in_db_job.rb
+++ b/app/jobs/populate_register_data_in_db_job.rb
@@ -15,8 +15,8 @@ class PopulateRegisterDataInDbJob < ApplicationJob
     rescue InvalidRegisterError => e
     # If register data is invalid we want to delete existing entries and records to force a full reload
       ActiveRecord::Base.transaction do
-        Record.where(register_id: register.id).destroy_all
-        Entry.where(register_id: register.id).destroy_all
+        Record.where(register_id: register.id).delete_all
+        Entry.where(register_id: register.id).delete_all
       end
       raise Exceptions::FrontendInvalidRegisterError, e
     end


### PR DESCRIPTION
### Context
Previously we were using `destroy_all` which deletes records and entries one by one which was very slow. 

### Changes proposed in this pull request
Use `delete_all` which deletes in a single query because we do not need the extra safety in this case of checking for dependencies.

### Guidance to review
If there is an invalid root hash. Register records and entries should still be deleted and repopulated on a subsequent run.