### PR TITLE
store fields as array in DB

### DIFF
--- a/app/jobs/populate_register_data_in_db_job.rb
+++ b/app/jobs/populate_register_data_in_db_job.rb
@@ -26,6 +26,7 @@ class PopulateRegisterDataInDbJob < ApplicationJob
     metadata_records = Record.where(register_id: register.id, entry_type: :system)
     fields = metadata_records.select { |record| record.key.start_with?("field:") }
     register.fields = fields.map { |field| field.data['field'] }.join(',')
+    register.fields_array = Record.where(key: "register:#{register.slug}").pluck("data -> 'fields' as fields").first
     register.url = register_url
     register.save
   end

--- a/db/migrate/20180227142929_add_fields_array.rb
+++ b/db/migrate/20180227142929_add_fields_array.rb
@@ -1,0 +1,5 @@
+class AddFieldsArray < ActiveRecord::Migration[5.1]
+  def change
+    add_column :registers, :fields_array, :text, array: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180226115528) do
+ActiveRecord::Schema.define(version: 20180227142929) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -72,6 +72,7 @@ ActiveRecord::Schema.define(version: 20180226115528) do
     t.text "related_registers"
     t.string "url"
     t.string "root_hash"
+    t.text "fields_array", array: true
   end
 
   create_table "request_registers", force: :cascade do |t|


### PR DESCRIPTION
### Context
Previously we stored fields in the DB as a comma separated string in the order from the RSF (which may not match the register definition). This meant we were frequently turning it back into an array in the app logic and also performing additional queries to get the order.

### Changes proposed in this pull request
Store fields in the DB as an array ordered based on the register definition. 

### Guidance to review
This is a prerequisite to future refactoring once this migration is applied and the data is populated we can deprecate the previous `fields` column in the DB.