### PR TITLE
Update Docker base image to ruby 2.5.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.5.0
+FROM ruby:2.5.1
 
 RUN apt-get update -qq \
   && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
### Context

Docker fails to build due the Gemfile.lock having a dependency on ruby 2.5.1 and bundler 1.6.2.

### Changes proposed in this pull request

Update Docker base image to ruby 2.5.1 to align with current dependencies.

### Guidance to review

`docker-compose build` should succeed.