### PR TITLE
Remove JSON reference in download copy

### DIFF
--- a/app/views/registers/show.html.haml
+++ b/app/views/registers/show.html.haml
@@ -118,7 +118,7 @@
                 %li Always access the most recent version of all registers through our API
               %ul.list
                 %li= link_to 'Download the data', register_download_index_path(@register.slug)
-                %li Get the latest data in this register as a CSV and JSON file
+                %li Get the latest data in this register as a CSV file
 
 = content_for :javascript do
   :javascript


### PR DESCRIPTION
### Context
We want download users see CSV only, API users JSON

### Changes proposed in this pull request
Remove JSON from download copy

### Guidance to review
Any register page, expand "Access this data"
<img width="713" alt="screen shot 2018-05-18 at 12 56 59" src="https://user-images.githubusercontent.com/3071606/40233474-0cfc99f0-5a9b-11e8-81f7-05902675c9eb.png">
