### PR TITLE
Fix bug where filter does not take effect

### DIFF
--- a/app/views/registers/show.html.haml
+++ b/app/views/registers/show.html.haml
@@ -52,7 +52,7 @@
                 %summary{"aria-controls" => "details-content-0", "aria-expanded" => "#{params[:status].present? ? 'true' : 'false'}", role: "button"}
                   %span.summary Search and filter
                 %div{id: "details-content-0", "aria-hidden" => "#{params[:status].present? && @records.present? ? 'false' : 'true'}"}
-                  = form_tag register_path(@register.slug, anchor: 'records_wrapper'), method: :get, class: 'panel panel-border' do
+                  = form_tag register_path(@register.slug, anchor: 'records_wrapper'), method: :get, id: 'search_records', class: 'panel panel-border' do
                     .grid-row
                       .column-one-third
                         .records-search


### PR DESCRIPTION
### Context
There is a bug where the radio buttons do not change the data when selection is changed. They only change the data when the search button is later clicked.

Spotted during user research run through and should be merged ASAP before today's sessions.

### Changes proposed in this pull request
This fixes this bug.

### Guidance to review
Check that when you click on radio buttons the data changes without having to manually click on the search button.