### PR TITLE
add required attribute to form fields

### DIFF
--- a/app/views/request_registers/steps/_page2.html.haml
+++ b/app/views/request_registers/steps/_page2.html.haml
@@ -3,4 +3,4 @@
   = f.label :email, class: 'form-label' do
     %span.visually-hidden Email address
     %span.form-hint We need this to update you on the register’s progress
-  = f.email_field :email, class: "form-control #{@request_register.errors[:email].present? ? 'form-control-error' : ''}", value: session[:request_register_params]['email']
+  = f.email_field :email, required: true, class: "form-control #{@request_register.errors[:email].present? ? 'form-control-error' : ''}", value: session[:request_register_params]['email']

--- a/app/views/suggest_registers/steps/_page2.html.haml
+++ b/app/views/suggest_registers/steps/_page2.html.haml
@@ -3,4 +3,4 @@
   = f.label :message, class: 'form-label' do
     %span.visually-hidden Register title
     %span.form-hint Make this as short and clear as possible
-  = f.text_field :message, class: "form-control #{@suggest_register.errors[:message].present? ? 'form-control-error' : ''}", value: session[:suggest_register_params]['message']
+  = f.text_field :message, required: true, class: "form-control #{@suggest_register.errors[:message].present? ? 'form-control-error' : ''}", value: session[:suggest_register_params]['message']

--- a/app/views/suggest_registers/steps/_page3.html.haml
+++ b/app/views/suggest_registers/steps/_page3.html.haml
@@ -3,4 +3,4 @@
   = f.label :email, class: 'form-label' do
     %span.visually-hidden Email address
     %span.form-hint We need this to update you on the register’s progress
-  = f.email_field :email, class: "form-control #{@suggest_register.errors[:email].present? ? 'form-control-error' : ''}", value: session[:suggest_register_params]['email']
+  = f.email_field :email, required: true, class: "form-control #{@suggest_register.errors[:email].present? ? 'form-control-error' : ''}", value: session[:suggest_register_params]['email']

--- a/app/views/support/problem.html.haml
+++ b/app/views/support/problem.html.haml
@@ -9,7 +9,7 @@
 
       = form_for @support, url: support_problem_path  do |f|
         = f.hidden_field :subject, value: "[Problem]"
-        = f.text_area :message, rows: 10
-        = f.text_field :name
-        = f.email_field :email
+        = f.text_area :message, rows: 10, required:  true
+        = f.text_field :name, required: true
+        = f.email_field :email, required: true
         = f.submit "Submit", class: "button"


### PR DESCRIPTION
### Context
Previously we were not making required mandatory fields on the client side

### Changes proposed in this pull request
add `required` attribute to mandatory fields

### Guidance to review
empty fields should not be allowed by the browser.