### PR TITLE
add error handling in api key post

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,6 +58,9 @@ gem 'clockwork'
 
 gem 'gds_metrics', '~> 0.0.2'
 
+# HTTP
+gem 'net_http_exception_fix', '~> 1.0'
+
 group :development, :test do
   gem 'govuk-lint', github: 'openregister/govuk-lint', branch: 'bump-rubocop-version'
   gem 'pry-byebug'

--- a/Gemfile
+++ b/Gemfile
@@ -59,7 +59,7 @@ gem 'clockwork'
 gem 'gds_metrics', '~> 0.0.2'
 
 # HTTP
-gem 'net_http_exception_fix', '~> 1.0'
+gem 'httparty', '~> 0.16.2'
 
 group :development, :test do
   gem 'govuk-lint', github: 'openregister/govuk-lint', branch: 'bump-rubocop-version'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -275,6 +275,7 @@ GEM
       request_store (~> 1.0)
     multi_json (1.13.1)
     multipart-post (2.0.0)
+    net_http_exception_fix (1.0.1)
     netrc (0.11.0)
     nio4r (2.3.0)
     nokogiri (1.8.2)
@@ -463,6 +464,7 @@ DEPENDENCIES
   listen (~> 3.0.5)
   lograge (~> 0.9.0)
   logstash-event (~> 1.2, >= 1.2.02)
