### PR TITLE
Remove scheduler and queue apps from research manifest

### DIFF
--- a/manifest-research.yml
+++ b/manifest-research.yml
@@ -12,13 +12,3 @@ applications:
 - name: registers-frontend-research
   <<: *defaults
   instances: 2
-- name: registers-frontend-queue
-  <<: *defaults
-  instances: 1
-  command: bundle exec 'rake environment jobs:work'
-  health-check-type: process
-- name: registers-frontend-scheduler
-  <<: *defaults
-  instances: 1
-  command: bundle exec clockwork 'lib/clock.rb'
-  health-check-type: process


### PR DESCRIPTION
### Context
We don't run these for the research app as we can manually load registers when we need them.

### Changes proposed in this pull request
Remove scheduler and queue apps from research manifest.

### Guidance to review
