### PR TITLE
don't link to discovery registers from pipeline

### DIFF
--- a/app/views/registers/_register.html.haml
+++ b/app/views/registers/_register.html.haml
@@ -11,7 +11,7 @@
     %div{class: "govuk-organisation-logo #{register.authority.parameterize}"}
       %div{class: "logo-container #{crest_class_name(register.authority.parameterize)}"}
         %span= register.authority
-  - if register.register_phase != 'Backlog'
+  - unless ['Backlog','Discovery'].any? (register.register_phase)
     %td{class: "links", "data-title" => "View more: "}
       = link_to "View register", register_path(register.slug)
   - else


### PR DESCRIPTION
### Context
We don't want to link to discovery registers as they are primarily for custodian use

### Changes proposed in this pull request
Don't link to Discovery registers on pipeline page

### Guidance to review
should not link to discovery registers on pipeline 
<img width="1037" alt="screen shot 2018-02-21 at 14 40 41" src="https://user-images.githubusercontent.com/1764158/36485933-37c07b30-1715-11e8-8f9f-dc556b6cb285.png">

