### PR TITLE
Update gds org logo

### DIFF
--- a/app/assets/stylesheets/govuk_component/_organisation-logo.scss
+++ b/app/assets/stylesheets/govuk_component/_organisation-logo.scss
@@ -76,6 +76,10 @@
     border-color: $foreign-commonwealth-office;
   }
 
+  &.government-digital-service .logo-with-crest {
+    border-color: $cabinet-office;
+  }
+
   .logo-link:link,
   .logo-link:visited {
     color: $black;

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -15,7 +15,7 @@ module ApplicationHelper
       "logo-with-crest crest-so"
     when "uk-atomic-energy-authority"
       "logo-with-crest crest-ukaea"
-    when "nhs", "government-digital-service", "scottish-government", "welsh-government"
+    when "nhs", "scottish-government", "welsh-government"
       " "
     else
       "logo-with-crest crest-org"


### PR DESCRIPTION
### Context
GDS logo doesn't match whats shown on GOV.UK

### Changes proposed in this pull request
Make sure the GDS logo has a crest and border to match https://www.gov.uk/government/organisations/government-digital-service

### Guidance to review
# Before
<img width="1328" alt="screen shot 2018-06-27 at 09 45 12" src="https://user-images.githubusercontent.com/3071606/41963220-e65832fa-79ee-11e8-8b30-b6ea95cdf99c.png">
<img width="1328" alt="screen shot 2018-06-27 at 09 45 14" src="https://user-images.githubusercontent.com/3071606/41963219-e6410c2e-79ee-11e8-8f14-3210e01f7d87.png">

# After
<img width="1328" alt="screen shot 2018-06-27 at 09 45 03" src="https://user-images.githubusercontent.com/3071606/41963193-d4f750d6-79ee-11e8-9de1-1eb940abe419.png">
<img width="1328" alt="screen shot 2018-06-27 at 09 43 31" src="https://user-images.githubusercontent.com/3071606/41963194-d50edb66-79ee-11e8-9943-648e8ed1bb35.png">

