### PR TITLE
Revert register page header section for release

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -285,9 +285,17 @@ table {
 }
 
 .search-records-wrapper {
-  border-top: 2px solid $border-colour;
-  margin-bottom: $gutter-half;
-  padding-top: $gutter-half;
+  border-top: 2px solid $grey-3;
+  margin: 40px 0 20px 0;
+  padding-top: 40px;
+
+  .heading-medium {
+    margin-top: 0;
+  }
+
+  .form-control {
+    width: 100%;
+  }
 }
 
 .form-group-wrapper {

--- a/app/assets/stylesheets/modules/_search.scss
+++ b/app/assets/stylesheets/modules/_search.scss
@@ -1,6 +1,4 @@
 .records-search {
-  margin-top: $gutter-half;
-
   .search-input {
     border: 2px solid $black;
     font-size: 16px;

--- a/app/views/registers/show.html.haml
+++ b/app/views/registers/show.html.haml
@@ -28,7 +28,15 @@
         #{@register.register_name} register
         %span.heading-secondary= @register.register_description
 
-      %p.font-xsmall Last updated: #{link_to formatted_date(@register.register_last_updated), register_entries_path(@register.slug)}
+      .govuk-metadata
+        %dl
+          - if @register.register_authority.present?
+            %dt Managed by:
+            %dd
+              = link_to @register.register_authority.data['name'], @register.register_authority.data['website']
+          %dt Last updated:
+          %dd
+            = link_to formatted_date(@register.register_last_updated), register_entries_path(@register.slug)
 
       %details{role: "group"}
         %summary{"aria-controls" => "details-content-1", "aria-expanded" => "false", :role => "button"}
@@ -39,19 +47,17 @@
               - @register.register_fields.each do |field|
                 %dt= field['field']
                 %dd= field['text']
-
-    .column-one-third
-      - if @register.register_authority.present?
-        %h3.heading-small Managed by:
-        %div{class: "govuk-organisation-logo #{@register.register_authority.data['name'].parameterize}"}
-          %div{class: "logo-container #{crest_class_name(@register.register_authority.data['name'].parameterize)}"}
-            %span= @register.register_authority.data['name']
-        %h4.heading-small Use this register
-        %p= link_to "View the API", @register.url
-
+    .column-third
+      %aside#related
+        .related-container
+          %h4.heading-small Use this register
+          %ul
+            %li
+              = link_to "View the API", @register.url, target: :blank
   .grid-row
     .column-full
       .search-records-wrapper#search_wrapper
+        %h3.heading-medium Explore this register
         .grid-row
           = form_tag register_path(@register.slug, anchor: 'search_wrapper'), method: :get, id: 'search_records' do
             .column-one-third


### PR DESCRIPTION
### Changes proposed in this pull request
We'll update the header section in the next release with the API key flow so we're going to leave as is for the moment. We are removing the "total records" count though as this s confusing users

### Guidance to review
/registers/country

# After
<img width="1386" alt="screen shot 2018-05-02 at 08 53 41" src="https://user-images.githubusercontent.com/3071606/39511726-60a323ba-4de6-11e8-9448-3b79a06f83ad.png">
 