### PR TITLE
Add GA event tracking for register formats

### DIFF
--- a/app/views/download/index.html.haml
+++ b/app/views/download/index.html.haml
@@ -6,7 +6,7 @@
     .column-full
       %h1.heading-large Download the #{@register.register_name} register
       %p You can download the latest data in this register as:
-      %ul.list.list-bullet
+      %ul.list.list-bullet{data: {"click-events" => true, "click-category" => "Content", "click-action" => "Register Download"}}
         %li= link_to 'CSV', register_download_csv_path(@register.slug)
         %li= link_to 'JSON', register_download_json_path(@register.slug)
       .participate#participation_section

--- a/app/views/download/show.html.haml
+++ b/app/views/download/show.html.haml
@@ -6,7 +6,7 @@
     .column-full
       %h1.heading-large Download the #{@register.register_name} register
       %p You can download the latest data in this register as:
-      %ul.list.list-bullet
+      %ul.list.list-bullet{data: {"click-events" => true, "click-category" => "Content", "click-action" => "Register Download"}}
         %li= link_to 'CSV', register_download_csv_path(@register.slug)
         %li= link_to 'JSON', register_download_json_path(@register.slug)
       .participate


### PR DESCRIPTION
### Context
We want to track downloaded formats

### Changes proposed in this pull request
Add GA event tracking to download links

### Guidance to review
# After

<img width="1391" alt="screen shot 2018-06-19 at 11 55 48" src="https://user-images.githubusercontent.com/3071606/41593457-0079a822-73b8-11e8-886a-a0ad582d7bda.png">
