### PR TITLE
Disallow query params from google bots

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -48,6 +48,7 @@ module ApplicationHelper
                                                  .to_h.merge(sort_direction: direction,
                                                  sort_by: field_value,
                                                  anchor: 'search_wrapper')),
-                                                 class: css_class
+                                                 class: css_class,
+                                                 rel: 'canonical'
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -48,7 +48,6 @@ module ApplicationHelper
                                                  .to_h.merge(sort_direction: direction,
                                                  sort_by: field_value,
                                                  anchor: 'search_wrapper')),
-                                                 class: css_class,
-                                                 rel: 'canonical'
+                                                 class: css_class
   end
 end

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -4,7 +4,6 @@
 # User-agent: *
 # Disallow: /
 Disallow: /admin
-Disallow: /*?*
 
 
 Sitemap: https://www.registers.service.gov.uk/sitemap.xml

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -4,5 +4,7 @@
 # User-agent: *
 # Disallow: /
 Disallow: /admin
+Disallow: /*?*
+
 
 Sitemap: https://www.registers.service.gov.uk/sitemap.xml

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,4 +1,5 @@
 User-agent: *
 Disallow: /admin
+Disallow: /*?*
 
 Sitemap: https://www.registers.service.gov.uk/sitemap.xml

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,9 +1,4 @@
-# See http://www.robotstxt.org/robotstxt.html for documentation on how to use the robots.txt file
-#
-# To ban all spiders from the entire site uncomment the next two lines:
-# User-agent: *
-# Disallow: /
+User-agent: *
 Disallow: /admin
-
 
 Sitemap: https://www.registers.service.gov.uk/sitemap.xml


### PR DESCRIPTION
### Context
We have a number of query params when searching/filtering register data which causes duplicate content issues on Google Search

### Changes proposed in this pull request
Don't allow Google bots to crawl query params

### Guidance to review
