### PR TITLE
return 404 not 500 if record does not exist

### DIFF
--- a/app/models/record.rb
+++ b/app/models/record.rb
@@ -19,7 +19,7 @@ class Record < ApplicationRecord
   }
 
   scope :record, lambda { |record|
-    find_by(
+    find_by!(
       key: record,
       entry_type: 'user'
       )


### PR DESCRIPTION
### Context
previously we threw a 500 if a single record was requested that did not exist

### Changes proposed in this pull request
Use [find_by!](http://api.rubyonrails.org/classes/ActiveRecord/FinderMethods.html#method-i-find_by-21) so that it returns 404 in this case 

### Guidance to review
http://localhost:3000/registers/country/records/foo should 404.
