### PR TITLE
save the model after nulifying root hash

### DIFF
--- a/app/jobs/populate_register_data_in_db_job.rb
+++ b/app/jobs/populate_register_data_in_db_job.rb
@@ -18,6 +18,7 @@ class PopulateRegisterDataInDbJob < ApplicationJob
         Record.where(register_id: register.id).delete_all
         Entry.where(register_id: register.id).delete_all
         register.root_hash = nil
+        register.save
       end
       raise Exceptions::FrontendInvalidRegisterError, e
     end


### PR DESCRIPTION
### Context
Previously we were not saving the model after invalid register exception, so the register was stuck in an invalid state and unable to repopulate

### Changes proposed in this pull request
Save the model after making changes.

### Guidance to review
Set an invalid root hash in the frontend DB. Register should repopulate after first failure.
