### PR TITLE
Fix and add default meta description

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -30,6 +30,7 @@
 - content_for :head do
   = stylesheet_link_tag 'application'
   = csrf_meta_tags
+  %meta{ name: 'description', content: "#{@page_description.present? ? @page_description : 'GOV.UK Registers provides a secure API that is easy to integrate with so you can get the most up-to-date data from across government.'}" }
   = render partial: 'layouts/analytics' if Rails.env.production?
 
 - content_for :body_end do

--- a/app/views/registers/show.html.haml
+++ b/app/views/registers/show.html.haml
@@ -1,5 +1,5 @@
 - @page_title = "#{@register.register_name.capitalize} register"
-- @page_description = ""
+- @page_description = @register.register_description
 - content_for :body_classes, 'register-show'
 
 %nav.breadcrumbs{role: "Navigation", "aria-label" => "Breadcrumb"}


### PR DESCRIPTION
### Context
We'd like registers to appear nicely on Google search

### Changes proposed in this pull request
Add default meta description and use register description for register pages

### Guidance to review
View page source of homepage and a register page