### PR TITLE
Change download flow

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -464,4 +464,8 @@ details {
   .text {
     margin-bottom: $gutter;
   }
+
+  > p {
+    margin-top: 1.875em;
+  }
 }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -253,6 +253,12 @@ table {
   width: 50%;
 }
 
+.hint-text {
+  color: $grey-1;
+  font-size: 16px;
+  max-width: 30rem;
+}
+
 .form-group.error {
   margin-right: 15px;
   border-left: 4px solid $error-colour;
@@ -455,4 +461,10 @@ details {
   color: $white;
   margin-bottom: $gutter;
   padding: $gutter / 2;
+}
+
+.participate {
+  border-top: 1px solid $border-colour;
+  margin-top: $gutter;
+  padding-top: $gutter-half;
 }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -253,12 +253,6 @@ table {
   width: 50%;
 }
 
-.hint-text {
-  color: $grey-1;
-  font-size: 16px;
-  max-width: 30rem;
-}
-
 .form-group.error {
   margin-right: 15px;
   border-left: 4px solid $error-colour;
@@ -466,5 +460,8 @@ details {
 .participate {
   border-top: 1px solid $border-colour;
   margin-top: $gutter;
-  padding-top: $gutter-half;
+
+  .text {
+    margin-bottom: $gutter;
+  }
 }

--- a/app/controllers/download_controller.rb
+++ b/app/controllers/download_controller.rb
@@ -21,13 +21,13 @@ class DownloadController < ApplicationController
         when 422
           flash.now[:alert] = { title: 'Please fix the errors below', message: @download.errors.messages }
           JSON.parse(response.body).each { |k, v| @download.errors.add(k.to_sym, *v) }
-          render :new
+          render :index
         when 201
           redirect_to register_download_success_path(@register.slug)
         else
           logger.error("Download POST failed with unexpected response code: #{response.code}")
           flash.now[:alert] = { title: 'Something went wrong' }
-          render :new
+          render :index
         end
       else
         flash.now[:alert] = { title: 'Something went wrong' }

--- a/app/views/download/_form.html.haml
+++ b/app/views/download/_form.html.haml
@@ -10,9 +10,7 @@
     = f.radio_button_fieldset :non_gov_use_category, inline: false, choices: [:commercial_use, :non_commercial_use, :personal]
 
   .form-group
-    = f.submit 'Send', class: 'button'
-  .form-group
-    %p.hint-text By helping us to improve registers you agree to let us contact you occasionally about service status and upcoming developments. You can unsubscribe at any time.
+    = f.submit 'Submit', class: 'button'
 
 = content_for :javascript do
   :javascript

--- a/app/views/download/_form.html.haml
+++ b/app/views/download/_form.html.haml
@@ -1,4 +1,4 @@
-= form_for @download, url: register_download_index_path(@register.slug) do |f|
+= form_for @download, url: register_download_index_path(@register.slug, anchor: 'participation_section') do |f|
   = f.radio_button_fieldset :is_government, inline: true do |fieldset|
     - fieldset.radio_input :yes, panel_id: 'is_government_panel'
     - fieldset.radio_input :no, panel_id: 'not_government_panel'
@@ -10,7 +10,9 @@
     = f.radio_button_fieldset :non_gov_use_category, inline: false, choices: [:commercial_use, :non_commercial_use, :personal]
 
   .form-group
-    = f.submit 'Download the register', class: 'button'
+    = f.submit 'Send', class: 'button'
+  .form-group
+    %p.hint-text By helping us to improve registers you agree to let us contact you occasionally about service status and upcoming developments. You can unsubscribe at any time.
 
 = content_for :javascript do
   :javascript

--- a/app/views/download/index.html.haml
+++ b/app/views/download/index.html.haml
@@ -4,17 +4,18 @@
 %main#content{role: 'main'}
   .grid-row
     .column-full
-      = GovukElementsErrorsHelper.error_summary @download, "There is a problem with the form", ""
-      - if flash.alert.present?
-        %div{:class => 'error-summary', :role => 'alert'}
-          %h2{:class => %w(heading-medium error-summary-heading), :id => 'error-summary-heading'}= flash.alert[:title]
-          %p!="If the problem persists please contact  #{link_to 'support', support_path}" unless @download.errors.any?
-      %h1.heading-large
-        Download the #{@register.register_name} register
-      = render 'form', user: @user
+      %h1.heading-large Download the #{@register.register_name} register
+      %p You can download the latest data in this register as:
+      %ul.list.list-bullet
+        %li= link_to 'CSV', register_download_csv_path(@register.slug)
+        %li= link_to 'JSON', register_download_json_path(@register.slug)
+      .participate#participation_section
+        = GovukElementsErrorsHelper.error_summary @download, "There is a problem with the form", ""
+        - if flash.alert.present?
+          %div{:class => 'error-summary', :role => 'alert'}
+            %h2{:class => %w(heading-medium error-summary-heading), :id => 'error-summary-heading'}= flash.alert[:title]
+            %p!="If the problem persists please contact  #{link_to 'support', support_path}" unless @download.errors.any?
+        %h3.heading-medium Help us improve registers
+        %p.text As a government service, we want to make sure GOV.UK Registers works for everyone. By providing this information you can help us to understand more about our users and improve our service. Read more in our #{link_to 'privacy notice', privacy_notice_path}.
 
-  .grid-row
-    .column-two-thirds
-      %hr
-      %h3.heading-medium Why we ask for this information
-      %p As a government service, we want to make sure GOV.UK Registers works for everyone. By providing this information you can help us to understand more about our users and improve our service. Read more in our #{link_to 'privacy notice', privacy_notice_path}.
+        = render 'form', user: @user

--- a/app/views/download/index.html.haml
+++ b/app/views/download/index.html.haml
@@ -16,6 +16,6 @@
             %h2{:class => %w(heading-medium error-summary-heading), :id => 'error-summary-heading'}= flash.alert[:title]
             %p!="If the problem persists please contact  #{link_to 'support', support_path}" unless @download.errors.any?
         %h3.heading-medium Help us improve registers
-        %p.text As a government service, we want to make sure GOV.UK Registers works for everyone. By providing this information you can help us to understand more about our users and improve our service. Read more in our #{link_to 'privacy notice', privacy_notice_path}.
+        %p.text We’d like to contact you on occasion to ask you questions about how you use Registers. Your feedback will help us improve our service and you can unsubscribe at any time. Read more in our #{link_to 'privacy notice', privacy_notice_path}.
 
         = render 'form', user: @user

--- a/app/views/download/show.html.haml
+++ b/app/views/download/show.html.haml
@@ -2,7 +2,11 @@
 
 %main#content{role: 'main'}
   .grid-row
-    .column-two-thirds
-      %h1.heading-large Your register download
-      %p{data: {'click-events' => true, 'click-category' => 'Content', 'click-action' => 'Register Download' }}
-        You can download the latest data in this register as a #{link_to 'CSV', register_download_csv_path(@register.slug)} and #{link_to 'JSON', register_download_json_path(@register.slug)} file.
+    .column-full
+      %h1.heading-large Download the #{@register.register_name} register
+      %p You can download the latest data in this register as:
+      %ul.list.list-bullet
+        %li= link_to 'CSV', register_download_csv_path(@register.slug)
+        %li= link_to 'JSON', register_download_json_path(@register.slug)
+      .participate
+        %p Thank you for helping us to improve GOV.UK Registers.

--- a/app/views/download/show.html.haml
+++ b/app/views/download/show.html.haml
@@ -1,4 +1,5 @@
-- @page_title = "Your Download"
+- @page_title = "Download - #{@register.register_name} register"
+- content_for :body_classes, 'api-key-page'
 
 %main#content{role: 'main'}
   .grid-row

--- a/app/views/registers/show.html.haml
+++ b/app/views/registers/show.html.haml
@@ -115,10 +115,8 @@
             .subsection__content.js-subsection-content#access_section
               %ul.list
                 %li= link_to 'Create API key', api_users_path(register: @register.slug)
-                %li Always access the most recent version of all registers through our API
-              %ul.list
-                %li= link_to 'Download the data', register_download_index_path(@register.slug)
-                %li Get the latest data in this register as a CSV file
+                %li Always access the most recent version of all registers through our API.
+              %p You can #{link_to 'download the latest data', register_download_index_path(@register.slug)} in this register as a CSV or JSON file.
           .subsection.js-subsection
             .subsection__header
               %h2.subsection__title Give feedback


### PR DESCRIPTION
### Context
Users don't like providing thier email address before getting a download of "open data".

### Changes proposed in this pull request
Allow download without providing any information 

### Guidance to review
Visit any register page, click access the data, click download the data

# After
<img width="1280" alt="screen shot 2018-05-30 at 14 55 58" src="https://user-images.githubusercontent.com/3071606/40724807-dc527b7a-6419-11e8-984c-cc3b8ae3c6ef.png">
<img width="1280" alt="screen shot 2018-05-30 at 14 55 43" src="https://user-images.githubusercontent.com/3071606/40724810-dc727498-6419-11e8-8599-3305e5ec9066.png">
