### PR TITLE
clear hidden fields on is government toggle

### DIFF
--- a/app/views/api_users/_form.html.haml
+++ b/app/views/api_users/_form.html.haml
@@ -28,9 +28,16 @@
     var yesRadioButton = document.getElementById('api_user_is_government_yes');
     yesRadioButton.onclick = function() {
       ga('send', 'event', 'Form', 'Radio - Yes', 'Do you work for government?');
+      var nonGovEmail = document.getElementById('api_user_email_non_gov')
+      nonGovEmail.value = "";
+      $('input:radio[name="api_user[non_gov_use_category]"]').each(function () { $(this).prop('checked', false); });
     }
 
     var noRadioButton = document.getElementById('api_user_is_government_no');
     noRadioButton.onclick = function() {
       ga('send', 'event', 'Form', 'Radio - No', 'Do you work for government?');
+      var govEmail = document.getElementById('api_user_email_gov')
+      govEmail.value = "";
+      var govOrgs = document.getElementById('government-organisations');
+      govOrgs.value = "";
     }

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -31,7 +31,7 @@
   = stylesheet_link_tag 'application'
   = csrf_meta_tags
   %meta{ name: 'description', content: "#{@page_description.present? ? @page_description : 'GOV.UK Registers provides a secure API that is easy to integrate with so you can get the most up-to-date data from across government.'}" }
-  = render partial: 'layouts/analytics' if Rails.env.production?
+  = render partial: 'layouts/analytics'
 
 - content_for :body_end do
   = javascript_include_tag 'application'


### PR DESCRIPTION
### Context
Fix edge case where user fills out both branches of is-government toggle and ends up in invalid state.

### Changes proposed in this pull request
Clear hidden panel fields content with JS when toggling is-government radio button

### Guidance to review
Try populating both branches of form. Existing input should be cleared on toggle.
