### PR TITLE
Revert "use prometheus service instead of env var"

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -16,9 +16,8 @@ applications:
   instances: 2
   health-check-type: http
   health-check-http-endpoint: /health_check/standard
-  services:
-    # monitoring
-    - prometheus
+  env:
+    PROMETHEUS_METRICS_PATH: /metrics
 - name: registers-frontend-queue
   <<: *defaults
   instances: 1


### PR DESCRIPTION
Reverts openregister/registers-frontend#250 as it broke the deploy