### PR TITLE
use rocket instead of colon

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -94,4 +94,7 @@ Rails.application.configure do # rubocop:disable Metrics/BlockLength
   config.x.zendesk.username = ENV.fetch('ZENDESK_USERNAME')
   config.x.zendesk.token = ENV.fetch('ZENDESK_TOKEN')
   config.registers_api_key = ENV.fetch('REGISTERS_API_KEY')
+  config.public_file_server.headers = {
+    'Cache-Control': 'public, max-age=31536000'
+  }
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -95,6 +95,6 @@ Rails.application.configure do # rubocop:disable Metrics/BlockLength
   config.x.zendesk.token = ENV.fetch('ZENDESK_TOKEN')
   config.registers_api_key = ENV.fetch('REGISTERS_API_KEY')
   config.public_file_server.headers = {
-    'Cache-Control': 'public, max-age=31536000'
+    'Cache-Control' => 'public, max-age=31536000'
   }
 end


### PR DESCRIPTION
### Context
see https://github.com/openregister/registers-frontend/pull/300

### Changes proposed in this pull request
Previous attempt set an invalid header as `:` meant header was interpreted as a symbol rather than a string. 🤦‍♂️ 

### Guidance to review
Should set valid cache control header on production