### PR TITLE
Update support link

### DIFF
--- a/app/views/registers/show.html.haml
+++ b/app/views/registers/show.html.haml
@@ -20,7 +20,7 @@
       .column-two-thirds
         .panel.panel-border-wide
           %span.phase-banner In progress
-          %p This data is in progress and it’s not ready for use. #{link_to 'Contact the team', support_path} to give us feedback.
+          %p This data is in progress and it’s not ready for use. #{link_to 'Contact the team', support_question_path} to give us feedback.
 
   .grid-row
     .column-two-thirds


### PR DESCRIPTION
### Context
> conor.delahunty [15 minutes ago]
Can you change the "Contact the team" link on the in progress banner to be consistent with the "Open for feedback" link on the Upcoming Registers page?
i.e. both should go to `https://registers-trial.service.gov.uk/support/question`

### Changes proposed in this pull request
update support link

### Guidance to review
Check support link on alpha register