### PR TITLE
Revert "remove use of client class var"

### DIFF
--- a/app/jobs/populate_register_data_in_db_job.rb
+++ b/app/jobs/populate_register_data_in_db_job.rb
@@ -9,8 +9,7 @@ class PopulateRegisterDataInDbJob < ApplicationJob
     Delayed::Worker.logger.info("Updating #{register.name} in database")
     begin
     # Initialize client and download / update data
-      registers_client_manager = RegistersClient::RegisterClientManager.new
-      register_client = registers_client_manager.get_register(register.name.parameterize, register.register_phase.downcase, PostgresDataStore.new(register))
+      register_client = RegistersClientWrapper.registers_client.get_register(register.name.parameterize, register.register_phase.downcase, PostgresDataStore.new(register))
       register_url = register_client.instance_variable_get(:@register_url)
       register_client.refresh_data
     rescue InvalidRegisterError => e

--- a/config/initializers/registers_client.rb
+++ b/config/initializers/registers_client.rb
@@ -1,0 +1,8 @@
+class RegistersClientWrapper
+  @@registers_client ||= RegistersClient::RegisterClientManager.new # rubocop:disable Style/ClassVars
+  def self.registers_client
+    @@registers_client
+  end
+end
+
+RegistersClientWrapper.registers_client

--- a/spec/controllers/entries_controller_spec.rb
+++ b/spec/controllers/entries_controller_spec.rb
@@ -18,6 +18,8 @@ RSpec.describe EntriesController, type: :controller do
     charity_proof = File.read('./spec/support/charity_proof.json')
     territory_proof = File.read('./spec/support/territory_proof.json')
 
+    RegistersClientWrapper.class_variable_set(:@@registers_client, RegistersClient::RegisterClientManager.new)
+
     ObjectsFactory.new.create_register('country', 'Beta', 'D587')
     ObjectsFactory.new.create_register('charity', 'Beta', 'D587')
     ObjectsFactory.new.create_register('territory', 'Beta', 'D587')

--- a/spec/controllers/registers_controller_spec.rb
+++ b/spec/controllers/registers_controller_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe RegistersController, type: :controller do
     charity_proof = File.read('./spec/support/charity_proof.json')
     territory_proof = File.read('./spec/support/territory_proof.json')
 
+    RegistersClientWrapper.class_variable_set(:@@registers_client, RegistersClient::RegisterClientManager.new)
 
     ObjectsFactory.new.create_register('country', 'Beta', 'D587')
     ObjectsFactory.new.create_register('charity', 'Beta', 'D587')

--- a/spec/features/view_register_spec.rb
+++ b/spec/features/view_register_spec.rb
@@ -17,6 +17,8 @@ RSpec.feature 'View register', type: :feature do
     with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip, deflate', 'Host' => 'country.register.gov.uk' }).
     to_return(body: country_proof)
 
+    RegistersClientWrapper.class_variable_set(:@@registers_client, RegistersClient::RegisterClientManager.new)
+
     country = ObjectsFactory.new.create_register('Country', 'Beta', 'D587')
     PopulateRegisterDataInDbJob.perform_now(country)
   end

--- a/spec/jobs/handle_invalid_register_spec.rb
+++ b/spec/jobs/handle_invalid_register_spec.rb
@@ -18,6 +18,8 @@ RSpec.describe PopulateRegisterDataInDbJob, type: :job do
       stub_request(:get, "https://country.register.gov.uk/proof/register/merkle:sha-256").
       with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip, deflate', 'Host' => 'country.register.gov.uk' }).
       to_return({ body: country_proof }, body: country_proof_update)
+
+      RegistersClientWrapper.class_variable_set(:@@registers_client, RegistersClient::RegisterClientManager.new)
     end
 
     it 'throws exception when register invalid and deletes records and entries' do

--- a/spec/jobs/populate_register_data_in_db_job_spec.rb
+++ b/spec/jobs/populate_register_data_in_db_job_spec.rb
@@ -26,6 +26,8 @@ RSpec.describe PopulateRegisterDataInDbJob, type: :job do
     with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip, deflate', 'Host' => 'country.register.gov.uk' }).
     to_return({ body: country_proof }, body: country_proof_update)
 
+    RegistersClientWrapper.class_variable_set(:@@registers_client, RegistersClient::RegisterClientManager.new)
+
     ObjectsFactory.new.create_register('country', 'beta', 'D587')
     Register.find_each do |register|
       PopulateRegisterDataInDbJob.perform_now(register)


### PR DESCRIPTION
Reverts openregister/registers-frontend#226

Revert this while we investigate `Exited with status 137 (out of memory)` issue.