### PR TITLE
BAU: Bug fix to support controller

### DIFF
--- a/app/controllers/support_controller.rb
+++ b/app/controllers/support_controller.rb
@@ -6,7 +6,7 @@ class SupportController < ApplicationController
   def index; end
 
   def select_support
-    if params[:subject] == '[Problem]'
+    if params[:subject] == 'problem'
       redirect_to support_problem_path
     else
       redirect_to support_question_path


### PR DESCRIPTION
When user clicks on report a problem the support controller loads the question form

I previously changed the string 'problem' to '[Problem]' to keep consistency but for some reason that created the issue described above. So I have reverted that back and it now loads the correct form with the correct validation.
