### PR TITLE
validate email address on server-side

### DIFF
--- a/app/models/concerns/form_concerns.rb
+++ b/app/models/concerns/form_concerns.rb
@@ -10,6 +10,9 @@ module FormConcerns
     validates :email_non_gov, presence: true, unless: -> { is_government }
     validates :non_gov_use_category, presence: true, if: -> { is_government == false }
     validates :non_gov_use_category, absence: true, if: -> { is_government }
+    validates_format_of :email_gov, :email_non_gov,
+  with: /\A(|(([A-Za-z0-9]+_+)|([A-Za-z0-9]+\-+)|([A-Za-z0-9]+\.+)|([A-Za-z0-9]+\++))*[A-Za-z0-9]+@((\w+\-+)|(\w+\.))*\w{1,63}\.[a-zA-Z]{2,})\z/i
+
 
     def email
       is_government ? email_gov : email_non_gov

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -78,8 +78,10 @@ en:
         blank: 'Enter which government organisation you work for'
       email_gov:
         blank: 'Enter your email address'
+        invalid: 'Enter a valid email address'
       email_non_gov:
         blank: 'Enter your email address'
+        invalid: 'Enter a valid email address'
       non_gov_use_category:
         blank: "Enter what you're using GOV.UK Registers for"
       blank: is required

--- a/spec/features/api_user_spec.rb
+++ b/spec/features/api_user_spec.rb
@@ -26,8 +26,11 @@ RSpec.feature 'API Key Registration', type: :feature do
 )
   end
 
-  scenario 'valid submission generates API key' do
+  before(:each) do
     visit '/create-api-key'
+  end
+
+  scenario 'valid submission generates API key' do
     expect(page).to have_content('Create your API key')
     choose('Yes')
     select 'Government Digital Service', from: 'Which government organisation do you work for?'
@@ -38,9 +41,16 @@ RSpec.feature 'API Key Registration', type: :feature do
   end
 
   scenario 'invalid submission shows user errors' do
-    visit '/create-api-key'
     first(:css, 'input[data-link-name="new_api_user_submit"]').click
     expect(page).to have_content('Select if you work for government or not')
     expect(page).to have_content('Enter your email address')
+  end
+
+  scenario 'invalid email shows user error' do
+    choose('Yes')
+    select 'Government Digital Service', from: 'Which government organisation do you work for?'
+    fill_in('api_user_email_gov', with: 'foo@bar')
+    first(:css, 'input[data-link-name="new_api_user_submit"]').click
+    expect(page).to have_content('Enter a valid email addres')
   end
 end


### PR DESCRIPTION
### Context
previously we relied on the browser validation of email on the client-side

### Changes proposed in this pull request
validate email format on server-side

### Guidance to review
Invalid email address should be rejected