### PR TITLE
only show available registers count on homepage

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -6,7 +6,7 @@ class PagesController < ApplicationController
   before_action :get_ready_to_use_registers, only: %i[avaliable_registers home]
 
   def home
-    @registers = Register.all
+    @registers = Register.available.all
   end
 
   def roadmap; end


### PR DESCRIPTION
### Context
Previously we used different criteria for the register counts on the homepage vs. the pipeline page

### Changes proposed in this pull request
Only show _available_ registers in both counts, for consistency

### Guidance to review
Count should be consistent between pipeline page and homepage