### PR TITLE
Remove welsh government crest

### DIFF
--- a/app/assets/stylesheets/govuk_component/_organisation-logo.scss
+++ b/app/assets/stylesheets/govuk_component/_organisation-logo.scss
@@ -63,10 +63,6 @@
     border-color: $department-for-work-pensions;
   }
 
-  &.welsh-government .logo-with-crest {
-    border-color: $wales-office;
-  }
-
   &.department-for-environment-food-and-rural-affairs .logo-with-crest {
     border-color: $department-for-environment-food-rural-affairs;
   }

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -7,8 +7,6 @@ module ApplicationHelper
       "logo-with-crest crest-mod"
     when "hm-revenue-customs"
       "logo-with-crest crest-hmrc"
-    when "welsh-government"
-      "logo-with-crest crest-wales"
     when "department-for-business-innovation-and-skills"
       "logo-with-crest crest-bis"
     when "the-office-of-the-leader-of-the-house-of-commons"
@@ -17,7 +15,7 @@ module ApplicationHelper
       "logo-with-crest crest-so"
     when "uk-atomic-energy-authority"
       "logo-with-crest crest-ukaea"
-    when "nhs", "government-digital-service", "scottish-government"
+    when "nhs", "government-digital-service", "scottish-government", "welsh-government"
       " "
     else
       "logo-with-crest crest-org"


### PR DESCRIPTION
### Changes proposed in this pull request
To be consistent with the API Inspector and GOV.UK we want to remove the crest from the welsh government organisation logo.

### Guidance to review
/registers and check principal local authority registers

<img width="1005" alt="screen shot 2018-03-13 at 10 57 09" src="https://user-images.githubusercontent.com/3071606/37337739-226f6c9e-26ad-11e8-8188-a7c1e78f0880.png">
