### PR TITLE
Only show registers with records in alpha and beta in the sitemap

### DIFF
--- a/app/controllers/sitemaps_controller.rb
+++ b/app/controllers/sitemaps_controller.rb
@@ -1,5 +1,5 @@
 class SitemapsController < ApplicationController
   def show
-    @registers = Register.where(register_phase: %w[Alpha Beta]).has_records.sort_by_phase_name_asc.by_name
+    @registers = Register.where(register_phase: %w[Alpha Beta]).has_records
   end
 end

--- a/app/controllers/sitemaps_controller.rb
+++ b/app/controllers/sitemaps_controller.rb
@@ -1,5 +1,5 @@
 class SitemapsController < ApplicationController
   def show
-    @registers = Register.sort_by_phase_name_asc.by_name
+    @registers = Register.where(register_phase: %w[Alpha Beta]).has_records.sort_by_phase_name_asc.by_name
   end
 end


### PR DESCRIPTION
### Context
The sitemap was referencing registers that aren't good enough to display on Google or to our users

### Changes proposed in this pull request
Only show registers in `alpha` and `beta` that also have `records` in the sitemap

### Guidance to review
`/sitemap.xml`