### PR TITLE
remove prometheus

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,9 +51,6 @@ gem 'activerecord-import'
 # Schedule
 gem 'clockwork'
 
-# Monitoring
-gem 'gds_metrics', '~> 0.1.0'
-
 # Encrypted password
 gem 'bcrypt'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -105,8 +105,6 @@ GEM
     faraday (0.14.0)
       multipart-post (>= 1.2, < 3)
     ffi (1.9.23)
-    gds_metrics (0.1.0)
-      prometheus-client-mmap (= 0.9.1)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
     govuk-lint (3.8.0)
@@ -216,7 +214,6 @@ GEM
     polyamorous (1.3.3)
       activerecord (>= 3.0)
     powerpack (0.1.1)
-    prometheus-client-mmap (0.9.1)
     pry (0.11.3)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
@@ -369,7 +366,6 @@ DEPENDENCIES
   delayed_job_active_record (~> 4.1, >= 4.1.2)
   factory_bot_rails (~> 4.8, >= 4.8.2)
   faker
-  gds_metrics (~> 0.1.0)
   govuk-lint (~> 3.8)
   govuk-registers-api-client (~> 1.1.1)
   govuk_elements_form_builder!

--- a/manifest.yml
+++ b/manifest.yml
@@ -23,7 +23,6 @@ applications:
     - registers-frontend
     - registers-product-site-environment-variables
     - logit-ssl-drain
-    - prometheus
 - name: registers-frontend-queue
   <<: *defaults
   instances: 1


### PR DESCRIPTION
### Context
prometheus was causing deploys to production to fail

### Changes proposed in this pull request
remove prometheus (until fix is made by RE)

### Guidance to review
App should deploy, no longer attempting to bind to prometheus
