### PR TITLE
Revert "tighten scope of has_records"

### DIFF
--- a/app/models/register.rb
+++ b/app/models/register.rb
@@ -10,7 +10,7 @@ class Register < ApplicationRecord
   scope :by_name, -> { order name: :asc }
   scope :sort_by_phase_name_asc, -> { order("CASE register_phase WHEN 'Beta' THEN 2 WHEN 'Alpha' THEN 3 WHEN 'Discovery' THEN 4 WHEN 'Backlog' THEN 5 END") }
   scope :sort_by_phase_name_desc, -> { order("CASE register_phase WHEN 'Backlog' THEN 1 WHEN 'Discovery' THEN 2 WHEN 'Alpha' THEN 3 WHEN 'Beta' THEN 4 END") }
-  scope :has_records, -> { where(Record.where(id: :register_id, key: "register:#{name.parameterize}")) }
+  scope :has_records, -> { where(id: Record.select(:register_id)) }
   scope :available, -> { has_records.or(Register.where(register_phase: 'Backlog')) }
 
   has_many :entries, dependent: :destroy


### PR DESCRIPTION
### Changes proposed in this pull request
Revert commit as it was not filtering records as intended. 

### Guidance to review
Deleting records from register should cause it to not appear in `has_records` scope.