### PR TITLE
set root hash to nil when InvalidRegisterError thrown

### DIFF
--- a/app/jobs/populate_register_data_in_db_job.rb
+++ b/app/jobs/populate_register_data_in_db_job.rb
@@ -17,6 +17,7 @@ class PopulateRegisterDataInDbJob < ApplicationJob
       ActiveRecord::Base.transaction do
         Record.where(register_id: register.id).delete_all
         Entry.where(register_id: register.id).delete_all
+        register.root_hash = nil
       end
       raise Exceptions::FrontendInvalidRegisterError, e
     end


### PR DESCRIPTION
### Context
Previously when `InvalidRegisterError` was thrown we were deleting all Entries and Records which would force a full re-index on next run. However because the root hash was not cleared all subsequent re-index attempts would fail as the saved root hash would not match the expected empty root hash.

### Changes proposed in this pull request
Set the root hash to `nil` when deleting Records and Entries.

### Guidance to review
Set an invalid root hash. Subsequent re-index should not throw `InvalidRegisterError`
