### PR TITLE
exclude backlog registers from population job

### DIFF
--- a/lib/tasks/populate_register_data_in_db.rake
+++ b/lib/tasks/populate_register_data_in_db.rake
@@ -4,14 +4,14 @@ namespace :registers_frontend do
   namespace :populate_db do
     desc 'Add task to the queue to populate register data in the database'
     task fetch_later: :environment do
-      Register.find_each do |register|
+      Register.where.not(register_phase: 'Backlog').find_each do |register|
         PopulateRegisterDataInDbJob.perform_later(register)
       end
     end
 
     desc 'For local envs: populate register data in the database now'
     task fetch_now: :environment do
-      Register.find_each do |register|
+      Register.where.not(register_phase: 'Backlog').find_each do |register|
         begin
           retries ||= 0
           puts("populating register #{register.name}")


### PR DESCRIPTION
### Context
Previously we were attempted to populate _Backlog_ registers which do not exist in ORJ so these would always fail.

### Changes proposed in this pull request
Exclude backlog registers from population job

### Guidance to review
Non-backlog registers should still populate. Note to test this locally you will need to add a Backlog register in the CMS.
