### PR TITLE
add register search view

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,6 +48,7 @@ gem 'delayed_job_active_record', '~> 4.1', '>= 4.1.2'
 
 # Database
 gem 'activerecord-import'
+gem 'scenic', '~> 1.4', '>= 1.4.1'
 
 # Schedule
 gem 'clockwork'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -309,6 +309,9 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
+    scenic (1.4.1)
+      activerecord (>= 4.0.0)
+      railties (>= 4.0.0)
     scss_lint (0.57.0)
       rake (>= 0.9, < 13)
       sass (~> 3.5.5)
@@ -401,6 +404,7 @@ DEPENDENCIES
   rails-controller-testing
   rspec-rails (~> 3.6)
   sass-rails (~> 5.0)
+  scenic (~> 1.4, >= 1.4.1)
   spring
   spring-watcher-listen (~> 2.0.0)
   uglifier (>= 1.3.0)

--- a/app/controllers/admin/registers_controller.rb
+++ b/app/controllers/admin/registers_controller.rb
@@ -38,6 +38,7 @@ module Admin
 
     def destroy
       @register.destroy
+      RegisterSearchResult.refresh
       redirect_to admin_registers_path
     end
 

--- a/app/jobs/populate_register_data_in_db_job.rb
+++ b/app/jobs/populate_register_data_in_db_job.rb
@@ -31,5 +31,6 @@ class PopulateRegisterDataInDbJob < ApplicationJob
                                   .first
     register.url = register_url
     register.save
+    RegisterSearchResult.refresh
   end
 end

--- a/app/models/register.rb
+++ b/app/models/register.rb
@@ -17,7 +17,7 @@ class Register < ApplicationRecord
   scope :in_beta, -> { where(register_phase: 'Beta') }
   scope :search_registers, lambda { |search_term|
                              if search_term.present?
-                               RegisterSearchResult.search_for(search_term)
+                               joins(:register_search_results).merge(RegisterSearchResult.search(search_term))
                              end
                            }
   scope :sort_registers, ->(sort_by) { sort_by == 'name' ? by_name : by_popularity }
@@ -26,6 +26,7 @@ class Register < ApplicationRecord
 
   has_many :entries, dependent: :destroy
   has_many :records, dependent: :destroy
+  has_many :register_search_results
 
   def register_last_updated
     Record.select('timestamp')

--- a/app/models/register.rb
+++ b/app/models/register.rb
@@ -17,7 +17,7 @@ class Register < ApplicationRecord
   scope :in_beta, -> { where(register_phase: 'Beta') }
   scope :search_registers, lambda { |search_term|
                              if search_term.present?
-                               where("name ilike ?", "%#{sanitize_sql_like(search_term)}%")
+                               RegisterSearchResult.search_for(search_term)
                              end
                            }
   scope :sort_registers, ->(sort_by) { sort_by == 'name' ? by_name : by_popularity }

--- a/app/models/register_search_result.rb
+++ b/app/models/register_search_result.rb
@@ -1,0 +1,12 @@
+class RegisterSearchResult < ActiveRecord::Base
+  self.primary_key = 'register_id'
+  scope :search, ->(search_term) { where(*['name ILIKE ? OR register_name ILIKE ? OR register_description ILIKE ?'].fill("%#{sanitize_sql_like(search_term)}%", 1..3)) }
+
+  def readonly?
+    true
+  end
+
+  def self.search_for(search_term)
+    Register.where(id: search(search_term).ids)
+  end
+end

--- a/app/models/register_search_result.rb
+++ b/app/models/register_search_result.rb
@@ -1,9 +1,13 @@
-class RegisterSearchResult < ActiveRecord::Base
+class RegisterSearchResult < ApplicationRecord
   self.primary_key = 'register_id'
   scope :search, ->(search_term) { where(*['name ILIKE ? OR register_name ILIKE ? OR register_description ILIKE ?'].fill("%#{sanitize_sql_like(search_term)}%", 1..3)) }
 
   def readonly?
     true
+  end
+
+  def self.refresh
+    Scenic.database.refresh_materialized_view(table_name, concurrently: false, cascade: false)
   end
 
   def self.search_for(search_term)

--- a/app/models/register_search_result.rb
+++ b/app/models/register_search_result.rb
@@ -1,6 +1,7 @@
 class RegisterSearchResult < ApplicationRecord
   self.primary_key = 'register_id'
-  scope :search, ->(search_term) { where(*['name ILIKE ? OR register_name ILIKE ? OR register_description ILIKE ?'].fill("%#{sanitize_sql_like(search_term)}%", 1..3)) }
+  scope :search, ->(search_term) { where(*['register_search_results.name ILIKE ? OR register_name ILIKE ? OR register_description ILIKE ?'].fill("%#{sanitize_sql_like(search_term)}%", 1..3)) }
+  belongs_to :register
 
   def readonly?
     true
@@ -8,9 +9,5 @@ class RegisterSearchResult < ApplicationRecord
 
   def self.refresh
     Scenic.database.refresh_materialized_view(table_name, concurrently: false, cascade: false)
-  end
-
-  def self.search_for(search_term)
-    Register.where(id: search(search_term).ids)
   end
 end

--- a/db/migrate/20180704141843_create_register_search_results.rb
+++ b/db/migrate/20180704141843_create_register_search_results.rb
@@ -1,0 +1,5 @@
+class CreateRegisterSearchResults < ActiveRecord::Migration[5.1]
+  def change
+    create_view :register_search_results
+  end
+end

