### PR TITLE
Specify routes in manifest

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -14,6 +14,9 @@ applications:
 - name: registers
   <<: *defaults
   instances: 2
+  routes:
+  - route: registers.cloudapps.digital
+  - route: www.registers.service.gov.uk
   health-check-type: http
   health-check-http-endpoint: /health_check/standard
   services:


### PR DESCRIPTION
### Context
Now that we use registers.cloudapps.digital and www.registers.service.gov.uk for this app, we must specify them both in the manifest to ensure they are not removed when we deploy the application.

### Changes proposed in this pull request
Add both routes to manifest.

### Guidance to review
Check both routes still work when we deploy.