### PR TITLE
Service domain updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Registers Frontend
 
-Frontend for [GOV.UK Registers](https://registers.cloudapps.digital/)
+Frontend for [GOV.UK Registers](https://registers.service.gov.uk/)
 
 ## Prerequisites
 

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,9 +1,5 @@
 @charset "utf-8";
 
-// Cannot use GDS Transport font on a non GOV.UK domain due to licensing
-$toolkit-font-stack: "HelveticaNeue", "Helvetica Neue", "Arial", "Helvetica", sans-serif;
-$toolkit-font-stack-tabular: "HelveticaNeue", "Helvetica Neue", "Arial", "Helvetica", sans-serif;
-
 // GOV.UK Toolkit and GOV.UK Elements
 @import 'govuk_elements';
 

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -27,7 +27,7 @@
           %li{class: "#{'active' if current_page?(support_path)}"}
             = link_to "Support", support_path
           %li
-            = link_to "Documentation", "https://registers-docs.cloudapps.digital/", target: :blank, rel: "noopener noreferrer"
+            = link_to "Documentation", "https://docs.registers.service.gov.uk/", target: :blank, rel: "noopener noreferrer"
 
 - content_for :head do
   = stylesheet_link_tag 'application'

--- a/app/views/pages/case_study.html.haml
+++ b/app/views/pages/case_study.html.haml
@@ -31,11 +31,11 @@
       %p TISCreport was launched in March 2016. Anti-slavery charities, consumer groups, business groups, large organisations with complex supply chains and individual ethical consumers were involved in the initiative.
       %p Everyone involved was aware that helping organisations to ensure they had ethical supply chains was a complex task. We knew that the only way we could hope to achieve this was by making use of pre-existing data and networks as foundations.
       %h3.heading-medium Accessing and linking data
-      %p TISCreport relies entirely on high-quality data from multiple organisations. Our users need to know that the information they are viewing is trustworthy and that it comes from impeccable sources. This is why being able to rely on the authoritative data supplied by #{link_to "GOV.UK Registers", "https://registers.cloudapps.digital/"} is so important.
+      %p TISCreport relies entirely on high-quality data from multiple organisations. Our users need to know that the information they are viewing is trustworthy and that it comes from impeccable sources. This is why being able to rely on the authoritative data supplied by #{link_to "GOV.UK Registers", root_path} is so important.
       %p If you need high-quality authoritative data you need to go directly to the source, which is the government in some cases. Before GOV.UK Registers existed, it was often difficult to know which organisation, never mind which individual, to approach to get hold of official datasets. This was assuming that an official single list existed. Often, multiple but different lists of the same things were made available by different parts of government, each one of which was ‘official’.
       %p In particular, we found the canonical lists of local authorities in the UK and the list of the many and varied different organisations that make up the government to be very useful. We were able to very quickly integrate our new system with the registers platform via their API and immediately begin using the data.
       %h3.heading-medium GOV.UK Registers are different
-      %p #{link_to 'GOV.UK Registers', 'https://registers.cloudapps.digital', target: :blank} have the following unique properties that make them especially suitable for our needs:
+      %p #{link_to 'GOV.UK Registers', 'https://registers.service.gov.uk', target: :blank} have the following unique properties that make them especially suitable for our needs:
       %ul.list-bullet
         %li they are the single official list of a set of data, such as countries and territories, as recognised by the UK government
         %li they are publicly available to anyone to use for free

--- a/app/views/pages/using_registers.html.haml
+++ b/app/views/pages/using_registers.html.haml
@@ -39,6 +39,6 @@
         %li download either the whole or part of a register
         %li find a single record, entry or item
 
-      %p The #{link_to 'technical documentation', 'https://registers-docs.cloudapps.digital', target: :blank, rel: 'noopener noreferrer'} has more information.
+      %p The #{link_to 'technical documentation', 'https://docs.registers.service.gov.uk', target: :blank, rel: 'noopener noreferrer'} has more information.
 
       %p Alternatively, you can download a copy of the register data directly from each register’s homepage.

--- a/app/views/registers/show.html.haml
+++ b/app/views/registers/show.html.haml
@@ -20,7 +20,7 @@
       .column-two-thirds
         .panel.panel-border-wide
           %span.phase-banner In progress
-          %p This data is in progress and it’s not ready for use. #{link_to 'Contact the team', 'https://registers.cloudapps.digital/support', target: :blank} to give us feedback.
+          %p This data is in progress and it’s not ready for use. #{link_to 'Contact the team', 'https://registers.service.gov.uk/support', target: :blank} to give us feedback.
 
   .grid-row
     .column-two-thirds

--- a/app/views/support/index.html.haml
+++ b/app/views/support/index.html.haml
@@ -22,5 +22,5 @@
   .grid-row
     .column-two-thirds
       %p The Government Digital Service (GDS) maintains the platform behind registers and helps custodians to manage their registers and keep the data up-to-date. GDS provides operational support from 9am to 5pm, Monday to Friday.
-      %p You can #{link_to "find help", "https://registers-docs.cloudapps.digital/#support-and-community", target: :blank} about common issues when using registers, including how to find a specific record or error codes.
+      %p You can #{link_to "find help", "https://docs.registers.service.gov.uk/#support-and-community", target: :blank} about common issues when using registers, including how to find a specific record or error codes.
       %p If your issue isn’t included or you’re struggling to use registers in your product or service, please contact the GDS registers team at #{mail_to "registers@digital.cabinet-office.gov.uk"}.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -82,5 +82,5 @@ Rails.application.configure do
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
 
-  config.action_mailer.default_url_options = { host: 'https://registers.cloudapps.digital' }
+  config.action_mailer.default_url_options = { host: 'https://registers.service.gov.uk' }
 end

--- a/spec/controllers/entries_controller_spec.rb
+++ b/spec/controllers/entries_controller_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe EntriesController, type: :controller do
       .with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip, deflate' })
       .to_return(status: 200, body: register_alpha_data, headers: {})
 
-    stub_request(:get, 'https://register.cloudapps.digital/download-rsf/0')
+    stub_request(:get, 'https://registers.service.gov.uk/download-rsf/0')
       .with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip, deflate' })
       .to_return(status: 200, body: register_discovery_data, headers: {})
 

--- a/spec/controllers/registers_controller_spec.rb
+++ b/spec/controllers/registers_controller_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe RegistersController, type: :controller do
       .with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip, deflate' })
       .to_return(status: 200, body: register_alpha_data, headers: {})
 
-    stub_request(:get, 'https://register.cloudapps.digital/download-rsf/0')
+    stub_request(:get, 'https://registers.service.gov.uk/download-rsf/0')
       .with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip, deflate' })
       .to_return(status: 200, body: register_discovery_data, headers: {})
 


### PR DESCRIPTION
### Changes proposed in this pull request
We now have `https://registers.service.gov.uk/`

### Guidance to review
All links updated and we can now use the transport font