### PR TITLE
set use_ssl boolean on request

### DIFF
--- a/app/controllers/api_users_controller.rb
+++ b/app/controllers/api_users_controller.rb
@@ -31,6 +31,7 @@ private
     uri = URI.parse(Rails.configuration.self_service_api_endpoint)
 
     Net::HTTP.start(uri.host, uri.port) do |http|
+      http.use_ssl = (url.scheme == 'https')
       request = Net::HTTP::Post.new(uri.request_uri)
       request.basic_auth(ENV['SELF_SERVICE_HTTP_AUTH_USERNAME'], ENV['SELF_SERVICE_HTTP_AUTH_PASSWORD'])
       request.set_form_data(@user)


### PR DESCRIPTION
### Context
`POST` to selfservice app was failing on production with error: `EOFError (end of file reached):`

### Changes proposed in this pull request
Set `use_ssl` to true on request. This is a speculative fix based on https://stackoverflow.com/questions/5244887/eoferror-end-of-file-reached-issue-with-nethttp

### Guidance to review
As fix is speculative we should test it once merged as it is fixing a production only issue