### PR TITLE
send 'is government' response to self-service

### DIFF
--- a/app/controllers/api_users_controller.rb
+++ b/app/controllers/api_users_controller.rb
@@ -28,7 +28,10 @@ class ApiUsersController < ApplicationController
 private
 
   def post_to_endpoint(user)
-    @user = { email: user.email, department: user.department, service: user.service }
+    @user = { email: user.email,
+              department: user.department,
+              service: user.service,
+              is_government: user.is_government == 'yes' }
     uri = URI.parse(Rails.configuration.self_service_api_endpoint)
     options = {
       basic_auth: { username: ENV.fetch('SELF_SERVICE_HTTP_AUTH_USERNAME'), password: ENV.fetch('SELF_SERVICE_HTTP_AUTH_PASSWORD') },
@@ -49,7 +52,8 @@ private
     params.require(:api_user).permit(
       :email,
       :department,
-      :service
+      :service,
+      :is_government
     )
   end
 

--- a/app/models/api_user.rb
+++ b/app/models/api_user.rb
@@ -1,4 +1,4 @@
 class ApiUser
   include ActiveModel::Model
-  attr_accessor :email, :service, :department
+  attr_accessor :email, :service, :department, :is_government
 end

--- a/app/views/api_users/_form.html.haml
+++ b/app/views/api_users/_form.html.haml
@@ -5,21 +5,13 @@
       %span.form-hint Your API key will be sent to this email address
     = f.text_field :email, class: 'form-control', type: 'email', required: true
 
-  .form-group
     %fieldset.inline
-      %legend
-        %label.form-label-bold
-          Do you work for government?
-      .multiple-choice{"data-target" => "government-department"}
-        %input#work-for-government{name: "radio-org-group", type: "radio", value: "Yes"}
-        %label{for: "work-for-government"} Yes
-      .multiple-choice
-        %input#not-work-for-government{name: "radio-org-group", type: "radio", value: "No"}
-        %label{for: "not-work-for-government"} No
+      = f.radio_button_fieldset :is_government,
+          inline: true      
+    .form-group
       #government-department.panel.panel-border-narrow.js-hidden
         = f.label :department, 'Which government organisation do you work for?', class: 'form-label'
         = f.select :department, @government_organisations.all.collect{ |org| [org.data['name'], org.key] }, { include_blank: true }, id: 'government-organisations'
-  .form-group
     %fieldset.inline
       %legend
         %label.form-label-bold

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -36,6 +36,10 @@ en:
     label:
       support:
         email: Email address
+    fieldset:
+      api_user:
+        is_government: |
+          Do you work for government?
   errors:
     messages:
       blank: is required


### PR DESCRIPTION
### Context
To fulfil suggestion by Dan Gilbert

### Changes proposed in this pull request
send 'is government' response in self-service form POST

### Guidance to review
if run with https://github.com/openregister/registers-selfservice/pull/12 'non government user' should be written to department column of sheet. 
