### PR TITLE
Update api key flow

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -409,6 +409,13 @@ details {
   }
 }
 
+.code-curl {
+  border: none;
+  color: $red;
+  font-size: 16px;
+  white-space: inherit;
+}
+
 .code-large {
   display: block;
   line-height: 1;

--- a/app/controllers/api_users_controller.rb
+++ b/app/controllers/api_users_controller.rb
@@ -9,6 +9,10 @@ class ApiUsersController < ApplicationController
 
   def new
     @api_user = ApiUser.new
+
+    if params[:register].present?
+      session[:register] = params[:register]
+    end
   end
 
   def create
@@ -25,7 +29,9 @@ class ApiUsersController < ApplicationController
           render :new
         when 201
           @api_key = JSON.parse(response.body)['api_key']
+          @register = Register.find_by(slug: session[:register])
           render :show
+          session.delete(:register)
         else
           logger.error("API Key POST failed with unexpected response code: #{response.code}")
           flash.now[:alert] = { title: 'Something went wrong' }

--- a/app/views/api_users/show.html.haml
+++ b/app/views/api_users/show.html.haml
@@ -15,7 +15,7 @@
         %p
           %code.code.code-curl
             curl #{@register.url}/records.json?page-size=5000 --header "Authorization: #{@api_key}"
-        %p This data is also avaliable in other formats. Read more in our #{link_to 'technical documentation', 'https://docs.registers.service.gov.uk/#choose-a-response-format'}.
+        %p This register is also avaliable in other formats. Read more in our #{link_to 'technical documentation', 'https://docs.registers.service.gov.uk/#choose-a-response-format'}.
       - else
         .subsection__header
           %h2.subsection__title{data: {"click-events" => true, "click-category" => "Content", "click-action" => "External Link Clicked"}}

--- a/app/views/api_users/show.html.haml
+++ b/app/views/api_users/show.html.haml
@@ -8,18 +8,25 @@
       %code.code.code-large
         = @api_key
 
-      %p.font-xsmall Your API key has also been emailed to you. Your key can be used for all registers.
+      %p Your API key has also been emailed to you. Your key can be used for all registers.
 
-      .subsection__header
-        %h2.subsection__title{data: {"click-events" => true, "click-category" => "Content", "click-action" => "External Link Clicked"}}
-          = link_to 'Authenticate with your API key', 'https://docs.registers.service.gov.uk#authenticate-with-your-api-key'
-      %div{class: "js-hidden", "data-module" => "accordion-with-descriptions"}
-        .subsection-wrapper
-          .subsection.js-subsection
-            .subsection__header
-              %h2.subsection__title Give feedback
-            .subsection__content.js-subsection-content#subsection_content_2
-              %p #{link_to 'Give feedback about GOV.UK Registers', support_path} to help us improve our service.
+      - if @register.present?
+        %h3.heading-medium Get this register as JSON
+        %p
+          %code.code.code-curl
+            curl #{@register.url}/records.json?page-size=5000 --header "Authorization: #{@api_key}"
+        %p This data is also avaliable in other formats. Read more in our #{link_to 'technical documentation', 'https://docs.registers.service.gov.uk/#choose-a-response-format'}.
+      - else
+        .subsection__header
+          %h2.subsection__title{data: {"click-events" => true, "click-category" => "Content", "click-action" => "External Link Clicked"}}
+            = link_to 'Authenticate with your API key', 'https://docs.registers.service.gov.uk#authenticate-with-your-api-key'
+        %div{class: "js-hidden", "data-module" => "accordion-with-descriptions"}
+          .subsection-wrapper
+            .subsection.js-subsection
+              .subsection__header
+                %h2.subsection__title Give feedback
+              .subsection__content.js-subsection-content#subsection_content_2
+                %p #{link_to 'Give feedback about GOV.UK Registers', support_path} to help us improve our service.
 
 = content_for :javascript do
   :javascript

--- a/app/views/registers/show.html.haml
+++ b/app/views/registers/show.html.haml
@@ -114,7 +114,7 @@
               %h2.subsection__title Access the data
             .subsection__content.js-subsection-content#subsection_content_2
               %ul.list
-                %li= link_to 'Create API key', new_api_user_path
+                %li= link_to 'Create API key', new_api_user_path(register: @register.slug)
                 %li Always access the most recent version of all registers through our API
               %ul.list
                 %li= link_to 'Download the data', register_download_index_path(@register.slug)


### PR DESCRIPTION
### Context
Users are struggling with the "next step" once they have created an API key.

### Changes proposed in this pull request
Add curl example to API key show page

### Guidance to review
Create a new API key from a register page

# After - coming from a register page
<img width="713" alt="screen shot 2018-05-18 at 10 14 34" src="https://user-images.githubusercontent.com/3071606/40226796-926fcdf8-5a84-11e8-8905-42ef56fd04d2.png">

# After - going straight to `/api_users/new`
<img width="713" alt="screen shot 2018-05-18 at 12 50 27" src="https://user-images.githubusercontent.com/3071606/40233273-392433e0-5a9a-11e8-8871-b6bdb56afd2c.png">

