### PR TITLE
use debug version of gds_metrics

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,7 +52,7 @@ gem 'activerecord-import'
 gem 'clockwork'
 
 # Monitoring
-gem 'gds_metrics', '~> 0.1.0'
+ gem 'gds_metrics', github: 'openregister/gds_metrics_ruby'
 
 # Encrypted password
 gem 'bcrypt'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,6 +18,13 @@ GIT
       govuk_frontend_toolkit (>= 6.0.0)
       rails (>= 4.2)
 
+GIT
+  remote: https://github.com/openregister/gds_metrics_ruby.git
+  revision: b81de457bc36ce29427eed71f12d037779e22183
+  specs:
+    gds_metrics (0.1.0)
+      prometheus-client-mmap (= 0.9.1)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -105,8 +112,6 @@ GEM
     faraday (0.14.0)
       multipart-post (>= 1.2, < 3)
     ffi (1.9.23)
-    gds_metrics (0.1.0)
-      prometheus-client-mmap (= 0.9.1)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
     govuk-lint (3.8.0)
@@ -369,7 +374,7 @@ DEPENDENCIES
   delayed_job_active_record (~> 4.1, >= 4.1.2)
   factory_bot_rails (~> 4.8, >= 4.8.2)
   faker
-  gds_metrics (~> 0.1.0)
+  gds_metrics!
   govuk-lint (~> 3.8)
   govuk-registers-api-client (~> 1.1.1)
   govuk_elements_form_builder!

--- a/manifest-trial.yml
+++ b/manifest-trial.yml
@@ -3,8 +3,6 @@ applications:
   buildpack: ruby_buildpack
   memory: 1GB
   instances: 2
-  domain: registers-trial.service.gov.uk
-  no-hostname: true
   health-check-type: http
   health-check-http-endpoint: /health_check/standard
   services:


### PR DESCRIPTION
### Context
Auth is currently failing for prometheus on production

### Changes proposed in this pull request
Use a debug version of the gem with additional logging to understand more about why it is failing.

### Guidance to review
When deployed additional logging should be visible (does not happen in development as auth is not applied)

CC @philandstuff

