### PR TITLE
use registers API key when set

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ gem 'govuk_elements_form_builder', git: 'https://github.com/ministryofjustice/go
 gem 'govuk_elements_rails'
 gem 'govuk_frontend_toolkit'
 gem 'govuk_template'
-gem 'govuk-registers-api-client', '~> 1.0'
+gem 'govuk-registers-api-client', '~> 1.1.1'
 
 # Ransack
 gem 'ransack', github: 'activerecord-hackery/ransack'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -113,7 +113,7 @@ GEM
       rubocop (~> 0.52.0)
       rubocop-rspec (~> 1.19.0)
       scss_lint
-    govuk-registers-api-client (1.0.1)
+    govuk-registers-api-client (1.1.1)
       rest-client (~> 2)
     govuk_elements_rails (3.1.2)
       govuk_frontend_toolkit (>= 6.0.2)
@@ -371,7 +371,7 @@ DEPENDENCIES
   faker
   gds_metrics (~> 0.1.0)
   govuk-lint (~> 3.8)
-  govuk-registers-api-client (~> 1.0)
+  govuk-registers-api-client (~> 1.1.1)
   govuk_elements_form_builder!
   govuk_elements_rails
   govuk_frontend_toolkit

--- a/app/jobs/populate_register_data_in_db_job.rb
+++ b/app/jobs/populate_register_data_in_db_job.rb
@@ -9,8 +9,10 @@ class PopulateRegisterDataInDbJob < ApplicationJob
     Delayed::Worker.logger.info("Updating #{register.name} in database")
     begin
     # Initialize client and download / update data
-      registers_client_manager = RegistersClient::RegisterClientManager.new
-      register_client = registers_client_manager.get_register(register.name.parameterize, register.register_phase.downcase, PostgresDataStore.new(register))
+      registers_client_manager = RegistersClient::RegisterClientManager.new({
+        api_key: Rails.configuration.try(:registers_api_key)
+      }.compact)
+      register_client = registers_client_manager.get_register(register.name.parameterize, register.register_phase.downcase, data_store: PostgresDataStore.new(register))
       register_url = register_client.instance_variable_get(:@register_url)
       register_client.refresh_data
     rescue InvalidRegisterError => e

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -93,4 +93,5 @@ Rails.application.configure do # rubocop:disable Metrics/BlockLength
   config.x.zendesk.url = ENV.fetch('ZENDESK_URL')
   config.x.zendesk.username = ENV.fetch('ZENDESK_USERNAME')
   config.x.zendesk.token = ENV.fetch('ZENDESK_TOKEN')
+  config.registers_api_key = ENV.fetch('REGISTERS_API_KEY')
 end


### PR DESCRIPTION
### Context
Previously we weren't setting an API key

### Changes proposed in this pull request
use registers API key when set

### Guidance to review
Check population still works locally