### PR TITLE
Add disclaimer messages on api key and download form

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -442,3 +442,8 @@ details {
   position: sticky;
   top: 0;
 }
+
+.disclaimer {
+  color: $grey-1;
+  font-size: 16px;
+}

--- a/app/views/api_users/index.html.haml
+++ b/app/views/api_users/index.html.haml
@@ -14,8 +14,10 @@
         Create your API key
         %span.heading-secondary Always access the most recent version of all registers.
       = render 'form', user: @user
+
   .grid-row
     .column-two-thirds
+      .disclaimer By creating an API key you agree to let us contact you occasionally about service status and upcoming developments. You can unsubscribe at any time.
       %hr
       %h3.heading-medium Why we ask you to create an API key
-      %p As a government service, we want to make sure GOV.UK Registers works for everyone. By creating an API key you can help us to understand more about our users and improve our service.
+      %p As a government service, we want to make sure GOV.UK Registers works for everyone. By creating an API key you can help us to understand more about our users and improve our service. Read more in our #{link_to 'privacy notice', privacy_notice_path}.

--- a/app/views/download/_form.html.haml
+++ b/app/views/download/_form.html.haml
@@ -10,7 +10,7 @@
     = f.radio_button_fieldset :non_gov_use_category, inline: false, choices: [:commercial_use, :non_commercial_use, :personal]
 
   .form-group
-    = f.submit 'Download', class: 'button'
+    = f.submit 'Download the register', class: 'button'
 
 = content_for :javascript do
   :javascript

--- a/app/views/download/index.html.haml
+++ b/app/views/download/index.html.haml
@@ -7,8 +7,14 @@
       = GovukElementsErrorsHelper.error_summary @download, "There is a problem with the form", ""
       - if flash.alert.present?
         %div{:class => 'error-summary', :role => 'alert'}
-          %h2{:class => %w(heading-medium error-summary-heading), :id => 'error-summary-heading'}= flash.alert[:title]   
+          %h2{:class => %w(heading-medium error-summary-heading), :id => 'error-summary-heading'}= flash.alert[:title]
           %p!="If the problem persists please contact  #{link_to 'support', support_path}" unless @download.errors.any?
       %h1.heading-large
         Download the #{@register.register_name} register
       = render 'form', user: @user
+
+  .grid-row
+    .column-two-thirds
+      %hr
+      %h3.heading-medium Why we ask for this information
+      %p As a government service, we want to make sure GOV.UK Registers works for everyone. By providing this information you can help us to understand more about our users and improve our service. Read more in our #{link_to 'privacy notice', privacy_notice_path}.


### PR DESCRIPTION
### Context
GDPR

### Changes proposed in this pull request
Add a disclaimer to api key page

### Guidance to review
`/create-api-key`. Page should look like the below screenshot

# After
<img width="1314" alt="screen shot 2018-05-22 at 23 23 57" src="https://user-images.githubusercontent.com/3071606/40393491-91be7a62-5e17-11e8-921f-6fcb3da113b7.png">

<img width="1314" alt="screen shot 2018-05-23 at 08 17 16" src="https://user-images.githubusercontent.com/3071606/40409091-9839d568-5e61-11e8-902d-44316c74fd65.png">
