### PR TITLE
Update breadcrumbs to cater for long register names

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -73,10 +73,6 @@ img {
 }
 
 .register-show {
-  .link-back {
-    margin-bottom: 0;
-  }
-
   .panel-border-wide {
     margin-top: $gutter;
   }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -58,9 +58,9 @@ img {
   margin-top: 0;
 }
 
-.register-show,
 .register-index,
-.static-content {
+.static-content,
+.entries-index {
   .heading-large {
     margin-top: 0;
   }
@@ -69,6 +69,20 @@ img {
 .records-show {
   .heading-large {
     font-weight: normal;
+  }
+}
+
+.register-show {
+  .link-back {
+    margin-bottom: 0;
+  }
+
+  .related-items {
+    border: none;
+
+    @include media(tablet) {
+      margin-top: $gutter-half * 3;
+    }
   }
 }
 
@@ -132,7 +146,7 @@ a:visited {
 }
 
 .register-meta-data {
-  margin: $gutter-half 0;
+  margin-bottom: $gutter-half;
 }
 
 table {

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -77,6 +77,10 @@ img {
     margin-bottom: 0;
   }
 
+  .panel-border-wide {
+    margin-top: $gutter;
+  }
+
   .related-items {
     border: none;
 

--- a/app/views/entries/index.html.haml
+++ b/app/views/entries/index.html.haml
@@ -1,11 +1,8 @@
 - @page_title = "#{@register.register_name} register updates"
+- content_for :body_classes, 'entries-index'
 
 %nav.breadcrumbs{role: "Navigation", "aria-label" => "Breadcrumb"}
   %ol{data: {"click-events" => "", "click-category" => "Header", "click-action" => "Breadcrumb Clicked"}}
-    %li.breadcrumbs__item
-      = link_to 'Components', 'https://www.gov.uk/service-toolkit#components'
-    %li.breadcrumbs__item
-      = link_to 'GOV.UK Registers', root_path
     %li.breadcrumbs__item
       = link_to 'Get data', registers_path
     %li.breadcrumbs__item
@@ -16,7 +13,7 @@
 %main#content.container{role:'main'}
   .grid-row
     .column-full
-      %h1.heading-xlarge Register updates
+      %h1.heading-large Register updates
 
   .grid-row
     .column-one-third

--- a/app/views/registers/show.html.haml
+++ b/app/views/registers/show.html.haml
@@ -2,18 +2,8 @@
 - @page_description = "#{[@register.meta_description, @register.register_description].find(&:present?)}"
 - content_for :body_classes, 'register-show'
 
-%nav.breadcrumbs{role: "Navigation", "aria-label" => "Breadcrumb"}
-  %ol{data: {"click-events" => "", "click-category" => "Header", "click-action" => "Breadcrumb Clicked"}}
-    %li.breadcrumbs__item
-      = link_to 'Components', 'https://www.gov.uk/service-toolkit#components'
-    %li.breadcrumbs__item
-      = link_to 'GOV.UK Registers', root_path
-    %li.breadcrumbs__item
-      = link_to 'Get data', registers_path
-    %li.breadcrumbs__item.breadcrumbs__item--active
-      = link_to "#{@register.register_name} register", '#content', 'aria-current' => 'page'
-
 %main#content.container{role:'main'}
+  = link_to 'Back', registers_path, class: 'link-back'
 
   - if @register.register_phase != 'Beta'
     .grid-row
@@ -32,10 +22,11 @@
 
       .column-one-third
         - if @register.register_authority.present?
-          %p.bold-small Managed by:
-          %div{class: "govuk-organisation-logo #{@register.register_authority.data['name'].parameterize}"}
-            %div{class: "logo-container #{crest_class_name(@register.register_authority.data['name'].parameterize)}"}
-              %span= @register.register_authority.data['name']
+          .related-items
+            %p.bold-small Managed by:
+            %div{class: "govuk-organisation-logo #{@register.register_authority.data['name'].parameterize}"}
+              %div{class: "logo-container #{crest_class_name(@register.register_authority.data['name'].parameterize)}"}
+                %span= @register.register_authority.data['name']
 
   .grid-row
     .column-full

--- a/app/views/registers/show.html.haml
+++ b/app/views/registers/show.html.haml
@@ -3,8 +3,6 @@
 - content_for :body_classes, 'register-show'
 
 %main#content.container{role:'main'}
-  = link_to 'Back', registers_path, class: 'link-back'
-
   - if @register.register_phase != 'Beta'
     .grid-row
       .column-two-thirds


### PR DESCRIPTION
### Changes proposed in this pull request
- Replace breadcrumbs on `register#show` with back link
- Stripe back breadcrumbs on the updates page

### Guidance to review
Visit any register page

# After
<img width="829" alt="screen shot 2018-06-29 at 16 01 35" src="https://user-images.githubusercontent.com/3071606/42099592-c03ea6a8-7bb5-11e8-9a7b-66fbc75cbb0c.png">
<img width="829" alt="screen shot 2018-06-29 at 16 01 30" src="https://user-images.githubusercontent.com/3071606/42099593-c053e964-7bb5-11e8-845e-9a287dc04c56.png">

