### PR TITLE
use prometheus service instead of env var

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -16,8 +16,9 @@ applications:
   instances: 2
   health-check-type: http
   health-check-http-endpoint: /health_check/standard
-  env:
-    PROMETHEUS_METRICS_PATH: /metrics
+  services:
+    # monitoring
+    - prometheus
 - name: registers-frontend-queue
   <<: *defaults
   instances: 1


### PR DESCRIPTION
### Context
Required as prometheus is now a CF service

### Changes proposed in this pull request
bind to prometheus service

### Guidance to review
After deploying validate metrics are arriving by checking the default dashboard at https://grafana-paas.cloudapps.digital

CC @davbo
