### PR TITLE
Remove wildcard query param from robots.txt

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,5 +1,4 @@
 User-agent: *
 Disallow: /admin
-Disallow: /*?*
 
 Sitemap: https://www.registers.service.gov.uk/sitemap.xml


### PR DESCRIPTION
### Changes proposed in this pull request
Googlebot doesn't like this syntax so the file isn't being picked up correctly

### Guidance to review
`/robots.txt`