### PR TITLE
Remove Home from home page SEO title

### DIFF
--- a/app/views/entries/index.html.haml
+++ b/app/views/entries/index.html.haml
@@ -1,4 +1,4 @@
-- @page_title = "Register updates"
+- @page_title = "#{@register.register_name} register updates"
 
 %nav.breadcrumbs{role: "Navigation", "aria-label" => "Breadcrumb"}
   %ol{data: {"click-events" => "", "click-category" => "Header", "click-action" => "Breadcrumb Clicked"}}
@@ -9,7 +9,7 @@
     %li.breadcrumbs__item
       = link_to 'Get data', registers_path
     %li.breadcrumbs__item
-      = link_to "#{@register.register_name} Register", register_path(@register.slug)
+      = link_to "#{@register.register_name} register", register_path(@register.slug)
     %li.breadcrumbs__item.breadcrumbs__item--active
       = link_to 'Register updates', '#content', 'aria-current' => 'page'
 

--- a/app/views/entries/index.html.haml
+++ b/app/views/entries/index.html.haml
@@ -1,4 +1,4 @@
-= content_for :page_title, "Register updates"
+- @page_title = "Register updates"
 
 %nav.breadcrumbs{role: "Navigation", "aria-label" => "Breadcrumb"}
   %ol{data: {"click-events" => "", "click-category" => "Header", "click-action" => "Breadcrumb Clicked"}}

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -1,6 +1,6 @@
 - @omit_header = true
 
-- content_for :page_title, "#{@page_title} - GOV.UK Registers"
+- content_for :page_title, "#{@page_title.present? ? "#{@page_title} - GOV.UK Registers" : 'GOV.UK Registers' }"
 
 - content_for :after_header do
   %header{class: "header #{current_page?(root_path) ? 'header--without-border' : ''}"}

--- a/app/views/pages/home.html.haml
+++ b/app/views/pages/home.html.haml
@@ -1,4 +1,3 @@
-- @page_title = 'Home'
 = content_for :body_classes, 'home-page'
 
 %main{role:'main'}

--- a/app/views/registers/in_progress.html.haml
+++ b/app/views/registers/in_progress.html.haml
@@ -1,4 +1,4 @@
-- @page_title = 'Registers collection'
+- @page_title = 'Upcoming registers'
 - content_for :body_classes, 'register-index'
 
 %nav.breadcrumbs{role: "Navigation", "aria-label" => "Breadcrumb"}


### PR DESCRIPTION
### Context
Improve appearance on Google search

### Changes proposed in this pull request
- Remove "Home" from home page title
- Ensure we prepend the page title before "- GOV.UK Registers"

### Guidance to review
Check browser tab for SEO page title on home page and others