### PR TITLE
remove queue and scheduler apps from manifest

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -20,13 +20,3 @@ applications:
   no-hostname: true
   health-check-type: http
   health-check-http-endpoint: /health_check/standard
-- name: registers-frontend-queue
-  <<: *defaults
-  instances: 1
-  command: bundle exec 'rake environment jobs:work'
-  health-check-type: process
-- name: registers-frontend-scheduler
-  <<: *defaults
-  instances: 1
-  command: bundle exec clockwork 'lib/clock.rb'
-  health-check-type: process


### PR DESCRIPTION
### Context
fix production issue

### Changes proposed in this pull request
remove these apps from the trial app as they were causing conflicts with the production app

### Guidance to review
We can review the need for these in future but need to remove them for now