### PR TITLE
display register-name where available

### DIFF
--- a/app/models/register.rb
+++ b/app/models/register.rb
@@ -58,6 +58,11 @@ class Register < ApplicationRecord
     Record.where(register_id: id, entry_type: 'user').count
   end
 
+  def register_name
+    Record.where(register_id: id, entry_type: 'system', key: 'register-name')
+          .pluck("data -> 'register-name' as register_name").first || name
+  end
+
 private
 
   def set_slug

--- a/app/models/register.rb
+++ b/app/models/register.rb
@@ -59,8 +59,9 @@ class Register < ApplicationRecord
   end
 
   def register_name
-    Record.where(register_id: id, entry_type: 'system', key: 'register-name')
-          .pluck("data -> 'register-name' as register_name").first || name
+    register_phase != 'Backlog' &&
+      Record.where(register_id: id, entry_type: 'system', key: 'register-name')
+            .pluck("data -> 'register-name' as register_name").first || name
   end
 
 private

--- a/app/views/entries/index.html.haml
+++ b/app/views/entries/index.html.haml
@@ -9,7 +9,7 @@
     %li.breadcrumbs__item
       = link_to 'Registers collection', registers_path
     %li.breadcrumbs__item
-      = link_to "#{@register.name} Register", register_path(@register.slug)
+      = link_to "#{@register.register_name} Register", register_path(@register.slug)
     %li.breadcrumbs__item.breadcrumbs__item--active
       = link_to 'Register updates', '#content', 'aria-current' => 'page'
 

--- a/app/views/registers/_register.html.haml
+++ b/app/views/registers/_register.html.haml
@@ -1,6 +1,6 @@
 %tr
   %th{"data-title" => index, }
-    %h4.heading-small= register.name
+    %h4.heading-small= register.register_name
     - if register.register_phase == 'Backlog'
       %p= register.description
     - else

--- a/app/views/registers/show.html.haml
+++ b/app/views/registers/show.html.haml
@@ -1,4 +1,4 @@
-- @page_title = "#{@register.name.capitalize} Register"
+- @page_title = "#{@register.register_name.capitalize} Register"
 - @page_description = ""
 - content_for :body_classes, 'register-show'
 
@@ -11,7 +11,7 @@
     %li.breadcrumbs__item
       = link_to 'Registers collection', registers_path
     %li.breadcrumbs__item.breadcrumbs__item--active
-      = link_to "#{@register.name} Register", '#content', 'aria-current' => 'page'
+      = link_to "#{@register.register_name} Register", '#content', 'aria-current' => 'page'
 
 %main#content.container{role:'main'}
 
@@ -26,7 +26,7 @@
     .column-two-thirds
 
       %h1.heading-large
-        #{@register.name} register
+        #{@register.register_name} register
         %span.heading-secondary= @register.register_description
 
       .govuk-metadata


### PR DESCRIPTION
### Context
https://github.com/openregister/openregister-java/pull/459

### Changes proposed in this pull request
Display `register-name` in preference to ID where available.
![screen shot 2018-04-26 at 15 41 40](https://user-images.githubusercontent.com/1764158/39312824-5807233c-4968-11e8-8a8e-4558ddffceed.png)

![screen shot 2018-04-26 at 15 09 19](https://user-images.githubusercontent.com/1764158/39312763-36f23718-4968-11e8-9349-2239054b5041.png)


### Guidance to review
Check `register-name` is displayed where you would expect. Note: you may need to add a DSA register to the CMS to see this change.