### PR TITLE
fix 500 when requested unpopulated or backlog register

### DIFF
--- a/app/controllers/registers_controller.rb
+++ b/app/controllers/registers_controller.rb
@@ -20,7 +20,7 @@ class RegistersController < ApplicationController
   end
 
   def show
-    @register = Register.find_by_slug!(params[:id])
+    @register = Register.has_records.find_by_slug!(params[:id])
     @records = recover_records(@register.fields_array, params)
     @feedback = Feedback.new
   end


### PR DESCRIPTION
### Context
Previously we would throw a `500` if a user attempted to hit a register page of a backlog register or one that had not yet been populated with records.

### Changes proposed in this pull request
Filter `@register` by `has_records`

### Guidance to review
attempting to GET `/registers/$backlog_register_name` should be a `404`.