### PR TITLE
copy paste services for frontend

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -16,8 +16,12 @@ applications:
   instances: 2
   health-check-type: http
   health-check-http-endpoint: /health_check/standard
-  env:
-    PROMETHEUS_METRICS_PATH: /metrics
+  services:     
+    # TODO: This block overrides to add prometheus but we should do this using inheritence if possible 
+    - registers-frontend
+    - registers-product-site-environment-variables
+    - logit-ssl-drain
+    - prometheus
 - name: registers-frontend-queue
   <<: *defaults
   instances: 1


### PR DESCRIPTION
### Context
The attempt to add a `prometheus` service failed in https://github.com/openregister/registers-frontend/pull/255 due to the inheritance of services not working

### Changes proposed in this pull request
Copy and paste the required services as a workaround until we can get inheritance to work

### Guidance to review
frontend should be bound to prometheus and other required services
