### PR TITLE
Bump version for registers client.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,7 @@ gem 'govuk_elements_form_builder', git: 'https://github.com/ministryofjustice/go
 gem 'govuk_elements_rails'
 gem 'govuk_frontend_toolkit'
 gem 'govuk_template'
-gem 'govuk-registers-api-client', '~> 1.2.1'
+gem 'govuk-registers-api-client', '~> 1.2.2'
 
 gem 'autoprefixer-rails'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -113,7 +113,7 @@ GEM
       rubocop (~> 0.52.0)
       rubocop-rspec (~> 1.19.0)
       scss_lint
-    govuk-registers-api-client (1.2.1)
+    govuk-registers-api-client (1.2.2)
       rest-client (~> 2)
     govuk_elements_rails (3.1.2)
       govuk_frontend_toolkit (>= 6.0.2)
@@ -380,7 +380,7 @@ DEPENDENCIES
   faker
   gds_metrics (~> 0.1.0)
   govuk-lint (~> 3.8)
-  govuk-registers-api-client (~> 1.2.1)
+  govuk-registers-api-client (~> 1.2.2)
   govuk_elements_form_builder!
   govuk_elements_rails
   govuk_frontend_toolkit


### PR DESCRIPTION
### Context
This fixes a bug in refreshing data for an empty register.

### Changes proposed in this pull request
Upgrade govuk-registers-api-client to version 1.2.2

### Guidance to review
Loading data from an empty register multiple times should not duplicate system entries in datastore.