### PR TITLE
Change app name to registers-trial

### DIFF
--- a/bin/deploy
+++ b/bin/deploy
@@ -3,7 +3,7 @@ set -e
 
 # Parse app names from manifest to ensure it matches up
 SINGLE_INSTANCE_APPS=(registers-frontend-queue registers-frontend-scheduler)
-ZERO_DOWNTIME_APPS=registers-frontend
+ZERO_DOWNTIME_APPS=registers-trial
 
 # $CF env variables are set by Travis and configured in ../.travis.yml
 cf login -a $CF_API -u $CF_USERNAME -p $CF_PASSWORD -o $CF_ORG -s $CF_SPACE

--- a/manifest.yml
+++ b/manifest.yml
@@ -11,7 +11,7 @@ defaults: &defaults
     - logit-ssl-drain
 
 applications:
-- name: registers-frontend
+- name: registers-trial
   <<: *defaults
   instances: 2
   domain: registers-trial.service.gov.uk


### PR DESCRIPTION
### Changes proposed in this pull request
The app names and services are too confusing. This will atleast match the database service name and domain.

### Guidance to review
This still needs to work - https://registers-trial.service.gov.uk