### PR TITLE
add uri check to authentication

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,9 @@
 class ApplicationController < Spina::ApplicationController
   include Spina::Frontend
 
-  http_basic_authenticate_with name: ENV['HTTP_AUTH_USERNAME'], password: ENV['HTTP_AUTH_PASSWORD'] if Rails.env.production?
+  is_trial_domain = Rails.env.production? && JSON.parse(ENV.fetch('VCAP_APPLICATION'))['uris'].include?('registers-trial.service.gov.uk')
+
+  http_basic_authenticate_with name: ENV['HTTP_AUTH_USERNAME'], password: ENV['HTTP_AUTH_PASSWORD'] if is_trial_domain
 
   protect_from_forgery with: :exception
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,8 +2,7 @@ class ApplicationController < Spina::ApplicationController
   include Spina::Frontend
 
   is_trial_domain = Rails.env.production? && JSON.parse(ENV.fetch('VCAP_APPLICATION'))['uris'].include?('registers-trial.service.gov.uk')
-
-  http_basic_authenticate_with name: ENV['HTTP_AUTH_USERNAME'], password: ENV['HTTP_AUTH_PASSWORD'] if is_trial_domain
+  http_basic_authenticate_with name: Rails.configuration.http_auth_username, password: Rails.configuration.http_auth_password if is_trial_domain
 
   protect_from_forgery with: :exception
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,4 +1,4 @@
-Rails.application.configure do
+Rails.application.configure do # rubocop:disable Metrics/BlockLength
   # Settings specified here will take precedence over those in config/application.rb.
 
   # Code is not reloaded between requests.
@@ -86,4 +86,6 @@ Rails.application.configure do
   config.self_service_api_endpoint = 'https://registers-selfservice.cloudapps.digital/users'
   config.self_service_http_auth_username = ENV.fetch('SELF_SERVICE_HTTP_AUTH_USERNAME')
   config.self_service_http_auth_password = ENV.fetch('SELF_SERVICE_HTTP_AUTH_PASSWORD')
+  config.http_auth_username = ENV.fetch('HTTP_AUTH_USERNAME')
+  config.http_auth_password = ENV.fetch('HTTP_AUTH_PASSWORD')
 end


### PR DESCRIPTION
### Context
Required to make `beta-assessment-v2` safe to merge into `master`

### Changes proposed in this pull request
Only apply authentication if URI is `registers-trial.service.gov.uk`

### Guidance to review
https://registers-trial.service.gov.uk should continue to have auth after merge. https://registers.cloudapps.digital should not have auth.
