### PR TITLE
handle non html format errors

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -1,9 +1,15 @@
 class ErrorsController < ApplicationController
   def not_found
-    render status: 404
+    respond_to do |format|
+      format.html { render status: 404 }
+      format.any { head :not_found }
+    end
   end
 
   def internal_server_error
-    render status: 500
+    respond_to do |format|
+      format.html { render status: 500 }
+      format.any { head :internal_server_error }
+    end
   end
 end

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -1,14 +1,14 @@
 class ErrorsController < ApplicationController
   def not_found
     respond_to do |format|
-      format.html { render status: 404 }
+      format.html { render status: :not_found }
       format.any { head :not_found }
     end
   end
 
   def internal_server_error
     respond_to do |format|
-      format.html { render status: 500 }
+      format.html { render status: :internal_server_error }
       format.any { head :internal_server_error }
     end
   end


### PR DESCRIPTION
### Context
We were getting 5xx alerts because non-HTML format 404 responses were throwing 500 as we did not provide a template for them
e.g. https://www.registers.service.gov.uk/assets/foo.css

### Changes proposed in this pull request
provide fallback handler which provides HEAD only response

### Guidance to review
you can test this locally by setting `development.rb` `config.consider_all_requests_local = false` and GETting: `localhost:3000/assets/foo.css`
