### PR TITLE
Fix layout of meta data on mobile

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -89,7 +89,7 @@ dl dt {
   max-width: 150px;
   padding-bottom: 0.5rem;
   padding-right: 1%;
-  width: 25%;
+  width: 24%;
 }
 
 dl dd {
@@ -156,7 +156,7 @@ table {
 
 .records-search {
   @include media(mobile) {
-    margin-bottom: 40px;
+    margin-bottom: $gutter-half;
   }
 }
 
@@ -205,6 +205,10 @@ table {
 }
 
 .related-container {
+  @include media(mobile) {
+    margin-top: $gutter;
+  }
+
   .heading-small:first-of-type {
     margin-top: 0;
   }


### PR DESCRIPTION
### Context
Our metadata section looks untidy on small screens

### Changes proposed in this pull request
Tweak some styling for small screens

### Guidance to review
View a register on a small screen/devise

# Before
![screen shot 2018-02-22 at 12 29 32](https://user-images.githubusercontent.com/3071606/36538594-0b87b512-17cc-11e8-9d37-e0c344396c15.png)

# After
![screen shot 2018-02-22 at 12 29 02](https://user-images.githubusercontent.com/3071606/36538586-03d08092-17cc-11e8-814c-3d0097121711.png)