--- a/db/migrate/20180704141843_create_register_search_results.rb
+++ b/db/migrate/20180704141843_create_register_search_results.rb
@@ -1,5 +1,5 @@
 class CreateRegisterSearchResults < ActiveRecord::Migration[5.1]
   def change
-    create_view :register_search_results
+    create_view :register_search_results, materialized: true
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180628112728) do
+ActiveRecord::Schema.define(version: 20180704141843) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -89,5 +89,21 @@ ActiveRecord::Schema.define(version: 20180628112728) do
     t.string "password_reset_token"
     t.datetime "password_reset_sent_at"
   end
+
+
+  create_view "register_search_results",  sql_definition: <<-SQL
+      SELECT registers.id AS register_id,
+      registers.name,
+      ((register_name_data.data -> 'register-name'::text))::character varying AS register_name,
+      ((register_description_data.data -> 'text'::text))::character varying AS register_description
+     FROM ((registers
+       LEFT JOIN ( SELECT records.register_id,
+              records.data
+             FROM records
+            WHERE ((records.key = 'register-name'::text) AND (records.entry_type = 'system'::text))) register_name_data ON ((register_name_data.register_id = registers.id)))
+       LEFT JOIN ( SELECT records.key,
+              records.data
+             FROM records) register_description_data ON ((register_description_data.key = ('register:'::text || (registers.slug)::text))));
+  SQL
 
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,11 +10,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180706094206) do
+ActiveRecord::Schema.define(version: 20180704141843) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
-  enable_extension "pg_trgm"
 
   create_table "delayed_jobs", force: :cascade do |t|
     t.integer "priority", default: 0, null: false
@@ -106,12 +105,5 @@ ActiveRecord::Schema.define(version: 20180706094206) do
               records.data
              FROM records) register_description_data ON ((register_description_data.key = ('register:'::text || (registers.slug)::text))));
   SQL
-
-  add_index "register_search_results", "name gin_trgm_ops", name: "index_register_search_results_on_name", using: :gin
-  add_index "register_search_results", "name gin_trgm_ops", name: "register_search_results_name_idx", using: :gin
-  add_index "register_search_results", "name gin_trgm_ops", name: "register_search_results_name_idx1", using: :gin
-  add_index "register_search_results", "name gin_trgm_ops", name: "register_search_results_name_idx2", using: :gin
-  add_index "register_search_results", "name gin_trgm_ops", name: "trgrm_idx_name", using: :gin
-  add_index "register_search_results", "name gin_trgm_ops, register_name gin_trgm_ops, register_description gin_trgm_ops", name: "contacts_search_idx", using: :gin
 
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,11 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180704141843) do
+ActiveRecord::Schema.define(version: 20180706094206) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+  enable_extension "pg_trgm"
 
   create_table "delayed_jobs", force: :cascade do |t|
     t.integer "priority", default: 0, null: false
@@ -91,7 +92,7 @@ ActiveRecord::Schema.define(version: 20180704141843) do
   end
 
 
-  create_view "register_search_results",  sql_definition: <<-SQL
+  create_view "register_search_results", materialized: true,  sql_definition: <<-SQL
       SELECT registers.id AS register_id,
       registers.name,
       ((register_name_data.data -> 'register-name'::text))::character varying AS register_name,
@@ -105,5 +106,12 @@ ActiveRecord::Schema.define(version: 20180704141843) do
               records.data
              FROM records) register_description_data ON ((register_description_data.key = ('register:'::text || (registers.slug)::text))));
   SQL
+
+  add_index "register_search_results", "name gin_trgm_ops", name: "index_register_search_results_on_name", using: :gin
+  add_index "register_search_results", "name gin_trgm_ops", name: "register_search_results_name_idx", using: :gin
+  add_index "register_search_results", "name gin_trgm_ops", name: "register_search_results_name_idx1", using: :gin
+  add_index "register_search_results", "name gin_trgm_ops", name: "register_search_results_name_idx2", using: :gin
+  add_index "register_search_results", "name gin_trgm_ops", name: "trgrm_idx_name", using: :gin
+  add_index "register_search_results", "name gin_trgm_ops, register_name gin_trgm_ops, register_description gin_trgm_ops", name: "contacts_search_idx", using: :gin
 
 end

--- a/db/views/register_search_results_v01.sql
+++ b/db/views/register_search_results_v01.sql
@@ -1,0 +1,15 @@
+
+SELECT registers.id AS register_id,
+       registers.name,
+       CAST(register_name_data.data->'register-name' AS varchar) AS register_name,
+       CAST(register_description_data.data->'text' AS varchar) AS register_description
+FROM registers
+LEFT JOIN
+  (SELECT register_id,
+          DATA
+   FROM records
+   WHERE KEY = 'register-name' AND ENTRY_TYPE='system' ) AS register_name_data ON register_name_data.register_id = registers.id
+LEFT JOIN
+  (SELECT KEY,
+          DATA
+   FROM records) AS register_description_data ON register_description_data.key = 'register:' || registers.slug;


### PR DESCRIPTION
### Context
Previously we only searched on register `name`
https://trello.com/c/l7SSYCv3/1976-pipeline-search-return-results-based-on-matches-on-the-description-text

### Changes proposed in this pull request
Search across 
* register name (humanized ID)
* `register-name` (friendly name)
* register description

### Guidance to review
As this is quite a complex SQL query this PR creates a Postgres View and uses [scenic](https://github.com/thoughtbot/scenic) to make it available to Rails model. Let me know if you feel strongly against this approach and would rather denormalise or use plain subqueries in code rather than a view. 
*H/T @nacnudus helping me with the SQL query* 🔥 
