### PR TITLE
Fix load more link

### DIFF
--- a/app/views/registers/show.js.erb
+++ b/app/views/registers/show.js.erb
@@ -4,5 +4,5 @@ $("#records-count").html('Showing <strong>1 &ndash; <%= @records.count + @record
 <% if @records.last_page? %>
   $("#load-more-records").hide();
 <% else %>
-  $("#load-more-records").replaceWith("<%= escape_javascript(link_to_next_page @records, 'Load more', id: 'load-more-records', class: 'js-hidden', remote: true) %>");
+  $("#load-more-records").replaceWith("<%= escape_javascript(link_to_next_page @records, 'Load more', id: 'load-more-records', class: 'js-load-more', remote: true) %>");
 <% end %>


### PR DESCRIPTION
### Context
The load more link was not displayed after the first click

### Changes proposed in this pull request
Fix css class that was hiding the link

### Guidance to review
Any register page with more than 200 records. Scroll to the button and click load more, you should still see the load more link 