### PR TITLE
add government email validation

### DIFF
--- a/app/models/api_user.rb
+++ b/app/models/api_user.rb
@@ -5,7 +5,7 @@ class ApiUser
   attr_accessor :email_gov, :email_non_gov, :is_government, :contactable
 
   validates :contactable, presence: true, if: -> { is_government_boolean == true }
-  validates :email_gov, presence: true, email: true, if: -> { is_government_boolean == true }
+  validates :email_gov, presence: true, email: true, gov_email: true, if: -> { is_government_boolean == true }
   validates :email_non_gov, allow_blank: true, email: true, if: -> { is_government_boolean == false }
 
   def is_contactable_boolean

--- a/app/models/download_user.rb
+++ b/app/models/download_user.rb
@@ -4,6 +4,6 @@ class DownloadUser
   include FormConcerns
   attr_accessor :email_gov, :email_non_gov, :non_gov_use_category, :department, :is_government, :register
 
-  validates :email_gov, presence: true, email: true, if: -> { is_government_boolean == true }
+  validates :email_gov, presence: true, email: true, gov_email: true, if: -> { is_government_boolean == true }
   validates :email_non_gov, presence: true, email: true, if: -> { is_government_boolean == false }
 end

--- a/app/validators/gov_email_validator.rb
+++ b/app/validators/gov_email_validator.rb
@@ -1,0 +1,45 @@
+class GovEmailValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    gov_domains = [
+      'gov.uk',
+      'mod.uk',
+      'mil.uk',
+      'ddc-mod.org',
+      'slc.co.uk',
+      'gov.scot',
+      'parliament.uk',
+      'nhs.uk',
+      'nhs.net',
+      'police.uk',
+      'dclgdatamart.co.uk',
+      'ucds.email',
+      'naturalengland.org.uk',
+      'hmcts.net',
+      'scotent.co.uk',
+      'assembly.wales',
+      'cjsm.net',
+      'cqc.org.uk',
+      'bl.uk',
+      'wmfs.net',
+      'bbsrc.ac.uk',
+      'acas.org.uk',
+      'gov.wales',
+      'biglotteryfund.org.uk',
+      'marinemanagement.org.uk',
+      'britishmuseum.org',
+      'derrystrabane.com',
+      'highwaysengland.co.uk',
+      'ac.uk',
+      'esfrs.org',
+      'tfgm.com',
+      'nationalgalleries.org',
+      'cynulliad.cymru',
+      'llyw.cymru',
+      'judiciary.uk'
+    ]
+
+    unless gov_domains.any? { |gd| value.end_with?(gd) }
+      record.errors[attribute] << 'Enter a government email address'
+    end
+  end
+end

--- a/spec/features/api_user_spec.rb
+++ b/spec/features/api_user_spec.rb
@@ -16,7 +16,7 @@ RSpec.feature 'API Key Registration', type: :feature do
 
     stub_request(:post, "https://registers-selfservice.cloudapps.digital/users").
     with(
-      body: "email=test%40example.com&is_government=true&contactable=true",
+      body: "email=test%40gov.uk&is_government=true&contactable=true",
       headers: {
       'Accept' => '*/*',
       'Authorization' => 'Basic dXNlcm5hbWU6cGFzc3dvcmQ=',
@@ -33,7 +33,7 @@ RSpec.feature 'API Key Registration', type: :feature do
   scenario 'valid submission generates API key' do
     expect(page).to have_content('Create your API key')
     choose('api_user[is_government]', option: "yes")
-    fill_in('api_user_email_gov', with: 'test@example.com')
+    fill_in('api_user_email_gov', with: 'test@gov.uk')
     choose('api_user[contactable]', option: "yes")
     first(:css, 'input[data-link-name="new_api_user_submit"]').click
     expect(page).to have_content('Your API key')


### PR DESCRIPTION
### Context
Previously we did not sanity check government email addresses

### Changes proposed in this pull request
Add government domain check, based on that done by Pay and Notify.

### Guidance to review
Non government email should fail validation, validation should only apply if user selects is_government true option. 
![screen shot 2018-06-13 at 13 04 11](https://user-images.githubusercontent.com/1764158/41350425-04a7415e-6f0b-11e8-89cc-7fd331468962.png)