### PR TITLE
Don't run forgery protection on error handlers

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -1,4 +1,6 @@
-class ErrorsController < ApplicationController
+class ErrorsController < ActionController::Base
+  layout 'application'
+
   def not_found
     respond_to do |format|
       format.html { render status: :not_found }


### PR DESCRIPTION
### Context
In https://github.com/openregister/registers-frontend/pull/331 we added dynamic error handlers using ErrorController.

However, because this inherits from ApplicationController, it attempts to apply cross site request forgery protection after the second render attempt.

This causes requests for missing javascript (like https://www.registers.service.gov.uk/assets/foo.js) to incorrectly return a 500 response, because it never passes the CSRF checks.

This is one of several cases where we are falsely reporting errors to kibana (https://trello.com/c/1QSgzqkE/2620-fix-registers-frontend-5xx-errors)

### Changes proposed in this pull request
This change removes all the standard authentication and CSRF protection from these pages, as it should always be OK to request these pages, regardless of where the request comes from.

The downside of this approach is these responses still go through all the rails middleware, which makes the request handling a bit hard to reason about. For reasons I don't entirely understand, a 404 request for javascript still seems to render a plain 404 response without a body, instead of the template:

```
curl -I 'http://localhost:3000/assets/foo.js'
HTTP/1.1 404 Not Found
X-Frame-Options: SAMEORIGIN
X-XSS-Protection: 1; mode=block
X-Content-Type-Options: nosniff
Content-Type: text/html; charset=utf-8
X-Request-Id: a5a51ae6-df3d-473e-b924-f1e4549758f5
X-Runtime: 1.407226
```

But this stops us reporting these requests as errors, so I think it still solves the problem.

### Guidance to review
1. Is there anything else from `ApplicationController` we do still need to run when rendering error pages?
2. Is it ok to deploy this on its own, or do you want me to look at the other kibana errors first?
3. As this is my first PR to registers, am I following the right process? Do you have any linter tools set up for this project? (on GOV.UK they use https://gds-way.cloudapps.digital/manuals/programming-languages/ruby.html)

My other idea was to revert back to the default rails way of responding to errors, which is to have  static 500.html and 404.html pages. These are normally served by the webserver rather than rails itself. But the reason it's dynamic in the first place is to easily reuse the base layout so you don't need to keep multiple sets of html in sync.