+  net_http_exception_fix (~> 1.0)
   pg (~> 0.18)
   pry-byebug
   puma (~> 3.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -214,6 +214,8 @@ GEM
       domain_name (~> 0.5)
     http-form_data (1.0.3)
     http_parser.rb (0.6.0)
+    httparty (0.16.2)
+      multi_xml (>= 0.5.2)
     i18n (1.0.0)
       concurrent-ruby (~> 1.0)
     inflection (1.0.0)
@@ -274,8 +276,8 @@ GEM
       i18n (>= 0.6.10, < 1.1)
       request_store (~> 1.0)
     multi_json (1.13.1)
+    multi_xml (0.6.0)
     multipart-post (2.0.0)
-    net_http_exception_fix (1.0.1)
     netrc (0.11.0)
     nio4r (2.3.0)
     nokogiri (1.8.2)
@@ -457,6 +459,7 @@ DEPENDENCIES
   haml-rails
   health_check (~> 2.7)
   http (= 2.2.1)
+  httparty (~> 0.16.2)
   jbuilder (~> 2.5)
   jquery-rails
   jquery-ui-rails
@@ -464,7 +467,6 @@ DEPENDENCIES
   listen (~> 3.0.5)
   lograge (~> 0.9.0)
   logstash-event (~> 1.2, >= 1.2.02)
-  net_http_exception_fix (~> 1.0)
   pg (~> 0.18)
   pry-byebug
   puma (~> 3.0)

--- a/app/controllers/api_users_controller.rb
+++ b/app/controllers/api_users_controller.rb
@@ -19,7 +19,7 @@ class ApiUsersController < ApplicationController
         render :show
       else
         flash.alert = 'Something went wrong'
-        logger.error("API Key POST failed with unexpected response code: #{response&.code}")
+        logger.error("API Key POST failed with unexpected response code: #{response.code}") if response&.code
         render :new
       end
     end
@@ -31,7 +31,7 @@ private
     @user = { email: user.email, department: user.department, service: user.service }
     uri = URI.parse(Rails.configuration.self_service_api_endpoint)
     options = {
-      basic_auth: { username: ENV['SELF_SERVICE_HTTP_AUTH_USERNAME'], password: ENV['SELF_SERVICE_HTTP_AUTH_PASSWORD'] },
+      basic_auth: { username: ENV.fetch['SELF_SERVICE_HTTP_AUTH_USERNAME'], password: ENV.fetch['SELF_SERVICE_HTTP_AUTH_PASSWORD'] },
       body: @user
     }
     error_message = 'Something went wrong'

--- a/app/controllers/api_users_controller.rb
+++ b/app/controllers/api_users_controller.rb
@@ -1,7 +1,7 @@
 require 'net/http'
 require 'uri'
 require 'json'
-require 'net_http_exception_fix'
+require 'httparty'
 
 class ApiUsersController < ApplicationController
   before_action :set_government_organisations
@@ -14,7 +14,7 @@ class ApiUsersController < ApplicationController
     @api_user = ApiUser.new(api_user_params)
     if @api_user.valid?
       response = post_to_endpoint(@api_user)
-      if response.is_a? Net::HTTPCreated
+      if response&.code == 201
         @api_key = JSON.parse(response.body)['api_key']
         render :show
       else
@@ -29,19 +29,19 @@ private
   def post_to_endpoint(user)
     @user = { email: user.email, department: user.department, service: user.service }
     uri = URI.parse(Rails.configuration.self_service_api_endpoint)
-    http = Net::HTTP.new(uri.host, uri.port)
-    http.use_ssl = (uri.scheme == 'https')
+    options = {
+      basic_auth: { username: ENV['SELF_SERVICE_HTTP_AUTH_USERNAME'], password: ENV['SELF_SERVICE_HTTP_AUTH_PASSWORD'] },
+      body: @user
+    }
+    error_message = 'Something went wrong'
     begin
-      http.start do |http_start|
-        request = Net::HTTP::Post.new(uri.request_uri)
-        request.basic_auth(ENV['SELF_SERVICE_HTTP_AUTH_USERNAME'], ENV['SELF_SERVICE_HTTP_AUTH_PASSWORD'])
-        request.set_form_data(@user)
-        http_start.request(request)
-      end
-    rescue Net::HTTPBroken => e
-      logger.error("API Key POST failed with #{e}")
-      flash.alert = 'Something went wrong'
+      HTTParty.post(uri, options)
     end
+  rescue StandardError => e
+    # Fallback for socket errors etc...
+    logger.error("API Key POST failed with exception: #{e}")
+    flash.alert = error_message
+    nil
   end
 
   def api_user_params

--- a/app/controllers/api_users_controller.rb
+++ b/app/controllers/api_users_controller.rb
@@ -19,6 +19,7 @@ class ApiUsersController < ApplicationController
         render :show
       else
         flash.alert = 'Something went wrong'
+        logger.error("API Key POST failed with unexpected response code: #{response&.code}")
         render :new
       end
     end

--- a/app/views/api_users/new.html.haml
+++ b/app/views/api_users/new.html.haml
@@ -3,5 +3,11 @@
 %main#content{role: 'main'}
   .grid-row
     .column-full
+      - if flash.alert.present?
+        %div{:class => 'error-summary', :role => 'alert'}
+          %h2{:class => %w(heading-medium error-summary-heading), :id => 'error-summary-heading'}  
+            #{flash.alert}
+          %p
+            If the problem persists please contact #{link_to 'support', support_path}
       %h1.heading-large Create your API key
       = render 'form', user: @user

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,9 @@ services:
       - "3000:3000"
     depends_on:
       - db
+    environment:
+      SELF_SERVICE_HTTP_AUTH_USERNAME: ${SELF_SERVICE_HTTP_AUTH_USERNAME}
+      SELF_SERVICE_HTTP_AUTH_PASSWORD: ${SELF_SERVICE_HTTP_AUTH_PASSWORD}
 
 volumes:
   data: {}


### PR DESCRIPTION
### Context
Handle case where we get an unexpected HTTP response from registers-selfservice

### Changes proposed in this pull request
Catch exceptions thrown by `net/http` and show error message

Note: I am aware this does not handle the case where we get a valid (e.g. 200 response from registers-selfservice but with malformed content, this will be a separate PR.)

## Before
![screen shot 2018-04-11 at 10 19 34](https://user-images.githubusercontent.com/1764158/38611906-eedf14ba-3d7c-11e8-8551-3bbdce6f6604.png)

## After
![screen shot 2018-04-11 at 11 30 30](https://user-images.githubusercontent.com/1764158/38611919-fc00c6f2-3d7c-11e8-938c-a4ddba6cb4fd.png)

### Guidance to review
You can test this locally by attempting to submit the api key form whilst `registers-selfservice` app is not running