### PR TITLE
Update manifest to deploy to cloud apps domain

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -13,11 +13,9 @@ defaults: &defaults
     PROMETHEUS_METRICS_PATH: /metrics
 
 applications:
-- name: registers-frontend
+- name: registers
   <<: *defaults
   instances: 2
-  domain: registers-trial.service.gov.uk
-  no-hostname: true
   health-check-type: http
   health-check-http-endpoint: /health_check/standard
 - name: registers-frontend-queue


### PR DESCRIPTION
### Context
Pushing everything to https://registers.cloudapps.digital

### Changes proposed in this pull request
Update manifest to use `registers.cloudapps.digital`

### Guidance to review
🤔 