### PR TITLE
Cleaner API key url

### DIFF
--- a/app/controllers/api_users_controller.rb
+++ b/app/controllers/api_users_controller.rb
@@ -7,7 +7,7 @@ class ApiUsersController < ApplicationController
   include FormHelpers
   helper_method :government_orgs_local_authorities
 
-  def new
+  def index
     @api_user = ApiUser.new
 
     if params[:register].present?

--- a/app/views/api_users/index.html.haml
+++ b/app/views/api_users/index.html.haml
@@ -7,7 +7,7 @@
       - if flash.alert.present?
         %div{:class => 'error-summary', :role => 'alert'}
           %h2{:class => %w(heading-medium error-summary-heading), :id => 'error-summary-heading'}
-            = flash.alert[:title]   
+            = flash.alert[:title]
           %p!="If the problem persists please contact  #{link_to 'support', support_path}" unless @api_user.errors.any?
       = GovukElementsErrorsHelper.error_summary @api_user, "There is a problem with the form", ""
       %h1.heading-large

--- a/app/views/registers/show.html.haml
+++ b/app/views/registers/show.html.haml
@@ -114,7 +114,7 @@
               %h2.subsection__title Access the data
             .subsection__content.js-subsection-content#subsection_content_2
               %ul.list
-                %li= link_to 'Create API key', new_api_user_path(register: @register.slug)
+                %li= link_to 'Create API key', api_users_path(register: @register.slug)
                 %li Always access the most recent version of all registers through our API
               %ul.list
                 %li= link_to 'Download the data', register_download_index_path(@register.slug)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,7 +18,8 @@ Rails.application.routes.draw do
     get '/download-csv', to: 'download#download_csv', as: 'download_csv'
   end
 
-  resources :api_users
+  resources :api_users, path: 'create-api'
+  get '/api_users/new', to: redirect('/create-api', status: 301)
 
   get '/registers-in-progress', to: 'registers#in_progress'
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,8 +18,8 @@ Rails.application.routes.draw do
     get '/download-csv', to: 'download#download_csv', as: 'download_csv'
   end
 
-  resources :api_users, path: 'create-api'
-  get '/api_users/new', to: redirect('/create-api', status: 301)
+  resources :api_users, path: 'create-api-key'
+  get '/api_users/new', to: redirect('/create-api-key', status: 301)
 
   get '/registers-in-progress', to: 'registers#in_progress'
 


### PR DESCRIPTION
### Context
`/api_keys/new` isnt a nice URL

### Changes proposed in this pull request
Change url to `/create-api`

### Guidance to review
Go to any register page and click "create api key"