### PR TITLE
add distinct to query

### DIFF
--- a/db/migrate/20180709102012_update_register_search_results_to_version_2.rb
+++ b/db/migrate/20180709102012_update_register_search_results_to_version_2.rb
@@ -1,0 +1,8 @@
+class UpdateRegisterSearchResultsToVersion2 < ActiveRecord::Migration[5.1]
+  def change
+    update_view :register_search_results,
+      version: 2,
+      revert_to_version: 1,
+      materialized: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180704141843) do
+ActiveRecord::Schema.define(version: 20180709102012) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -92,7 +92,7 @@ ActiveRecord::Schema.define(version: 20180704141843) do
 
 
   create_view "register_search_results", materialized: true,  sql_definition: <<-SQL
-      SELECT registers.id AS register_id,
+      SELECT DISTINCT registers.id AS register_id,
       registers.name,
       ((register_name_data.data -> 'register-name'::text))::character varying AS register_name,
       ((register_description_data.data -> 'text'::text))::character varying AS register_description

--- a/db/views/register_search_results_v02.sql
+++ b/db/views/register_search_results_v02.sql
@@ -1,0 +1,14 @@
+SELECT DISTINCT registers.id AS register_id,
+       registers.name,
+       CAST(register_name_data.data->'register-name' AS varchar) AS register_name,
+       CAST(register_description_data.data->'text' AS varchar) AS register_description
+FROM registers
+LEFT JOIN
+  (SELECT register_id,
+          DATA
+   FROM records
+   WHERE KEY = 'register-name' AND ENTRY_TYPE='system' ) AS register_name_data ON register_name_data.register_id = registers.id
+LEFT JOIN
+  (SELECT KEY,
+          DATA
+   FROM records) AS register_description_data ON register_description_data.key = 'register:' || registers.slug;


### PR DESCRIPTION
### Context
Bug fix after #379 
Some duplicate search results were appearing

### Changes proposed in this pull request
Put `DISTINCT` clause on query to remove duplicates from registers search results view.


### Guidance to review
No duplicates should appear in search results.