### PR TITLE
add register name when logging error

### DIFF
--- a/app/jobs/populate_register_data_in_db_job.rb
+++ b/app/jobs/populate_register_data_in_db_job.rb
@@ -20,10 +20,12 @@ class PopulateRegisterDataInDbJob < ApplicationJob
         register.root_hash = nil
         register.save
       end
-      raise Exceptions::FrontendInvalidRegisterError, e
+      raise Exceptions::FrontendInvalidRegisterError, "#{register.name}: #{e}"
     end
 
-    register.fields_array = Record.where(key: "register:#{register.slug}").pluck("data -> 'fields' as fields").first
+    register.fields_array = Record.where(key: "register:#{register.slug}")
+                                  .pluck("data -> 'fields' as fields")
+                                  .first
     register.url = register_url
     register.save
   end

--- a/spec/jobs/handle_invalid_register_spec.rb
+++ b/spec/jobs/handle_invalid_register_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe PopulateRegisterDataInDbJob, type: :job do
 
     it 'throws exception when register invalid and deletes records and entries' do
       country = ObjectsFactory.new.create_register('country', 'beta', 'D587')
-      expect { PopulateRegisterDataInDbJob.perform_now(country) }.to raise_error(PopulateRegisterDataInDbJob::Exceptions::FrontendInvalidRegisterError, 'Register has been reloaded with different data - root hashes do not match')
+      expect { PopulateRegisterDataInDbJob.perform_now(country) }.to raise_error(PopulateRegisterDataInDbJob::Exceptions::FrontendInvalidRegisterError, 'country: Register has been reloaded with different data - root hashes do not match')
       expect(Record.where(register_id: country.id).count).to equal(0)
       expect(Entry.where(register_id: country.id).count).to equal(0)
     end


### PR DESCRIPTION
### Context
Add more logging to aid debugging

### Changes proposed in this pull request
Log register name when throwing `FrontendInvalidRegisterError`

### Guidance to review
Should show log message including register name in `development.log` when exception is thrown.