### PR TITLE
Add custodian method in register class

### DIFF
--- a/app/models/register.rb
+++ b/app/models/register.rb
@@ -64,6 +64,10 @@ class Register < ApplicationRecord
             .pluck("data -> 'register-name' as register_name").first || name
   end
 
+  def custodian
+    Record.where(register_id: id, entry_type: 'system', key: "custodian").pluck("data -> 'custodian' as text").first
+  end
+
 private
 
   def set_slug


### PR DESCRIPTION
### Context
Users would like to see the custodian name to aid in "trusting" the register

### Changes proposed in this pull request
Add a method so we can easily display in the UI

### Guidance to review
Add `= @register.custodian` to `registers#show`

# Demo
![screen shot 2018-06-04 at 10 32 59](https://user-images.githubusercontent.com/3071606/40909986-d8d45942-67e2-11e8-8afb-f09defab9110.png)
