### PR TITLE
Remove route for registers.cloudapps.digital

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -15,7 +15,6 @@ applications:
   <<: *defaults
   instances: 2
   routes:
-  - route: registers.cloudapps.digital
   - route: www.registers.service.gov.uk
   health-check-type: http
   health-check-http-endpoint: /health_check/standard


### PR DESCRIPTION
### Context
registers.cloudapps.digital now redirects to www.registers.service.gov.uk via the `www-registers-service-redirect` app. This route is therefore no longer required for the `registers` app.

### Changes proposed in this pull request
Remove route registers.cloudapps.digital from `registers` app.

### Guidance to review
Check you can still access registers.cloudapps.digital and it redirects to www.registers.service.gov.uk.