### PR TITLE
comment out API key route

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,8 +13,8 @@ Rails.application.routes.draw do
     resources :entries, path: 'updates', only: :index
   end
 
-  resources :api_users
-
+  # TODO: enable this when we release the API key flow
+  # resources :api_users
   get '/registers-in-progress', to: 'registers#in_progress'
 
   resources :suggest_registers, path: 'suggest-register', except: %i[show edit]


### PR DESCRIPTION
### Context
We don't want to expose API key route yet.

### Changes proposed in this pull request
comment out API key route

### Guidance to review
`/api_users/new` should not resolve.
