### PR TITLE
Revert "remove prometheus"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,6 +51,9 @@ gem 'activerecord-import'
 # Schedule
 gem 'clockwork'
 
+# Monitoring
+gem 'gds_metrics', '~> 0.1.0'
+
 # Encrypted password
 gem 'bcrypt'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -105,6 +105,8 @@ GEM
     faraday (0.14.0)
       multipart-post (>= 1.2, < 3)
     ffi (1.9.23)
+    gds_metrics (0.1.0)
+      prometheus-client-mmap (= 0.9.1)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
     govuk-lint (3.8.0)
@@ -214,6 +216,7 @@ GEM
     polyamorous (1.3.3)
       activerecord (>= 3.0)
     powerpack (0.1.1)
+    prometheus-client-mmap (0.9.1)
     pry (0.11.3)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
@@ -366,6 +369,7 @@ DEPENDENCIES
   delayed_job_active_record (~> 4.1, >= 4.1.2)
   factory_bot_rails (~> 4.8, >= 4.8.2)
   faker
+  gds_metrics (~> 0.1.0)
   govuk-lint (~> 3.8)
   govuk-registers-api-client (~> 1.2.1)
   govuk_elements_form_builder!

--- a/manifest.yml
+++ b/manifest.yml
@@ -23,6 +23,7 @@ applications:
     - registers-frontend
     - registers-product-site-environment-variables
     - logit-ssl-drain
+    - prometheus
 - name: registers-frontend-queue
   <<: *defaults
   instances: 1


### PR DESCRIPTION
Reverts openregister/registers-frontend#297

Adds back prometheus following fix by RE in: https://github.com/alphagov/cf_app_discovery/pull/7