### PR TITLE
Add single record resolver and record linking 🔗

### DIFF
--- a/app/controllers/registers_controller.rb
+++ b/app/controllers/registers_controller.rb
@@ -30,7 +30,7 @@ class RegistersController < ApplicationController
 
   def field_link_resolver(field, field_value, register_slug = @register.slug)
     single_resolver = lambda { |f, fv|
-      if f['register'].present? && f['register'] != register_slug
+      if f['register'].present? && f['field'] != register_slug
         link_to(fv, register_path(field['register'], record: fv, anchor: 'records_wrapper'))
       elsif f['datatype'] == 'url'
         link_to(fv, fv)

--- a/app/controllers/registers_controller.rb
+++ b/app/controllers/registers_controller.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 class RegistersController < ApplicationController
+  include ActionView::Helpers::UrlHelper
+  helper_method :record_link_resolver
+
   def index
     @registers = Register.available
                          .in_beta
@@ -23,6 +26,10 @@ class RegistersController < ApplicationController
     @register = Register.find_by_slug!(params[:id])
     @records = recover_records(@register.fields_array, params)
     @feedback = Feedback.new
+  end
+
+  def field_link_resolver(field, field_value)
+    field_value.is_a?(Array) ? field_value.join(', ') : link_to_if(field['datatype'] == 'url', field_value, field_value) || "<span class='unknown'>No data</span>".html_safe
   end
 
 private

--- a/app/controllers/registers_controller.rb
+++ b/app/controllers/registers_controller.rb
@@ -31,15 +31,13 @@ class RegistersController < ApplicationController
   def field_link_resolver(field, field_value)
     if field_value.is_a?(Array)
       field_value.join(', ')
-    elsif field['datatype'] == 'url' && field_value
+    elsif field['datatype'] == 'url'
       link_to(field_value, field_value)
-    elsif field['datatype'] == 'curie' && field_value
+    elsif field['datatype'] == 'curie'
       curie = field_value.split(':')
-      link_to(curie[0], register_path(curie[0])) + ':' + curie[1]
-    elsif field_value.present?
-      field_value
+      link_to(curie[0], register_path(curie[0])) + ':' + link_to(curie[1], register_path(curie[0], record: curie[1], anchor: 'records_wrapper'))
     else
-      "<span class='unknown'>No data</span>".html_safe
+      field_value
     end
   end
 
@@ -57,6 +55,7 @@ private
     @register.records
              .where(entry_type: 'user')
              .search_for(fields, params[:q])
+             .record(params[:record])
              .status(params[:status])
              .sort_by_field(sort_by, sort_direction)
              .page(params[:page])

--- a/app/controllers/registers_controller.rb
+++ b/app/controllers/registers_controller.rb
@@ -2,7 +2,7 @@
 
 class RegistersController < ApplicationController
   include ActionView::Helpers::UrlHelper
-  helper_method :record_link_resolver
+  helper_method :field_link_resolver
 
   def index
     @registers = Register.available
@@ -29,7 +29,18 @@ class RegistersController < ApplicationController
   end
 
   def field_link_resolver(field, field_value)
-    field_value.is_a?(Array) ? field_value.join(', ') : link_to_if(field['datatype'] == 'url', field_value, field_value) || "<span class='unknown'>No data</span>".html_safe
+    if field_value.is_a?(Array)
+      field_value.join(', ')
+    elsif field['datatype'] == 'url' && field_value
+      link_to(field_value, field_value)
+    elsif field['datatype'] == 'curie' && field_value
+      curie = field_value.split(':')
+      link_to(curie[0], register_path(curie[0])) + ':' + curie[1]
+    elsif field_value.present?
+      field_value
+    else
+      "<span class='unknown'>No data</span>".html_safe
+    end
   end
 
 private

--- a/app/controllers/registers_controller.rb
+++ b/app/controllers/registers_controller.rb
@@ -36,6 +36,8 @@ class RegistersController < ApplicationController
     elsif field['datatype'] == 'curie'
       curie = field_value.split(':')
       link_to(curie[0], register_path(curie[0])) + ':' + link_to(curie[1], register_path(curie[0], record: curie[1], anchor: 'records_wrapper'))
+    elsif field['register']
+      link_to(field_value, register_path(field['register'], record: field_value, anchor: 'records_wrapper'))
     else
       field_value
     end

--- a/app/controllers/registers_controller.rb
+++ b/app/controllers/registers_controller.rb
@@ -31,7 +31,7 @@ class RegistersController < ApplicationController
   def field_link_resolver(field, field_value, register_slug = @register.slug)
     single_resolver = lambda { |f, fv|
       if f['register'].present? && f['field'] != register_slug
-        link_to(fv, register_path(field['register'], record: fv, anchor: 'records_wrapper'))
+        link_to(fv, register_path(f['register'], record: fv, anchor: 'records_wrapper'))
       elsif f['datatype'] == 'url'
         link_to(fv, fv)
       elsif f['datatype'] == 'curie'

--- a/app/controllers/registers_controller.rb
+++ b/app/controllers/registers_controller.rb
@@ -31,7 +31,7 @@ class RegistersController < ApplicationController
   def field_link_resolver(field, field_value, register_slug = @register.slug)
     single_resolver = lambda { |f, fv|
       if f['register'].present? && f['register'] != register_slug
-        link_to(fv, register_path(field['register'], record: field_value, anchor: 'records_wrapper'))
+        link_to(fv, register_path(field['register'], record: fv, anchor: 'records_wrapper'))
       elsif f['datatype'] == 'url'
         link_to(fv, fv)
       elsif f['datatype'] == 'curie'

--- a/app/models/record.rb
+++ b/app/models/record.rb
@@ -17,4 +17,12 @@ class Record < ApplicationRecord
   scope :sort_by_field, lambda { |sort_by, sort_direction|
     order("data->> '#{sort_by}' #{sort_direction.upcase} nulls last")
   }
+
+  scope :record, lambda { |record|
+    if record.present?
+      where(
+        key: record
+        )
+    end
+  }
 end

--- a/app/views/registers/_record.html.haml
+++ b/app/views/registers/_record.html.haml
@@ -2,4 +2,4 @@
   - @register.register_fields.each do |field|
     - field_value = record.data[field['field']]
     %td
-      = field_value.is_a?(Array) ? field_value.join(', ') : link_to_if(field['datatype'] == 'url', field_value, field_value) || "<span class='unknown'>No data</span>".html_safe
+      = field_link_resolver(field, field_value)

--- a/app/views/registers/_record.html.haml
+++ b/app/views/registers/_record.html.haml
@@ -2,4 +2,4 @@
   - @register.register_fields.each do |field|
     - field_value = record.data[field['field']]
     %td
-      = field_link_resolver(field, field_value)
+      =  field_value ? field_link_resolver(field, field_value) :  "<span class='unknown'>No data</span>".html_safe

--- a/spec/controllers/registers_controller_spec.rb
+++ b/spec/controllers/registers_controller_spec.rb
@@ -201,4 +201,42 @@ RSpec.describe RegistersController, type: :controller do
       expect(assigns(:records).last.data['start-date']).to be_nil
     end
   end
+
+  describe 'URL datatype linking' do
+    it "links to external URL" do
+      field = { "text" => "The website for a register entry.", "field" => "website", "phase" => "beta", "datatype" => "url", "cardinality" => "1" }
+      field_value = "https://www.gov.uk/government/organisations/academy-for-justice-commissioning"
+      expect(subject.field_link_resolver(field, field_value, 'government-organisation')).to eq("<a href=\"https://www.gov.uk/government/organisations/academy-for-justice-commissioning\">https://www.gov.uk/government/organisations/academy-for-justice-commissioning</a>")
+    end
+  end
+
+  describe 'Register datatype linking' do
+    it "does not link primary key field" do
+      field = { "text" => "The unique code for a government organisation.", "field" => "government-organisation", "phase" => "beta", "datatype" => "string", "register" => "government-organisation", "cardinality" => "1" }
+      field_value = "D13"
+      expect(subject.field_link_resolver(field, field_value, 'government-organisation')).to eq("D13")
+    end
+
+    it "links register type fields" do
+      field = { "text" => "The unique code for a government organisation.", "field" => "government-organisation", "phase" => "beta", "datatype" => "string", "register" => "government-organisation", "cardinality" => "1" }
+      field_value = "D13"
+      expect(subject.field_link_resolver(field, field_value, 'government-service')).to eq("<a href=\"/registers/government-organisation?record=D13#records_wrapper\">D13</a>")
+    end
+  end
+
+  describe 'CURIE datatype linking' do
+    it "links both sides of a CURIE" do
+      field = { "text" => "The unique code for a government organisation.", "field" => "government-organisation", "phase" => "beta", "datatype" => "string", "register" => "government-organisation", "cardinality" => "1" }
+      field_value = "D13"
+      expect(subject.field_link_resolver(field, field_value, 'government-organisation')).to eq("D13")
+    end
+  end
+
+  describe 'Cardinality N linking' do
+    it "links each field value in cardinality N fields" do
+      field = { "text" => "The classes that a charity falls into.", "field" => "charity-classes", "phase" => "discovery", "datatype" => "string", "register" => "charity-class", "cardinality" => "n" }
+      field_value = %w[307 302 301 207 103 102 101]
+      expect(subject.field_link_resolver(field, field_value, 'charity')).to eq("<a href=\"/registers/charity-class?record=307#records_wrapper\">307</a>, <a href=\"/registers/charity-class?record=302#records_wrapper\">302</a>, <a href=\"/registers/charity-class?record=301#records_wrapper\">301</a>, <a href=\"/registers/charity-class?record=207#records_wrapper\">207</a>, <a href=\"/registers/charity-class?record=103#records_wrapper\">103</a>, <a href=\"/registers/charity-class?record=102#records_wrapper\">102</a>, <a href=\"/registers/charity-class?record=101#records_wrapper\">101</a>")
+    end
+  end
 end


### PR DESCRIPTION
### Context
Previously the frontend did not show any links between records.

### Changes proposed in this pull request
* Adds single record key lookup using `record` query parameter
* Adds links for register type fields and CURIEs
* resolves all links for cardinality N fields
![single record linking](https://user-images.githubusercontent.com/1764158/41166595-8b3de140-6b38-11e8-937d-493d3dbd1c43.gif)

### Guidance to review
All links should resolve as long as corresponding registers are loaded 


