### PR TITLE
restore fields in self-service POST

### DIFF
--- a/app/controllers/concerns/form_helpers.rb
+++ b/app/controllers/concerns/form_helpers.rb
@@ -22,6 +22,8 @@ def post_to_endpoint(user, endpoint = 'users')
   @user = { email: user.email,
             is_government: user.is_government_boolean,
             register: user.try(:register),
+            non_gov_use_category: user.try(:non_gov_use_category),
+            department: user.try(:department),
             contactable: user.try(:is_contactable_boolean) }
             .compact
   uri = URI.parse("#{Rails.configuration.self_service_api_host}/#{endpoint}")


### PR DESCRIPTION
### Context
Fix regression introduced in: https://github.com/openregister/registers-frontend/commit/67421d274d13a9c57c3535b33b5dc6320fd04e29 and spotted in https://github.com/openregister/registers-selfservice/pull/27#issuecomment-397659004

### Changes proposed in this pull request
restore `department` and `non_gov_use_category` fields in registers-selfservice POST

### Guidance to review
Check fields are included in POST to self-service

Note: I think we could add a test for this regression but I would rather get this out first and think about it as a follow-up task.
