### PR TITLE
BAU: Bug fix to support controller

### DIFF
--- a/app/controllers/support_controller.rb
+++ b/app/controllers/support_controller.rb
@@ -6,7 +6,7 @@ class SupportController < ApplicationController
   def index; end
 
   def select_support
-    if params[:subject] == "problem"
+    if params[:subject] == '[Problem]'
       redirect_to support_problem_path
     else
       redirect_to support_question_path
@@ -30,7 +30,7 @@ class SupportController < ApplicationController
       redirect_to support_thanks_path
     else
       flash[:errors] = @support.errors
-      if params[:subject] == "problem"
+      if params[:support][:subject] == '[Problem]'
         render :problem
       else
         render :question

--- a/spec/features/view_support_problem_spec.rb
+++ b/spec/features/view_support_problem_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+RSpec.feature 'View support', type: :feature do
+  scenario 'correct information shown after invalid submission' do
+    visit '/support/problem'
+    expect(page).to have_content('Report a problem')
+    click_button('Submit')
+    expect(page).to have_content('Report a problem')
+  end
+end


### PR DESCRIPTION
I found this bug while trying to replicate the support form for the Connecting to verify team. 
When user submits an invalid form, the support controller caused the fields to change.
Example: The title on 'Report a problem' page changes to 'Ask a question or give feedback' upon invalid submission.