### PR TITLE
restore friendly name

### DIFF
--- a/app/views/registers/_register.html.haml
+++ b/app/views/registers/_register.html.haml
@@ -1,7 +1,7 @@
 %tr
   %th{"data-title" => index, }
     %p
-      %strong= link_to_if register.register_phase == 'Alpha', register.name, register_path(register.slug)
+      %strong= link_to_if register.register_phase == 'Alpha', register.register_name, register_path(register.slug)
       %br
       - if register.register_phase == 'Backlog'
         = register.description

--- a/app/views/registers/index.html.haml
+++ b/app/views/registers/index.html.haml
@@ -30,7 +30,7 @@
             - @registers.each do |register|
               .column-one-third
                 = link_to register_path(register.slug), class: 'register-block' do
-                  %h3.register-block__name= register.name
+                  %h3.register-block__name= register.register_name
                   %p.register-block__description= register.register_description
                   - if register.register_authority.present?
                     %div{class: "govuk-organisation-logo #{register.register_authority.data['name'].parameterize}"}

--- a/app/views/registers/show.html.haml
+++ b/app/views/registers/show.html.haml
@@ -26,7 +26,7 @@
     .grid-row
       .column-two-thirds
         %h1.heading-large
-          #{@register.name} register
+          #{@register.register_name} register
           %span.heading-secondary= @register.register_description
         %p.font-xsmall Last updated: #{link_to formatted_date(@register.register_last_updated), register_entries_path(@register.slug)}
 


### PR DESCRIPTION
### Context
fix regression from #269

### Changes proposed in this pull request
restore use of `register-name`  where available

### Guidance to review
`register-name` should take precedence over register ID where populated
