### PR TITLE
fix download validation rule

### DIFF
--- a/app/models/api_user.rb
+++ b/app/models/api_user.rb
@@ -5,6 +5,8 @@ class ApiUser
   attr_accessor :email_gov, :email_non_gov, :is_government, :contactable
 
   validates :contactable, presence: true, if: -> { is_government_boolean == true }
+  validates :email_gov, presence: true, email: true, if: -> { is_government_boolean == true }
+  validates :email_non_gov, allow_blank: true, email: true, if: -> { is_government_boolean == false }
 
   def is_contactable_boolean
     case contactable

--- a/app/models/concerns/form_concerns.rb
+++ b/app/models/concerns/form_concerns.rb
@@ -4,8 +4,6 @@ module FormConcerns
   extend ActiveSupport::Concern
   included do
     validates :is_government, presence: true
-    validates :email_gov, presence: true, email: true, if: -> { is_government_boolean == true }
-    validates :email_non_gov, allow_blank: true, email: true, if: -> { is_government_boolean == false }
 
     def email
       is_government_boolean ? email_gov : email_non_gov

--- a/app/models/download_user.rb
+++ b/app/models/download_user.rb
@@ -3,4 +3,7 @@ class DownloadUser
   include ActiveModel::Translation
   include FormConcerns
   attr_accessor :email_gov, :email_non_gov, :non_gov_use_category, :department, :is_government, :register
+
+  validates :email_gov, presence: true, email: true, if: -> { is_government_boolean == true }
+  validates :email_non_gov, presence: true, email: true, if: -> { is_government_boolean == false }
 end


### PR DESCRIPTION
### Context
there was a mismatch between validation rules enforced by frontend and selfservice in the download flow

### Changes proposed in this pull request
Email is always required when filling out the (optional) download form.

### Guidance to review
Should show frontend error if download form submitted without email.
