### PR TITLE
Honeypot field on feedback

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -65,6 +65,8 @@ gem 'httparty', '~> 0.16.2'
 # Canonical meta tag
 gem 'canonical-rails'
 
+gem 'invisible_captcha'
+
 group :development, :test do
   gem 'govuk-lint', '~> 3.8'
   gem 'pry-byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -157,6 +157,8 @@ GEM
     i18n (1.0.0)
       concurrent-ruby (~> 1.0)
     inflection (1.0.0)
+    invisible_captcha (0.10.0)
+      rails (>= 3.2.0)
     jbuilder (2.7.0)
       activesupport (>= 4.2.0)
       multi_json (>= 1.2)
@@ -385,6 +387,7 @@ DEPENDENCIES
   health_check (~> 2.7)
   http (= 2.2.1)
   httparty (~> 0.16.2)
+  invisible_captcha
   jbuilder (~> 2.5)
   jquery-rails
   jquery-ui-rails (~> 5.0, >= 5.0.5)

--- a/app/controllers/feedback_controller.rb
+++ b/app/controllers/feedback_controller.rb
@@ -1,10 +1,10 @@
 class FeedbackController < ApplicationController
   before_action :set_register
+  invisible_captcha only: :create, honeypot: :spam
 
   def create
     @feedback = Feedback.new(feedback_params)
 
-    redirect_to register_path(@register.slug) and return if params[:feedback][:spam].present?
     if @feedback.valid?
       if @feedback.message.present?
         @zendesk_service = ZendeskFeedback.new
@@ -29,8 +29,7 @@ private
       :email,
       :message,
       :useful,
-      :reason,
-      :spam
+      :reason
     )
   end
 end

--- a/app/controllers/feedback_controller.rb
+++ b/app/controllers/feedback_controller.rb
@@ -4,6 +4,7 @@ class FeedbackController < ApplicationController
   def create
     @feedback = Feedback.new(feedback_params)
 
+    redirect_to register_path(@register.slug) and return if params[:feedback][:spam].present?
     if @feedback.valid?
       if @feedback.message.present?
         @zendesk_service = ZendeskFeedback.new
@@ -28,7 +29,8 @@ private
       :email,
       :message,
       :useful,
-      :reason
+      :reason,
+      :spam
     )
   end
 end

--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -2,7 +2,7 @@ class Feedback
   include ActiveModel::Model
   include ActiveModel::Translation
 
-  attr_accessor :email, :message, :useful, :reason, :subject
+  attr_accessor :email, :message, :useful, :reason, :subject, :spam
 
   validates :useful, presence: true
   validates :reason, presence: true, if: -> { useful == "no" }

--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -2,7 +2,7 @@ class Feedback
   include ActiveModel::Model
   include ActiveModel::Translation
 
-  attr_accessor :email, :message, :useful, :reason, :subject, :spam
+  attr_accessor :email, :message, :useful, :reason, :subject
 
   validates :useful, presence: true
   validates :reason, presence: true, if: -> { useful == "no" }

--- a/app/views/feedback/_form.html.haml
+++ b/app/views/feedback/_form.html.haml
@@ -3,6 +3,7 @@
   .alert--success= flash[:success]
 
 = form_for @feedback, url: register_feedback_index_path(@register.slug, anchor: 'feedback_section')  do |f|
+  = f.hidden_field :spam
   = f.hidden_field :subject, value: "[Question or Feedback] #{@register.name} register"
   = f.radio_button_fieldset :useful do |fieldset|
     - fieldset.radio_input :yes

--- a/app/views/feedback/_form.html.haml
+++ b/app/views/feedback/_form.html.haml
@@ -3,7 +3,7 @@
   .alert--success= flash[:success]
 
 = form_for @feedback, url: register_feedback_index_path(@register.slug, anchor: 'feedback_section')  do |f|
-  = f.hidden_field :spam
+  = f.invisible_captcha :spam
   = f.hidden_field :subject, value: "[Question or Feedback] #{@register.name} register"
   = f.radio_button_fieldset :useful do |fieldset|
     - fieldset.radio_input :yes


### PR DESCRIPTION
### Context
Spam coming through to ZenDesk is causing unnecessary overhead to manage

### Changes proposed in this pull request
Add [invisible_captcha](https://github.com/markets/invisible_captcha) i.e. honeypot field to feedback form to fight spam

### Guidance to review

 If you inspect the element, untick the display-none which will show the field, out something the text_field and submit the form. The response should be `no content` but this [customisable](https://github.com/markets/invisible_captcha#usage) i.e. we could redirect to the homepage.

#### The DOM output
```
<div class="spam_1528453644">
<style media="screen">
.spam_1528453644 {position:absolute!important;height:1px;width:1px;overflow:hidden;}
</style>
<label for="feedback_spam">If you are a human, ignore this field</label>
<input type="text" name="feedback[spam]" id="feedback_spam" tabindex="-1">
</div>
```