### PR TITLE
Don't render access the data for non beta registers

### DIFF
--- a/app/views/registers/show.html.haml
+++ b/app/views/registers/show.html.haml
@@ -109,14 +109,15 @@
                       No results found.
                     - if params[:q].present? || params[:status].present?
                       = link_to 'Reset', register_path(@register.slug, anchor: 'search_wrapper'), class: 'reset-link'
-          .subsection.js-subsection
-            .subsection__header
-              %h2.subsection__title Access the data
-            .subsection__content.js-subsection-content#access_section
-              %ul.list
-                %li= link_to 'Create API key', api_users_path(register: @register.slug)
-                %li Always access the most recent version of all registers through our API.
-              %p You can #{link_to 'download the latest data', register_download_index_path(@register.slug)} in this register as a CSV or JSON file.
+          - if @register.register_phase == 'Beta'
+            .subsection.js-subsection
+              .subsection__header
+                %h2.subsection__title Access the data
+              .subsection__content.js-subsection-content#access_section
+                %ul.list
+                  %li= link_to 'Create API key', api_users_path(register: @register.slug)
+                  %li Always access the most recent version of all registers through our API.
+                %p You can #{link_to 'download the latest data', register_download_index_path(@register.slug)} in this register as a CSV or JSON file.
           .subsection.js-subsection
             .subsection__header
               %h2.subsection__title Give feedback


### PR DESCRIPTION
### Context
We don't want users accessing data that isn't ready to use.

### Changes proposed in this pull request
Hide "access the data" for all registers that arent ready for use

### Guidance to review

# After
<img width="746" alt="screen shot 2018-06-08 at 09 08 04" src="https://user-images.githubusercontent.com/3071606/41147545-92eca03c-6afe-11e8-923e-f4aee788bff6.png">
<img width="746" alt="screen shot 2018-06-08 at 09 07 59" src="https://user-images.githubusercontent.com/3071606/41147718-17cc61ac-6aff-11e8-96fc-ed3033ea2bc8.png">

