### PR TITLE
bump client library version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ gem 'govuk_elements_form_builder', git: 'https://github.com/ministryofjustice/go
 gem 'govuk_elements_rails'
 gem 'govuk_frontend_toolkit'
 gem 'govuk_template'
-gem 'govuk-registers-api-client', '~> 1.1.1'
+gem 'govuk-registers-api-client', '~> 1.2.1'
 
 # Ransack
 gem 'ransack', github: 'activerecord-hackery/ransack'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -111,7 +111,7 @@ GEM
       rubocop (~> 0.52.0)
       rubocop-rspec (~> 1.19.0)
       scss_lint
-    govuk-registers-api-client (1.1.1)
+    govuk-registers-api-client (1.2.1)
       rest-client (~> 2)
     govuk_elements_rails (3.1.2)
       govuk_frontend_toolkit (>= 6.0.2)
@@ -367,7 +367,7 @@ DEPENDENCIES
   factory_bot_rails (~> 4.8, >= 4.8.2)
   faker
   govuk-lint (~> 3.8)
-  govuk-registers-api-client (~> 1.1.1)
+  govuk-registers-api-client (~> 1.2.1)
   govuk_elements_form_builder!
   govuk_elements_rails
   govuk_frontend_toolkit


### PR DESCRIPTION
### Context
https://github.com/openregister/govuk-registers-api-client/releases/tag/v1.2.1

### Changes proposed in this pull request
bump client library version

### Guidance to review
population should still work.
