### PR TITLE
Revert "set cache headers on static assets"

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -94,7 +94,4 @@ Rails.application.configure do # rubocop:disable Metrics/BlockLength
   config.x.zendesk.username = ENV.fetch('ZENDESK_USERNAME')
   config.x.zendesk.token = ENV.fetch('ZENDESK_TOKEN')
   config.registers_api_key = ENV.fetch('REGISTERS_API_KEY')
-  config.public_file_server.headers = {
-    'Cache-Control': 'public, max-age=31536000'
-  }
 end


### PR DESCRIPTION
Reverts openregister/registers-frontend#299 as it seemed to break assets.