### PR TITLE
Add route and view for fields

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -12,6 +12,7 @@
 //
 //= require jquery
 //= require jquery_ujs
+//= require dialog-polyfill
 //= require govuk/modules
 //= require scrolling-tables
 //= require gaap-analytics

--- a/app/assets/javascripts/dialog-polyfill.js
+++ b/app/assets/javascripts/dialog-polyfill.js
@@ -1,0 +1,740 @@
+// https://github.com/GoogleChrome/dialog-polyfill
+
+(function() {
+
+  // nb. This is for IE10 and lower _only_.
+  var supportCustomEvent = window.CustomEvent;
+  if (!supportCustomEvent || typeof supportCustomEvent === 'object') {
+    supportCustomEvent = function CustomEvent(event, x) {
+      x = x || {};
+      var ev = document.createEvent('CustomEvent');
+      ev.initCustomEvent(event, !!x.bubbles, !!x.cancelable, x.detail || null);
+      return ev;
+    };
+    supportCustomEvent.prototype = window.Event.prototype;
+  }
+
+  /**
+   * @param {Element} el to check for stacking context
+   * @return {boolean} whether this el or its parents creates a stacking context
+   */
+  function createsStackingContext(el) {
+    while (el && el !== document.body) {
+      var s = window.getComputedStyle(el);
+      var invalid = function(k, ok) {
+        return !(s[k] === undefined || s[k] === ok);
+      }
+      if (s.opacity < 1 ||
+          invalid('zIndex', 'auto') ||
+          invalid('transform', 'none') ||
+          invalid('mixBlendMode', 'normal') ||
+          invalid('filter', 'none') ||
+          invalid('perspective', 'none') ||
+          s['isolation'] === 'isolate' ||
+          s.position === 'fixed' ||
+          s.webkitOverflowScrolling === 'touch') {
+        return true;
+      }
+      el = el.parentElement;
+    }
+    return false;
+  }
+
+  /**
+   * Finds the nearest <dialog> from the passed element.
+   *
+   * @param {Element} el to search from
+   * @return {HTMLDialogElement} dialog found
+   */
+  function findNearestDialog(el) {
+    while (el) {
+      if (el.localName === 'dialog') {
+        return /** @type {HTMLDialogElement} */ (el);
+      }
+      el = el.parentElement;
+    }
+    return null;
+  }
+
+  /**
+   * Blur the specified element, as long as it's not the HTML body element.
+   * This works around an IE9/10 bug - blurring the body causes Windows to
+   * blur the whole application.
+   *
+   * @param {Element} el to blur
+   */
+  function safeBlur(el) {
+    if (el && el.blur && el !== document.body) {
+      el.blur();
+    }
+  }
+
+  /**
+   * @param {!NodeList} nodeList to search
+   * @param {Node} node to find
+   * @return {boolean} whether node is inside nodeList
+   */
+  function inNodeList(nodeList, node) {
+    for (var i = 0; i < nodeList.length; ++i) {
+      if (nodeList[i] === node) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * @param {HTMLFormElement} el to check
+   * @return {boolean} whether this form has method="dialog"
+   */
+  function isFormMethodDialog(el) {
+    if (!el || !el.hasAttribute('method')) {
+      return false;
+    }
+    return el.getAttribute('method').toLowerCase() === 'dialog';
+  }
+
+  /**
+   * @param {!HTMLDialogElement} dialog to upgrade
+   * @constructor
+   */
+  function dialogPolyfillInfo(dialog) {
+    this.dialog_ = dialog;
+    this.replacedStyleTop_ = false;
+    this.openAsModal_ = false;
+
+    // Set a11y role. Browsers that support dialog implicitly know this already.
+    if (!dialog.hasAttribute('role')) {
+      dialog.setAttribute('role', 'dialog');
+    }
+
+    dialog.show = this.show.bind(this);
+    dialog.showModal = this.showModal.bind(this);
+    dialog.close = this.close.bind(this);
+
+    if (!('returnValue' in dialog)) {
+      dialog.returnValue = '';
+    }
+
+    if ('MutationObserver' in window) {
+      var mo = new MutationObserver(this.maybeHideModal.bind(this));
+      mo.observe(dialog, {attributes: true, attributeFilter: ['open']});
+    } else {
+      // IE10 and below support. Note that DOMNodeRemoved etc fire _before_ removal. They also
+      // seem to fire even if the element was removed as part of a parent removal. Use the removed
+      // events to force downgrade (useful if removed/immediately added).
+      var removed = false;
+      var cb = function() {
+        removed ? this.downgradeModal() : this.maybeHideModal();
+        removed = false;
+      }.bind(this);
+      var timeout;
+      var delayModel = function(ev) {
+        if (ev.target !== dialog) { return; }  // not for a child element
+        var cand = 'DOMNodeRemoved';
+        removed |= (ev.type.substr(0, cand.length) === cand);
+        window.clearTimeout(timeout);
+        timeout = window.setTimeout(cb, 0);
+      };
+      ['DOMAttrModified', 'DOMNodeRemoved', 'DOMNodeRemovedFromDocument'].forEach(function(name) {
+        dialog.addEventListener(name, delayModel);
+      });
+    }
+    // Note that the DOM is observed inside DialogManager while any dialog
+    // is being displayed as a modal, to catch modal removal from the DOM.
+
+    Object.defineProperty(dialog, 'open', {
+      set: this.setOpen.bind(this),
+      get: dialog.hasAttribute.bind(dialog, 'open')
+    });
+
+    this.backdrop_ = document.createElement('div');
+    this.backdrop_.className = 'backdrop';
+    this.backdrop_.addEventListener('click', this.backdropClick_.bind(this));
+  }
+
+  dialogPolyfillInfo.prototype = {
+
+    get dialog() {
+      return this.dialog_;
+    },
+
+    /**
+     * Maybe remove this dialog from the modal top layer. This is called when
+     * a modal dialog may no longer be tenable, e.g., when the dialog is no
+     * longer open or is no longer part of the DOM.
+     */
+    maybeHideModal: function() {
+      if (this.dialog_.hasAttribute('open') && document.body.contains(this.dialog_)) { return; }
+      this.downgradeModal();
+    },
+
+    /**
+     * Remove this dialog from the modal top layer, leaving it as a non-modal.
+     */
+    downgradeModal: function() {
+      if (!this.openAsModal_) { return; }
+      this.openAsModal_ = false;
+      this.dialog_.style.zIndex = '';
+
+      // This won't match the native <dialog> exactly because if the user set top on a centered
+      // polyfill dialog, that top gets thrown away when the dialog is closed. Not sure it's
+      // possible to polyfill this perfectly.
+      if (this.replacedStyleTop_) {
+        this.dialog_.style.top = '';
+        this.replacedStyleTop_ = false;
+      }
+
+      // Clear the backdrop and remove from the manager.
+      this.backdrop_.parentNode && this.backdrop_.parentNode.removeChild(this.backdrop_);
+      dialogPolyfill.dm.removeDialog(this);
+    },
+
+    /**
+     * @param {boolean} value whether to open or close this dialog
+     */
+    setOpen: function(value) {
+      if (value) {
+        this.dialog_.hasAttribute('open') || this.dialog_.setAttribute('open', '');
+      } else {
+        this.dialog_.removeAttribute('open');
+        this.maybeHideModal();  // nb. redundant with MutationObserver
+      }
+    },
+
+    /**
+     * Handles clicks on the fake .backdrop element, redirecting them as if
+     * they were on the dialog itself.
+     *
+     * @param {!Event} e to redirect
+     */
+    backdropClick_: function(e) {
+      if (!this.dialog_.hasAttribute('tabindex')) {
+        // Clicking on the backdrop should move the implicit cursor, even if dialog cannot be
+        // focused. Create a fake thing to focus on. If the backdrop was _before_ the dialog, this
+        // would not be needed - clicks would move the implicit cursor there.
+        var fake = document.createElement('div');
+        this.dialog_.insertBefore(fake, this.dialog_.firstChild);
+        fake.tabIndex = -1;
+        fake.focus();
+        this.dialog_.removeChild(fake);
+      } else {
+        this.dialog_.focus();
+      }
+
+      var redirectedEvent = document.createEvent('MouseEvents');
+      redirectedEvent.initMouseEvent(e.type, e.bubbles, e.cancelable, window,
+          e.detail, e.screenX, e.screenY, e.clientX, e.clientY, e.ctrlKey,
+          e.altKey, e.shiftKey, e.metaKey, e.button, e.relatedTarget);
+      this.dialog_.dispatchEvent(redirectedEvent);
+      e.stopPropagation();
+    },
+
+    /**
+     * Focuses on the first focusable element within the dialog. This will always blur the current
+     * focus, even if nothing within the dialog is found.
+     */
+    focus_: function() {
+      // Find element with `autofocus` attribute, or fall back to the first form/tabindex control.
+      var target = this.dialog_.querySelector('[autofocus]:not([disabled])');
+      if (!target && this.dialog_.tabIndex >= 0) {
+        target = this.dialog_;
+      }
+      if (!target) {
+        // Note that this is 'any focusable area'. This list is probably not exhaustive, but the
+        // alternative involves stepping through and trying to focus everything.
+        var opts = ['button', 'input', 'keygen', 'select', 'textarea'];
+        var query = opts.map(function(el) {
+          return el + ':not([disabled])';
+        });
+        // TODO(samthor): tabindex values that are not numeric are not focusable.
+        query.push('[tabindex]:not([disabled]):not([tabindex=""])');  // tabindex != "", not disabled
+        target = this.dialog_.querySelector(query.join(', '));
+      }
+      safeBlur(document.activeElement);
+      target && target.focus();
+    },
+
+    /**
+     * Sets the zIndex for the backdrop and dialog.
+     *
+     * @param {number} dialogZ
+     * @param {number} backdropZ
+     */
+    updateZIndex: function(dialogZ, backdropZ) {
+      if (dialogZ < backdropZ) {
+        throw new Error('dialogZ should never be < backdropZ');
+      }
+      this.dialog_.style.zIndex = dialogZ;
+      this.backdrop_.style.zIndex = backdropZ;
+    },
+
+    /**
+     * Shows the dialog. If the dialog is already open, this does nothing.
+     */
+    show: function() {
+      if (!this.dialog_.open) {
+        this.setOpen(true);
+        this.focus_();
+      }
+    },
+
+    /**
+     * Show this dialog modally.
+     */
+    showModal: function() {
+      if (this.dialog_.hasAttribute('open')) {
+        throw new Error('Failed to execute \'showModal\' on dialog: The element is already open, and therefore cannot be opened modally.');
+      }
+      if (!document.body.contains(this.dialog_)) {
+        throw new Error('Failed to execute \'showModal\' on dialog: The element is not in a Document.');
+      }
+      if (!dialogPolyfill.dm.pushDialog(this)) {
+        throw new Error('Failed to execute \'showModal\' on dialog: There are too many open modal dialogs.');
+      }
+
+      if (createsStackingContext(this.dialog_.parentElement)) {
+        console.warn('A dialog is being shown inside a stacking context. ' +
+            'This may cause it to be unusable. For more information, see this link: ' +
+            'https://github.com/GoogleChrome/dialog-polyfill/#stacking-context');
+      }
+
+      this.setOpen(true);
+      this.openAsModal_ = true;
+
+      // Optionally center vertically, relative to the current viewport.
+      if (dialogPolyfill.needsCentering(this.dialog_)) {
+        dialogPolyfill.reposition(this.dialog_);
+        this.replacedStyleTop_ = true;
+      } else {
+        this.replacedStyleTop_ = false;
+      }
+
+      // Insert backdrop.
+      this.dialog_.parentNode.insertBefore(this.backdrop_, this.dialog_.nextSibling);
+
+      // Focus on whatever inside the dialog.
+      this.focus_();
+    },
+
+    /**
+     * Closes this HTMLDialogElement. This is optional vs clearing the open
+     * attribute, however this fires a 'close' event.
+     *
+     * @param {string=} opt_returnValue to use as the returnValue
+     */
+    close: function(opt_returnValue) {
+      if (!this.dialog_.hasAttribute('open')) {
+        throw new Error('Failed to execute \'close\' on dialog: The element does not have an \'open\' attribute, and therefore cannot be closed.');
+      }
+      this.setOpen(false);
+
+      // Leave returnValue untouched in case it was set directly on the element
+      if (opt_returnValue !== undefined) {
+        this.dialog_.returnValue = opt_returnValue;
+      }
+
+      // Triggering "close" event for any attached listeners on the <dialog>.
+      var closeEvent = new supportCustomEvent('close', {
+        bubbles: false,
+        cancelable: false
+      });
+      this.dialog_.dispatchEvent(closeEvent);
+    }
+
+  };
+
+  var dialogPolyfill = {};
+
+  dialogPolyfill.reposition = function(element) {
+    var scrollTop = document.body.scrollTop || document.documentElement.scrollTop;
+    var topValue = scrollTop + (window.innerHeight - element.offsetHeight) / 2;
+    element.style.top = Math.max(scrollTop, topValue) + 'px';
+  };
+
+  dialogPolyfill.isInlinePositionSetByStylesheet = function(element) {
+    for (var i = 0; i < document.styleSheets.length; ++i) {
+      var styleSheet = document.styleSheets[i];
+      var cssRules = null;
+      // Some browsers throw on cssRules.
+      try {
+        cssRules = styleSheet.cssRules;
+      } catch (e) {}
+      if (!cssRules) { continue; }
+      for (var j = 0; j < cssRules.length; ++j) {
+        var rule = cssRules[j];
+        var selectedNodes = null;
+        // Ignore errors on invalid selector texts.
+        try {
+          selectedNodes = document.querySelectorAll(rule.selectorText);
+        } catch(e) {}
+        if (!selectedNodes || !inNodeList(selectedNodes, element)) {
+          continue;
+        }
+        var cssTop = rule.style.getPropertyValue('top');
+        var cssBottom = rule.style.getPropertyValue('bottom');
+        if ((cssTop && cssTop !== 'auto') || (cssBottom && cssBottom !== 'auto')) {
+          return true;
+        }
+      }
+    }
+    return false;
+  };
+
+  dialogPolyfill.needsCentering = function(dialog) {
+    var computedStyle = window.getComputedStyle(dialog);
+    if (computedStyle.position !== 'absolute') {
+      return false;
+    }
+
+    // We must determine whether the top/bottom specified value is non-auto.  In
+    // WebKit/Blink, checking computedStyle.top == 'auto' is sufficient, but
+    // Firefox returns the used value. So we do this crazy thing instead: check
+    // the inline style and then go through CSS rules.
+    if ((dialog.style.top !== 'auto' && dialog.style.top !== '') ||
+        (dialog.style.bottom !== 'auto' && dialog.style.bottom !== '')) {
+      return false;
+    }
+    return !dialogPolyfill.isInlinePositionSetByStylesheet(dialog);
+  };
+
+  /**
+   * @param {!Element} element to force upgrade
+   */
+  dialogPolyfill.forceRegisterDialog = function(element) {
+    if (window.HTMLDialogElement || element.showModal) {
+      console.warn('This browser already supports <dialog>, the polyfill ' +
+          'may not work correctly', element);
+    }
+    if (element.localName !== 'dialog') {
+      throw new Error('Failed to register dialog: The element is not a dialog.');
+    }
+    new dialogPolyfillInfo(/** @type {!HTMLDialogElement} */ (element));
+  };
+
+  /**
+   * @param {!Element} element to upgrade, if necessary
+   */
+  dialogPolyfill.registerDialog = function(element) {
+    if (!element.showModal) {
+      dialogPolyfill.forceRegisterDialog(element);
+    }
+  };
+
+  /**
+   * @constructor
+   */
+  dialogPolyfill.DialogManager = function() {
+    /** @type {!Array<!dialogPolyfillInfo>} */
+    this.pendingDialogStack = [];
+
+    var checkDOM = this.checkDOM_.bind(this);
+
+    // The overlay is used to simulate how a modal dialog blocks the document.
+    // The blocking dialog is positioned on top of the overlay, and the rest of
+    // the dialogs on the pending dialog stack are positioned below it. In the
+    // actual implementation, the modal dialog stacking is controlled by the
+    // top layer, where z-index has no effect.
+    this.overlay = document.createElement('div');
+    this.overlay.className = '_dialog_overlay';
+    this.overlay.addEventListener('click', function(e) {
+      this.forwardTab_ = undefined;
+      e.stopPropagation();
+      checkDOM([]);  // sanity-check DOM
+    }.bind(this));
+
+    this.handleKey_ = this.handleKey_.bind(this);
+    this.handleFocus_ = this.handleFocus_.bind(this);
+
+    this.zIndexLow_ = 100000;
+    this.zIndexHigh_ = 100000 + 150;
+
+    this.forwardTab_ = undefined;
+
+    if ('MutationObserver' in window) {
+      this.mo_ = new MutationObserver(function(records) {
+        var removed = [];
+        records.forEach(function(rec) {
+          for (var i = 0, c; c = rec.removedNodes[i]; ++i) {
+            if (!(c instanceof Element)) {
+              continue;
+            } else if (c.localName === 'dialog') {
+              removed.push(c);
+            }
+            removed = removed.concat(c.querySelectorAll('dialog'));
+          }
+        });
+        removed.length && checkDOM(removed);
+      });
+    }
+  };
+
+  /**
+   * Called on the first modal dialog being shown. Adds the overlay and related
+   * handlers.
+   */
+  dialogPolyfill.DialogManager.prototype.blockDocument = function() {
+    document.documentElement.addEventListener('focus', this.handleFocus_, true);
+    document.addEventListener('keydown', this.handleKey_);
+    this.mo_ && this.mo_.observe(document, {childList: true, subtree: true});
+  };
+
+  /**
+   * Called on the first modal dialog being removed, i.e., when no more modal
+   * dialogs are visible.
+   */
+  dialogPolyfill.DialogManager.prototype.unblockDocument = function() {
+    document.documentElement.removeEventListener('focus', this.handleFocus_, true);
+    document.removeEventListener('keydown', this.handleKey_);
+    this.mo_ && this.mo_.disconnect();
+  };
+
+  /**
+   * Updates the stacking of all known dialogs.
+   */
+  dialogPolyfill.DialogManager.prototype.updateStacking = function() {
+    var zIndex = this.zIndexHigh_;
+
+    for (var i = 0, dpi; dpi = this.pendingDialogStack[i]; ++i) {
+      dpi.updateZIndex(--zIndex, --zIndex);
+      if (i === 0) {
+        this.overlay.style.zIndex = --zIndex;
+      }
+    }
+
+    // Make the overlay a sibling of the dialog itself.
+    var last = this.pendingDialogStack[0];
+    if (last) {
+      var p = last.dialog.parentNode || document.body;
+      p.appendChild(this.overlay);
+    } else if (this.overlay.parentNode) {
+      this.overlay.parentNode.removeChild(this.overlay);
+    }
+  };
+
+  /**
+   * @param {Element} candidate to check if contained or is the top-most modal dialog
+   * @return {boolean} whether candidate is contained in top dialog
+   */
+  dialogPolyfill.DialogManager.prototype.containedByTopDialog_ = function(candidate) {
+    while (candidate = findNearestDialog(candidate)) {
+      for (var i = 0, dpi; dpi = this.pendingDialogStack[i]; ++i) {
+        if (dpi.dialog === candidate) {
+          return i === 0;  // only valid if top-most
+        }
+      }
+      candidate = candidate.parentElement;
+    }
+    return false;
+  };
+
+  dialogPolyfill.DialogManager.prototype.handleFocus_ = function(event) {
+    if (this.containedByTopDialog_(event.target)) { return; }
+
+    event.preventDefault();
+    event.stopPropagation();
+    safeBlur(/** @type {Element} */ (event.target));
+
+    if (this.forwardTab_ === undefined) { return; }  // move focus only from a tab key
+
+    var dpi = this.pendingDialogStack[0];
+    var dialog = dpi.dialog;
+    var position = dialog.compareDocumentPosition(event.target);
+    if (position & Node.DOCUMENT_POSITION_PRECEDING) {
+      if (this.forwardTab_) {  // forward
+        dpi.focus_();
+      } else {  // backwards
+        document.documentElement.focus();
+      }
+    } else {
+      // TODO: Focus after the dialog, is ignored.
+    }
+
+    return false;
+  };
+
+  dialogPolyfill.DialogManager.prototype.handleKey_ = function(event) {
+    this.forwardTab_ = undefined;
+    if (event.keyCode === 27) {
+      event.preventDefault();
+      event.stopPropagation();
+      var cancelEvent = new supportCustomEvent('cancel', {
+        bubbles: false,
+        cancelable: true
+      });
+      var dpi = this.pendingDialogStack[0];
+      if (dpi && dpi.dialog.dispatchEvent(cancelEvent)) {
+        dpi.dialog.close();
+      }
+    } else if (event.keyCode === 9) {
+      this.forwardTab_ = !event.shiftKey;
+    }
+  };
+
+  /**
+   * Finds and downgrades any known modal dialogs that are no longer displayed. Dialogs that are
+   * removed and immediately readded don't stay modal, they become normal.
+   *
+   * @param {!Array<!HTMLDialogElement>} removed that have definitely been removed
+   */
+  dialogPolyfill.DialogManager.prototype.checkDOM_ = function(removed) {
+    // This operates on a clone because it may cause it to change. Each change also calls
+    // updateStacking, which only actually needs to happen once. But who removes many modal dialogs
+    // at a time?!
+    var clone = this.pendingDialogStack.slice();
+    clone.forEach(function(dpi) {
+      if (removed.indexOf(dpi.dialog) !== -1) {
+        dpi.downgradeModal();
+      } else {
+        dpi.maybeHideModal();
+      }
+    });
+  };
+
+  /**
+   * @param {!dialogPolyfillInfo} dpi
+   * @return {boolean} whether the dialog was allowed
+   */
+  dialogPolyfill.DialogManager.prototype.pushDialog = function(dpi) {
+    var allowed = (this.zIndexHigh_ - this.zIndexLow_) / 2 - 1;
+    if (this.pendingDialogStack.length >= allowed) {
+      return false;
+    }
+    if (this.pendingDialogStack.unshift(dpi) === 1) {
+      this.blockDocument();
+    }
+    this.updateStacking();
+    return true;
+  };
+
+  /**
+   * @param {!dialogPolyfillInfo} dpi
+   */
+  dialogPolyfill.DialogManager.prototype.removeDialog = function(dpi) {
+    var index = this.pendingDialogStack.indexOf(dpi);
+    if (index === -1) { return; }
+
+    this.pendingDialogStack.splice(index, 1);
+    if (this.pendingDialogStack.length === 0) {
+      this.unblockDocument();
+    }
+    this.updateStacking();
+  };
+
+  dialogPolyfill.dm = new dialogPolyfill.DialogManager();
+  dialogPolyfill.formSubmitter = null;
+  dialogPolyfill.useValue = null;
+
+  /**
+   * Installs global handlers, such as click listers and native method overrides. These are needed
+   * even if a no dialog is registered, as they deal with <form method="dialog">.
+   */
+  if (window.HTMLDialogElement === undefined) {
+
+    /**
+     * If HTMLFormElement translates method="DIALOG" into 'get', then replace the descriptor with
+     * one that returns the correct value.
+     */
+    var testForm = document.createElement('form');
+    testForm.setAttribute('method', 'dialog');
+    if (testForm.method !== 'dialog') {
+      var methodDescriptor = Object.getOwnPropertyDescriptor(HTMLFormElement.prototype, 'method');
+      if (methodDescriptor) {
+        // nb. Some older iOS and older PhantomJS fail to return the descriptor. Don't do anything
+        // and don't bother to update the element.
+        var realGet = methodDescriptor.get;
+        methodDescriptor.get = function() {
+          if (isFormMethodDialog(this)) {
+            return 'dialog';
+          }
+          return realGet.call(this);
+        };
+        var realSet = methodDescriptor.set;
+        methodDescriptor.set = function(v) {
+          if (typeof v === 'string' && v.toLowerCase() === 'dialog') {
+            return this.setAttribute('method', v);
+          }
+          return realSet.call(this, v);
+        };
+        Object.defineProperty(HTMLFormElement.prototype, 'method', methodDescriptor);
+      }
+    }
+
+    /**
+     * Global 'click' handler, to capture the <input type="submit"> or <button> element which has
+     * submitted a <form method="dialog">. Needed as Safari and others don't report this inside
+     * document.activeElement.
+     */
+    document.addEventListener('click', function(ev) {
+      dialogPolyfill.formSubmitter = null;
+      dialogPolyfill.useValue = null;
+      if (ev.defaultPrevented) { return; }  // e.g. a submit which prevents default submission
+
+      var target = /** @type {Element} */ (ev.target);
+      if (!target || !isFormMethodDialog(target.form)) { return; }
+
+      var valid = (target.type === 'submit' && ['button', 'input'].indexOf(target.localName) > -1);
+      if (!valid) {
+        if (!(target.localName === 'input' && target.type === 'image')) { return; }
+        // this is a <input type="image">, which can submit forms
+        dialogPolyfill.useValue = ev.offsetX + ',' + ev.offsetY;
+      }
+
+      var dialog = findNearestDialog(target);
+      if (!dialog) { return; }
+
+      dialogPolyfill.formSubmitter = target;
+    }, false);
+
+    /**
+     * Replace the native HTMLFormElement.submit() method, as it won't fire the
+     * submit event and give us a chance to respond.
+     */
+    var nativeFormSubmit = HTMLFormElement.prototype.submit;
+    var replacementFormSubmit = function () {
+      if (!isFormMethodDialog(this)) {
+        return nativeFormSubmit.call(this);
+      }
+      var dialog = findNearestDialog(this);
+      dialog && dialog.close();
+    };
+    HTMLFormElement.prototype.submit = replacementFormSubmit;
+
+    /**
+     * Global form 'dialog' method handler. Closes a dialog correctly on submit
+     * and possibly sets its return value.
+     */
+    document.addEventListener('submit', function(ev) {
+      var form = /** @type {HTMLFormElement} */ (ev.target);
+      if (!isFormMethodDialog(form)) { return; }
+      ev.preventDefault();
+
+      var dialog = findNearestDialog(form);
+      if (!dialog) { return; }
+
+      // Forms can only be submitted via .submit() or a click (?), but anyway: sanity-check that
+      // the submitter is correct before using its value as .returnValue.
+      var s = dialogPolyfill.formSubmitter;
+      if (s && s.form === form) {
+        dialog.close(dialogPolyfill.useValue || s.value);
+      } else {
+        dialog.close();
+      }
+      dialogPolyfill.formSubmitter = null;
+    }, true);
+  }
+
+  dialogPolyfill['forceRegisterDialog'] = dialogPolyfill.forceRegisterDialog;
+  dialogPolyfill['registerDialog'] = dialogPolyfill.registerDialog;
+
+  if (typeof define === 'function' && 'amd' in define) {
+    // AMD support
+    define(function() { return dialogPolyfill; });
+  } else if (typeof module === 'object' && typeof module['exports'] === 'object') {
+    // CommonJS support
+    module['exports'] = dialogPolyfill;
+  } else {
+    // all others
+    window['dialogPolyfill'] = dialogPolyfill;
+  }
+})();

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -30,6 +30,7 @@
 @import 'modules/accessible-autocomplete';
 @import 'modules/subsections';
 @import 'modules/scrolling-tables';
+@import 'modules/dialog';
 
 // From alphagov/static
 @import 'govuk_component/organisation-logo';

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -187,6 +187,7 @@ table {
     font-weight: normal;
     min-width: 280px;
     padding: 15px 30px 15px 15px;
+    position: relative;
     vertical-align: middle;
 
     &.start-date,
@@ -199,6 +200,22 @@ table {
     &:last-child {
       border-right: 0;
     }
+  }
+
+  .info-icon {
+    background-color: $govuk-blue;
+    border-radius: 50%;
+    color: $white;
+    display: inline-block;
+    font-weight: bold;
+    height: 25px;
+    line-height: 1.7;
+    position: absolute;
+    right: 12px;
+    text-align: center;
+    text-decoration: none;
+    top: 12px;
+    width: 25px;
   }
 
   td {

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -187,7 +187,7 @@ table {
     border-right: 2px solid $white;
     font-weight: normal;
     min-width: 280px;
-    padding: 15px 30px 15px 15px;
+    padding: 15px 45px 15px 15px;
     position: relative;
     vertical-align: middle;
 

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -200,6 +200,7 @@ table {
 
     &:last-child {
       border-right: 0;
+      padding-right: 45px;
     }
   }
 

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -187,7 +187,7 @@ table {
     border-right: 2px solid $white;
     font-weight: normal;
     min-width: 280px;
-    padding: 15px 45px 15px 15px;
+    padding: 15px 55px 15px 15px;
     position: relative;
     vertical-align: middle;
 
@@ -200,7 +200,7 @@ table {
 
     &:last-child {
       border-right: 0;
-      padding-right: 45px;
+      padding-right: 55px;
     }
   }
 

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -217,6 +217,11 @@ table {
     text-decoration: none;
     top: 12px;
     width: 25px;
+
+    &:focus,
+    &:hover {
+      color: $white;
+    }
   }
 
   td {

--- a/app/assets/stylesheets/modules/_dialog.scss
+++ b/app/assets/stylesheets/modules/_dialog.scss
@@ -49,6 +49,7 @@
     background: none;
     border: none;
     color: $govuk-blue;
+    cursor: pointer;
     font-size: 16px;
     position: absolute;
     right: 15px;

--- a/app/assets/stylesheets/modules/_dialog.scss
+++ b/app/assets/stylesheets/modules/_dialog.scss
@@ -59,6 +59,7 @@
 
   &__inner {
     padding: 20px;
+
     @include media(tablet) {
       padding: 30px;
     }
@@ -103,7 +104,7 @@
     }
   }
 
-  #dialog-title {
+  .heading-large {
     margin-top: 0;
   }
 }
@@ -114,10 +115,12 @@
 }
 
 // Modal dialog polyfill styles
-$dialog_backdrop_colour: rgba(0,0,0,0.8);
-$dialog_border: 5px solid black;
+$dialog-backdrop-colour: rgba(0, 0, 0, 0.8);
+$dialog-border: 5px solid $black;
+
 dialog {
-  left: 0; right: 0;
+  left: 0;
+  right: 0;
   width: -moz-fit-content;
   width: -webkit-fit-content;
   width: fit-content;
@@ -125,17 +128,20 @@ dialog {
   height: -webkit-fit-content;
   height: fit-content;
   margin: auto;
-  border: solid;
+  border-style: solid;
   padding: 1em;
-  background: white;
-  color: black;
+  background: $white;
+  color: $black;
   display: none;
-  border: $dialog_border;
+  border: $dialog-border;
 
-  & + .backdrop {
+  + .backdrop {
     position: fixed;
-    top: 0; right: 0; bottom: 0; left: 0;
-    background: $dialog_backdrop_colour;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    background: $dialog-backdrop-colour;
   }
 
   &[open] {
@@ -144,6 +150,7 @@ dialog {
     margin: 0 auto;
     padding: 15px;
     width: 90%;
+
     @include media(tablet) {
       padding: 30px;
       margin: 30px auto;
@@ -151,13 +158,13 @@ dialog {
     }
 
     // Backdrop styles for browsers using polyfil
-    &+ .backdrop {
-      background: $dialog_backdrop_colour;
+    + .backdrop {
+      background: $dialog-backdrop-colour;
     }
     // Backdrop styles for browsers with native support
     // NB: keep these two backdrop styles separate - safari didn't work when combined
     &::backdrop {
-      background: $dialog_backdrop_colour;
+      background: $dialog-backdrop-colour;
     }
   }
 }

--- a/app/assets/stylesheets/modules/_dialog.scss
+++ b/app/assets/stylesheets/modules/_dialog.scss
@@ -1,0 +1,163 @@
+.modal-dialog {
+  // Don't display modal if user doesn't have js. Can be overriden with .modal-dialog--no-js-persistent
+  display: none;
+
+  &--no-js-persistent {
+    display: inline-block;
+
+    .js-enabled & {
+      display: none;
+
+      &[open] {
+        display: inline-block;
+        z-index: 9999;
+      }
+
+      .dialog-button {
+        display: inline-block;
+      }
+    }
+  }
+
+  .js-enabled &[open] {
+    display: inline-block;
+  }
+
+  &[open] {
+    overflow-x: hidden;
+    overflow-y: auto;
+    max-height: 90vh; //Don't make the dialog quite the viewport height
+    padding: 0;
+    margin-bottom: 0;
+    margin-top: 0;
+
+    // From https://github.com/GoogleChrome/dialog-polyfill to vertically center dialog
+    position: fixed;
+    top: 50% !important;
+    -webkit-transform: translate(0, -50%);
+    -ms-transform: translate(0, -50%);
+    transform: translate(0, -50%);
+
+    z-index: 999;
+
+    @include media(tablet) {
+      padding: 0;
+    }
+  }
+
+  &__close {
+    background: none;
+    border: none;
+    color: $govuk-blue;
+    font-size: 16px;
+    position: absolute;
+    right: 15px;
+    text-decoration: underline;
+    top: 15px;
+    -webkit-appearance: none;
+  }
+
+  &__inner {
+    padding: 20px;
+    @include media(tablet) {
+      padding: 30px;
+    }
+
+    &__text {
+      @include copy-19;
+      margin-bottom: 20px;
+    }
+
+    &__button {
+      font-size: 19px;
+    }
+
+    &__link {
+      @include copy-19;
+      background: none;
+      border: none;
+      vertical-align: middle;
+      margin-top: 20px;
+
+      @include media(mobile) {
+        text-align: center;
+        display: block;
+        margin-top: 25px;
+      }
+
+      @include media(tablet) {
+        position: absolute;
+        top: 50%;
+        transform: translateY(-50%);
+        padding: 0;
+        margin: 0 0 0 30px;
+      }
+
+      &:hover {
+        cursor: pointer;
+      }
+    }
+
+    &__block {
+      position: relative;
+    }
+  }
+
+  #dialog-title {
+    margin-top: 0;
+  }
+}
+
+// Stop background scrolling while dialog open.
+.dialog-is-open {
+  overflow: hidden;
+}
+
+// Modal dialog polyfill styles
+$dialog_backdrop_colour: rgba(0,0,0,0.8);
+$dialog_border: 5px solid black;
+dialog {
+  left: 0; right: 0;
+  width: -moz-fit-content;
+  width: -webkit-fit-content;
+  width: fit-content;
+  height: -moz-fit-content;
+  height: -webkit-fit-content;
+  height: fit-content;
+  margin: auto;
+  border: solid;
+  padding: 1em;
+  background: white;
+  color: black;
+  display: none;
+  border: $dialog_border;
+
+  & + .backdrop {
+    position: fixed;
+    top: 0; right: 0; bottom: 0; left: 0;
+    background: $dialog_backdrop_colour;
+  }
+
+  &[open] {
+    display: block;
+    box-sizing: border-box;
+    margin: 0 auto;
+    padding: 15px;
+    width: 90%;
+    @include media(tablet) {
+      padding: 30px;
+      margin: 30px auto;
+      max-width: 500px;
+    }
+
+    // Backdrop styles for browsers using polyfil
+    &+ .backdrop {
+      background: $dialog_backdrop_colour;
+    }
+    // Backdrop styles for browsers with native support
+    // NB: keep these two backdrop styles separate - safari didn't work when combined
+    &::backdrop {
+      background: $dialog_backdrop_colour;
+    }
+  }
+}

--- a/app/assets/stylesheets/modules/_dialog.scss
+++ b/app/assets/stylesheets/modules/_dialog.scss
@@ -52,9 +52,9 @@
     cursor: pointer;
     font-size: 16px;
     position: absolute;
-    right: 15px;
+    right: 10px;
     text-decoration: underline;
-    top: 15px;
+    top: 10px;
     -webkit-appearance: none;
   }
 
@@ -66,47 +66,8 @@
     }
 
     &__text {
-      @include copy-19;
-      margin-bottom: 20px;
+      margin-bottom: 0;
     }
-
-    &__button {
-      font-size: 19px;
-    }
-
-    &__link {
-      @include copy-19;
-      background: none;
-      border: none;
-      vertical-align: middle;
-      margin-top: 20px;
-
-      @include media(mobile) {
-        text-align: center;
-        display: block;
-        margin-top: 25px;
-      }
-
-      @include media(tablet) {
-        position: absolute;
-        top: 50%;
-        transform: translateY(-50%);
-        padding: 0;
-        margin: 0 0 0 30px;
-      }
-
-      &:hover {
-        cursor: pointer;
-      }
-    }
-
-    &__block {
-      position: relative;
-    }
-  }
-
-  .heading-large {
-    margin-top: 0;
   }
 }
 

--- a/app/assets/stylesheets/modules/_sorting-link.scss
+++ b/app/assets/stylesheets/modules/_sorting-link.scss
@@ -12,8 +12,8 @@
   &.active {
     background-color: $govuk-blue;
     color: $white;
-    margin: -15px -45px -15px -15px;
-    padding: 15px 45px 15px 15px;
+    margin: -15px -55px -15px -15px;
+    padding: 15px 55px 15px 15px;
 
     + .info-icon {
       background: $white;

--- a/app/assets/stylesheets/modules/_sorting-link.scss
+++ b/app/assets/stylesheets/modules/_sorting-link.scss
@@ -14,6 +14,11 @@
     color: $white;
     margin: -15px -30px -15px -15px;
     padding: 15px 30px 15px 15px;
+
+    + .info-icon {
+      background: $white;
+      color: $govuk-blue;
+    }
   }
 }
 

--- a/app/assets/stylesheets/modules/_sorting-link.scss
+++ b/app/assets/stylesheets/modules/_sorting-link.scss
@@ -18,6 +18,11 @@
     + .info-icon {
       background: $white;
       color: $govuk-blue;
+
+      &:focus,
+      &:hover {
+        color: $govuk-blue;
+      }
     }
   }
 }

--- a/app/assets/stylesheets/modules/_sorting-link.scss
+++ b/app/assets/stylesheets/modules/_sorting-link.scss
@@ -12,8 +12,8 @@
   &.active {
     background-color: $govuk-blue;
     color: $white;
-    margin: -15px -30px -15px -15px;
-    padding: 15px 30px 15px 15px;
+    margin: -15px -45px -15px -15px;
+    padding: 15px 45px 15px 15px;
 
     + .info-icon {
       background: $white;

--- a/app/controllers/fields_controller.rb
+++ b/app/controllers/fields_controller.rb
@@ -1,0 +1,7 @@
+class FieldsController < ApplicationController
+  def show
+    @register = Register.find_by_slug!(params[:register_id])
+
+    @field = Record.where(register_id: @register.id, key: "field:#{params[:id]}").first
+  end
+end

--- a/app/views/fields/_field.html.haml
+++ b/app/views/fields/_field.html.haml
@@ -1,2 +1,2 @@
-%h1.heading-large= @field.data['field'].tr('-', ' ').humanize
-%p= @field.data['text']
+%p.modal-dialog__inner__text.bold-small= @field.data['field'].tr('-', ' ').humanize
+%p.modal-dialog__inner__text= @field.data['text']

--- a/app/views/fields/_field.html.haml
+++ b/app/views/fields/_field.html.haml
@@ -1,0 +1,2 @@
+%h1.heading-large= @field.data['field'].tr('-', ' ').humanize
+%p= @field.data['text']

--- a/app/views/fields/show.html.haml
+++ b/app/views/fields/show.html.haml
@@ -4,4 +4,5 @@
   .grid-row
     .column-full
       = link_to 'Back', register_path(@register.slug), class: 'link-back'
-      = render partial: 'field'
+      %h1.heading-large= @field.data['field'].tr('-', ' ').humanize
+      %p= @field.data['text']

--- a/app/views/fields/show.html.haml
+++ b/app/views/fields/show.html.haml
@@ -4,5 +4,4 @@
   .grid-row
     .column-full
       = link_to 'Back', register_path(@register.slug), class: 'link-back'
-      %h1.heading-large= @field.data['field'].tr('-', ' ').humanize
-      %p= @field.data['text']
+      = render partial: 'field'

--- a/app/views/fields/show.html.haml
+++ b/app/views/fields/show.html.haml
@@ -1,0 +1,8 @@
+- @page_title = "#{@register.name} - #{@field.data['field'].tr('-', ' ').humanize}"
+
+%main#content.container{role:'main'}
+  .grid-row
+    .column-full
+      = link_to 'Back', register_path(@register.slug), class: 'link-back'
+      %h1.heading-large= @field.data['field'].tr('-', ' ').humanize
+      %p= @field.data['text']

--- a/app/views/fields/show.js.erb
+++ b/app/views/fields/show.js.erb
@@ -23,11 +23,22 @@ dialog.setAttribute('aria-hidden', 'false');
 // Focus on close link
 dialogClose.focus();
 
-// Function to close dialog when close link is clicked
+// Close dialog when close link is clicked
 dialogClose.addEventListener('click', function() {
   dialog.close();
   dialog.setAttribute('aria-hidden', 'true');
   setFocusBackOnTarget();
+});
+
+// Close dialog when backdrop is clicked
+// https://stackoverflow.com/questions/25864259/how-to-close-the-new-html-dialog-tag-by-clicking-on-its-backdrop
+dialog.addEventListener('click', function (event) {
+  var rect = dialog.getBoundingClientRect();
+  var isInDialog = (rect.top <= event.clientY && event.clientY <= rect.top + rect.height && rect.left <= event.clientX && event.clientX <= rect.left + rect.width);
+  if (!isInDialog) {
+    dialog.close();
+    dialog.setAttribute('aria-hidden', 'true');
+  }
 });
 
 // Set focus back on clicked element on ESC key

--- a/app/views/fields/show.js.erb
+++ b/app/views/fields/show.js.erb
@@ -1,6 +1,21 @@
+// TODO: Refactor into GOV.UK JS Module
+
 var dialog = document.getElementById('modal_dialog');
 var dlalogContent = dialog.querySelectorAll('.modal-dialog__inner')[0];
 var dialogClose = dialog.querySelectorAll('.modal-dialog__close')[0];
+
+function initDialog() {
+  // Render field partial in dialog
+  dlalogContent.innerHTML = "<%= escape_javascript render(partial: 'fields/field') %>";
+
+  // Fix dialog for non-supporting browsers
+  dialogPolyfill.registerDialog(dialog);
+
+  // Open dialog
+  dialog.showModal();
+
+  isDialogOpen();
+}
 
 function setFocusBackOnTarget() {
   var targetUrl = "<%= register_field_url(@register.slug, @field.data['field']) %>";
@@ -8,26 +23,27 @@ function setFocusBackOnTarget() {
   targetElement.focus();
 }
 
-// Render field partial in dialog
-dlalogContent.innerHTML = "<%= escape_javascript render(partial: 'fields/field') %>";
+function isDialogOpen() {
+  if (dialog.open) {
+    dialog.setAttribute('aria-hidden', 'false');
 
-// Fix dialog for non-supporting browsers
-dialogPolyfill.registerDialog(dialog);
+    // Focus on close link
+    dialogClose.focus();
+  } else {
 
-// Open dialog
-dialog.showModal();
+    dialog.setAttribute('aria-hidden', 'true');
 
-// Update aria-hidden value
-dialog.setAttribute('aria-hidden', 'false');
+    // Focus back on clicked element
+    setFocusBackOnTarget();
+  }
+}
 
-// Focus on close link
-dialogClose.focus();
+initDialog();
 
 // Close dialog when close link is clicked
 dialogClose.addEventListener('click', function() {
   dialog.close();
-  dialog.setAttribute('aria-hidden', 'true');
-  setFocusBackOnTarget();
+  isDialogOpen();
 });
 
 // Close dialog when backdrop is clicked
@@ -37,13 +53,14 @@ dialog.addEventListener('click', function (event) {
   var isInDialog = (rect.top <= event.clientY && event.clientY <= rect.top + rect.height && rect.left <= event.clientX && event.clientX <= rect.left + rect.width);
   if (!isInDialog) {
     dialog.close();
-    dialog.setAttribute('aria-hidden', 'true');
+    isDialogOpen();
   }
 });
 
 // Set focus back on clicked element on ESC key
 document.addEventListener('keyup', function(e) {
   if (e.keyCode == 27) {
-    setFocusBackOnTarget();
+    dialog.close();
+    isDialogOpen();
   }
 });

--- a/app/views/fields/show.js.erb
+++ b/app/views/fields/show.js.erb
@@ -1,0 +1,24 @@
+var dialog = document.getElementById('modal_dialog');
+var dlalogContent = dialog.querySelectorAll('.modal-dialog__inner')[0];
+var dialogClose = dialog.querySelectorAll('.modal-dialog__close')[0];
+
+// Render field partial in dialog
+dlalogContent.innerHTML = "<%= escape_javascript render(partial: 'fields/field') %>";
+
+// Fix dialog for non-supporting browsers
+dialogPolyfill.registerDialog(dialog);
+
+// Open dialog
+dialog.showModal();
+
+// Update aria-hidden value
+dialog.setAttribute('aria-hidden', 'false');
+
+// Focus on close link
+dialogClose.focus();
+
+// Function to close dialog when close link is clicked
+dialogClose.addEventListener('click', function() {
+  dialog.close();
+  dialog.setAttribute('aria-hidden', 'true');
+});

--- a/app/views/fields/show.js.erb
+++ b/app/views/fields/show.js.erb
@@ -2,6 +2,12 @@ var dialog = document.getElementById('modal_dialog');
 var dlalogContent = dialog.querySelectorAll('.modal-dialog__inner')[0];
 var dialogClose = dialog.querySelectorAll('.modal-dialog__close')[0];
 
+function setFocusBackOnTarget() {
+  var targetUrl = "<%= register_field_url(@register.slug, @field.data['field']) %>";
+  var targetElement = document.querySelectorAll('[href="' + targetUrl + '"]')[0];
+  targetElement.focus();
+}
+
 // Render field partial in dialog
 dlalogContent.innerHTML = "<%= escape_javascript render(partial: 'fields/field') %>";
 
@@ -21,4 +27,12 @@ dialogClose.focus();
 dialogClose.addEventListener('click', function() {
   dialog.close();
   dialog.setAttribute('aria-hidden', 'true');
+  setFocusBackOnTarget();
+});
+
+// Set focus back on clicked element on ESC key
+document.addEventListener('keyup', function(e) {
+  if (e.keyCode == 27) {
+    setFocusBackOnTarget();
+  }
 });

--- a/app/views/registers/show.html.haml
+++ b/app/views/registers/show.html.haml
@@ -88,7 +88,7 @@
                         - @register.register_fields.each do |field|
                           %th{class: "#{field['field']}"}
                             = field['cardinality'] == '1' ? records_table_sort_link(field['field'], request.query_parameters) : field['field'].tr('-', ' ').humanize
-                            = link_to '?', register_field_path(@register.slug, field['field']), class: 'info-icon'
+                            = link_to '?', register_field_path(@register.slug, field['field']), class: 'info-icon', remote: true, "aria-label" => "What does #{field['field']} mean?"
                     %tbody#records-tbody
                       = render partial: 'record', collection: @records
 
@@ -124,6 +124,10 @@
               %h2.subsection__title Give feedback
             .subsection__content.js-subsection-content#feedback_section
               = render partial: 'feedback/form'
+
+%dialog#modal_dialog.modal-dialog.dialog{role: "dialog", "aria-hidden" => "true", "aria-labelledby" => "dialog-title"}
+  %button{type: 'button', class: 'modal-dialog__close', "aria-label" => "Close dialog"} Close
+  .modal-dialog__inner
 
 = content_for :javascript do
   :javascript

--- a/app/views/registers/show.html.haml
+++ b/app/views/registers/show.html.haml
@@ -88,7 +88,10 @@
                         - @register.register_fields.each do |field|
                           %th{class: "#{field['field']}"}
                             = field['cardinality'] == '1' ? records_table_sort_link(field['field'], request.query_parameters) : field['field'].tr('-', ' ').humanize
-                            = link_to '?', register_field_path(@register.slug, field['field']), class: 'info-icon', remote: true, "aria-label" => "What does #{field['field']} mean?"
+                            = link_to register_field_url(@register.slug, field['field']), class: 'info-icon', remote: true do
+                              %span.visually-hidden
+                                What does #{field['field']} mean
+                              ?
                     %tbody#records-tbody
                       = render partial: 'record', collection: @records
 

--- a/app/views/registers/show.html.haml
+++ b/app/views/registers/show.html.haml
@@ -86,7 +86,9 @@
                     %thead
                       %tr{data: {"click-events" => true, "click-category" => "Register Table", "click-action" => "Sort"}}
                         - @register.register_fields.each do |field|
-                          %th{class: "#{field['field']}"}= field['cardinality'] == '1' ? records_table_sort_link(field['field'], request.query_parameters) : field['field'].tr('-', ' ').humanize
+                          %th{class: "#{field['field']}"}
+                            = field['cardinality'] == '1' ? records_table_sort_link(field['field'], request.query_parameters) : field['field'].tr('-', ' ').humanize
+                            = link_to '?', register_field_path(@register.slug, field['field']), class: 'info-icon'
                     %tbody#records-tbody
                       = render partial: 'record', collection: @records
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,7 @@ Rails.application.routes.draw do
 
   resources :registers, only: %i[show index] do
     resources :entries, path: 'updates', only: :index
+    resources :fields, only: :show
     resources :download
     resources :feedback
     resources :records, constraints: { id: /.*/ }, only: :show


### PR DESCRIPTION
### Context
We want to show users the field descriptions

### Changes proposed in this pull request
- Render field description in own view for non-js users
- Render field description in dialog for js users

### Guidance to review
Click `?` icon next to any field name in table

Accessibility critea - https://gist.github.com/hannalaakso/2641fc16d2158e60d551cd9da960b5da

# After -JS Users
<img width="845" alt="screen shot 2018-06-25 at 18 13 57" src="https://user-images.githubusercontent.com/3071606/41864979-9c92a1ce-78a3-11e8-9480-0e94d848adc5.png">

# After - NON-JS Users
<img width="845" alt="screen shot 2018-06-25 at 18 14 05" src="https://user-images.githubusercontent.com/3071606/41864978-9c7d6dea-78a3-11e8-81e2-943730cae303.png">