### PR TITLE
Autocomplete off for all search inputs

### DIFF
--- a/app/views/entries/index.html.haml
+++ b/app/views/entries/index.html.haml
@@ -23,7 +23,7 @@
       = form_tag register_entries_path(@register.slug, anchor: 'updates_wrapper'), method: :get do
         .records-search#updates_wrapper
           = label_tag 'Search updates', nil, class: 'visually-hidden', for: 'q'
-          = search_field_tag 'q', nil, class: 'search-input', value: params[:q], placeholder: 'Search'
+          = search_field_tag 'q', nil, class: 'search-input', value: params[:q], placeholder: 'Search', autocomplete: 'off'
           = submit_tag 'Search', class: 'search-submit', name: nil
 
   .grid-row

--- a/app/views/registers/index.html.haml
+++ b/app/views/registers/index.html.haml
@@ -19,7 +19,7 @@
     .column-one-third
       = form_tag registers_path(anchor: 'content'), class: 'records-search', method: 'get' do
         = label_tag :q, 'Search', class: 'visually-hidden'
-        = search_field_tag :q, params[:q], class: 'search-input', placeholder: 'Search'
+        = search_field_tag :q, params[:q], class: 'search-input', placeholder: 'Search', autocomplete: 'off'
         = submit_tag 'Search', name: nil, class: 'search-submit'
 
     .column-full

--- a/app/views/registers/show.html.haml
+++ b/app/views/registers/show.html.haml
@@ -51,7 +51,7 @@
                     .column-one-third
                       .records-search
                         = label_tag 'Search', nil, for: 'q', class: 'visually-hidden'
-                        = search_field_tag 'q', nil, class: 'search-input', placeholder: 'Search', value: params[:q]
+                        = search_field_tag 'q', nil, class: 'search-input', placeholder: 'Search', value: params[:q], autocomplete: 'off'
                         = submit_tag 'Search', name: nil, class: 'search-submit'
                   %details{role: "group", open: (params[:status].present? ? 'open' : nil)}
                     %summary{"aria-controls" => "details-content-0", "aria-expanded" => "#{params[:status].present? ? 'true' : 'false'}", role: "button"}


### PR DESCRIPTION
### Changes proposed in this pull request
Turn `autocomplete` for all search inputs

### Guidance to review
`registers#index`, `registers#show`

# Before
<img width="876" alt="screen shot 2018-06-26 at 18 10 25" src="https://user-images.githubusercontent.com/3071606/41928166-36dbf1ae-796c-11e8-891a-f367d049b816.png">

# After 
<img width="876" alt="screen shot 2018-06-26 at 18 09 52" src="https://user-images.githubusercontent.com/3071606/41928137-232b0852-796c-11e8-9a0c-e7baad41ce53.png">
