### PR TITLE
apply env var to frontend app only

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -9,15 +9,15 @@ defaults: &defaults
     - registers-product-site-environment-variables
     # logging
     - logit-ssl-drain
-  env:
-    PROMETHEUS_METRICS_PATH: /metrics
-
+    
 applications:
 - name: registers
   <<: *defaults
   instances: 2
   health-check-type: http
   health-check-http-endpoint: /health_check/standard
+  env:
+    PROMETHEUS_METRICS_PATH: /metrics
 - name: registers-frontend-queue
   <<: *defaults
   instances: 1


### PR DESCRIPTION
### Context
Previously we set the Prometheus environment variable for all apps. However, the call was failing for the queue and scheduler apps as they don't respond to the `/metrics` endpoint.

### Changes proposed in this pull request
Only set prometheus environment variable for `registers` app.

### Guidance to review
After deploying failed hits to `/metrics` should no longer appear in Logit
