### PR TITLE
Add fields above table view

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -538,3 +538,7 @@ details {
     }
   }
 }
+
+.details--fields {
+  margin: 0 0 10px 0;
+}

--- a/app/views/registers/show.html.haml
+++ b/app/views/registers/show.html.haml
@@ -75,11 +75,23 @@
                             = submit_tag 'Search', name: nil, class: 'button filter-search-submit'
 
               - if @records.present?
-                .records-count
-                  %span#records-count
-                    = render partial: 'showing'
-                  - if params[:q].present? || params[:status].present?
-                    = link_to 'Reset', register_path(@register.slug, anchor: 'records_wrapper'), class: 'reset-link'
+                .grid-row
+                  .column-two-thirds
+                    .records-count
+                      %span#records-count
+                        = render partial: 'showing'
+                      - if params[:q].present? || params[:status].present?
+                        = link_to 'Reset', register_path(@register.slug, anchor: 'records_wrapper'), class: 'reset-link'
+                  .column-one-third
+                    %details.details--fields{role: "group"}
+                      %summary{"aria-controls" => "details-content-1", "aria-expanded" => "false", :role => "button"}
+                        %span.summary What do these field names mean?
+                      #details-content-1.panel.panel-border-narrow{"aria-hidden" => "true"}
+                        - @register.register_fields.each do |field|
+                          %p.font-xsmall
+                            %strong= field['field']
+                            %br
+                            = field['text']
 
                 .fullscreen-content{data: {module: 'scrolling-tables'}}
                   %table.table.register-data-table


### PR DESCRIPTION
### Context
User want to see field descriptions

### Changes proposed in this pull request
Add field descriptions into show view, above table

### Guidance to review
Any register page

# After
<img width="827" alt="screen shot 2018-06-25 at 13 03 36" src="https://user-images.githubusercontent.com/3071606/41854674-ba04e05c-7888-11e8-8a3a-67574ce2b81b.png">
<img width="827" alt="screen shot 2018-06-25 at 13 03 34" src="https://user-images.githubusercontent.com/3071606/41854675-ba1ec0da-7888-11e8-9887-0844e6479dc5.png">
