### PR TITLE
Add meta description and seo title for register pages

### DIFF
--- a/app/controllers/admin/registers_controller.rb
+++ b/app/controllers/admin/registers_controller.rb
@@ -68,7 +68,9 @@ module Admin
                                         :contextual_data,
                                         :related_registers,
                                         :url,
-                                        :position)
+                                        :position,
+                                        :seo_title,
+                                        :meta_description)
     end
   end
 end

--- a/app/views/admin/registers/_form.html.haml
+++ b/app/views/admin/registers/_form.html.haml
@@ -9,6 +9,10 @@
     = f.select :authority, @government_organisations.all.collect{ |org| [org.data['name'], org.key] }, {}, class: 'form-control'
   = f.text_area :contextual_data
   = f.text_area :related_registers
+  %hr
+  %h2.heading-medium SEO
+  = f.text_field :seo_title
+  = f.text_area :meta_description
   .form-group
     = f.submit 'Save', class: 'button'
 

--- a/app/views/admin/registers/edit.html.haml
+++ b/app/views/admin/registers/edit.html.haml
@@ -1,4 +1,4 @@
-- @page_title = '#{@register.name} | Admin'
+- @page_title = "#{@register.name} | Admin"
 
 %nav.breadcrumbs{"aria-label" => "Breadcrumb"}
   %ol

--- a/app/views/registers/show.html.haml
+++ b/app/views/registers/show.html.haml
@@ -1,5 +1,5 @@
-- @page_title = "#{@register.seo_title.present? ? @register.seo_title : @register.register_name + ' register'}"
-- @page_description = "#{@register.meta_description.present? ? @register.meta_description : @register.register_description}"
+- @page_title = "#{[@register.seo_title, @register.register_name].find(&:present?)}"
+- @page_description = "#{[@register.meta_description, @register.register_description].find(&:present?)}"
 - content_for :body_classes, 'register-show'
 
 %nav.breadcrumbs{role: "Navigation", "aria-label" => "Breadcrumb"}

--- a/app/views/registers/show.html.haml
+++ b/app/views/registers/show.html.haml
@@ -1,5 +1,5 @@
-- @page_title = "#{@register.register_name} register"
-- @page_description = @register.register_description
+- @page_title = "#{@register.seo_title.present? ? @register.seo_title : @register.register_name + ' register'}"
+- @page_description = "#{@register.meta_description.present? ? @register.meta_description : @register.register_description}"
 - content_for :body_classes, 'register-show'
 
 %nav.breadcrumbs{role: "Navigation", "aria-label" => "Breadcrumb"}

--- a/app/views/registers/show.html.haml
+++ b/app/views/registers/show.html.haml
@@ -1,4 +1,4 @@
-- @page_title = "#{[@register.seo_title, @register.register_name].find(&:present?)}"
+- @page_title = "#{[@register.seo_title, @register.register_name + ' register'].find(&:present?)}"
 - @page_description = "#{[@register.meta_description, @register.register_description].find(&:present?)}"
 - content_for :body_classes, 'register-show'
 

--- a/db/migrate/20180614064846_add_seo_fields_to_registers.rb
+++ b/db/migrate/20180614064846_add_seo_fields_to_registers.rb
@@ -1,0 +1,6 @@
+class AddSeoFieldsToRegisters < ActiveRecord::Migration[5.1]
+  def change
+    add_column :registers, :seo_title, :string
+    add_column :registers, :meta_description, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180611121537) do
+ActiveRecord::Schema.define(version: 20180614064846) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -73,6 +73,8 @@ ActiveRecord::Schema.define(version: 20180611121537) do
     t.string "root_hash"
     t.text "fields_array", array: true
     t.integer "position"
+    t.string "seo_title"
+    t.text "meta_description"
   end
 
   create_table "users", id: :serial, force: :cascade do |t|


### PR DESCRIPTION
### Context
We want to add a Google friendly seo title and meta description

### Changes proposed in this pull request
Add additional fields into the admin to enable the ability of an seo title and meta description

### Guidance to review
`/admin` edit any register to add an seo title and meta description