### PR TITLE
Temporarily remove `js-hidden` class to fix "Load more" bug

### DIFF
--- a/app/views/registers/show.html.haml
+++ b/app/views/registers/show.html.haml
@@ -97,7 +97,7 @@
                   = render partial: 'showing'
 
               - unless @records.last_page?
-                = link_to_next_page @records, 'Load more', id: 'load-more-records', class: 'js-hidden', remote: true
+                = link_to_next_page @records, 'Load more', id: 'load-more-records', remote: true
 
             - else
               .no-search-results


### PR DESCRIPTION
### Context
The "js-hidden" class inside the tab is causing the "Load more" button not to show up even when JS is switched on. This works fine in the `master` branch but not in the `beta-assessment-v2` branch. This is a temporary solution for today's user research session and needs to be fixed properly later. I might need some CSS help to come up with the correct way of doing it ...

### Changes proposed in this pull request
Remove `js-hidden` CSS class.

### Guidance to review
Confirm that the "Load more" button is visible.