### PR TITLE
set cache headers on static assets

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -94,4 +94,7 @@ Rails.application.configure do # rubocop:disable Metrics/BlockLength
   config.x.zendesk.username = ENV.fetch('ZENDESK_USERNAME')
   config.x.zendesk.token = ENV.fetch('ZENDESK_TOKEN')
   config.registers_api_key = ENV.fetch('REGISTERS_API_KEY')
+  config.public_file_server.headers = {
+    'Cache-Control': 'public, max-age=31536000'
+  }
 end


### PR DESCRIPTION
### Context
registers-frontend on the service domain is now behind cloudfront

### Changes proposed in this pull request
Set long cache header on hashed static assets as per: http://edgeguides.rubyonrails.org/asset_pipeline.html#cdns-and-the-cache-control-header

### Guidance to review
cache-control header should be set on production for static assets
