### PR TITLE
Fix occasional issue when trying to access CMS

### DIFF
--- a/db/migrate/20180308135757_remove_translated_columns.spina.rb
+++ b/db/migrate/20180308135757_remove_translated_columns.spina.rb
@@ -1,0 +1,12 @@
+# This migration comes from spina (originally 5)
+class RemoveTranslatedColumns < ActiveRecord::Migration[5.0]
+  def change
+    remove_column :spina_lines, :content
+    remove_column :spina_texts, :content
+    remove_column :spina_pages, :title
+    remove_column :spina_pages, :menu_title
+    remove_column :spina_pages, :description
+    remove_column :spina_pages, :seo_title
+    remove_column :spina_pages, :materialized_path
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180301171305) do
+ActiveRecord::Schema.define(version: 20180308135757) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -141,7 +141,6 @@ ActiveRecord::Schema.define(version: 20180301171305) do
   end
 
   create_table "spina_lines", id: :serial, force: :cascade do |t|
-    t.string "content"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
@@ -203,16 +202,12 @@ ActiveRecord::Schema.define(version: 20180301171305) do
   end
 
   create_table "spina_pages", id: :serial, force: :cascade do |t|
-    t.string "title"
-    t.string "menu_title"
-    t.string "description"
     t.boolean "show_in_menu", default: true
     t.string "slug"
     t.boolean "deletable", default: true
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "name"
-    t.string "seo_title"
     t.boolean "skip_to_first_child", default: false
     t.string "view_template"
     t.string "layout_template"
@@ -220,7 +215,6 @@ ActiveRecord::Schema.define(version: 20180301171305) do
     t.string "link_url"
     t.string "ancestry"
     t.integer "position"
-    t.string "materialized_path"
     t.boolean "active", default: true
   end
 
@@ -294,7 +288,6 @@ ActiveRecord::Schema.define(version: 20180301171305) do
   end
 
   create_table "spina_texts", id: :serial, force: :cascade do |t|
-    t.text "content"
     t.datetime "created_at"
     t.datetime "updated_at"
   end


### PR DESCRIPTION
### Changes proposed in this pull request
Add missing spina migration that removes the old translation coumns

### Guidance to review
`rake db:migrate` and check `/admin`