### PR TITLE
fix 500 when field not found

### DIFF
--- a/app/controllers/fields_controller.rb
+++ b/app/controllers/fields_controller.rb
@@ -1,7 +1,6 @@
 class FieldsController < ApplicationController
   def show
     @register = Register.find_by_slug!(params[:register_id])
-
-    @field = Record.where(register_id: @register.id, key: "field:#{params[:id]}").first
+    @field = Record.find_by!(register_id: @register.id, key: "field:#{params[:id]}")
   end
 end


### PR DESCRIPTION
### Context
Fix 500 error

### Changes proposed in this pull request
The non-JS route for field pages was throwing a 500 if it did not find a matching field. Fix by using [find_by!](http://api.rubyonrails.org/classes/ActiveRecord/FinderMethods.html#method-i-find_by-21)

### Guidance to review
Non-existant field page e.g. http://localhost:3000/registers/country/fields/foo should 404 rather than 500.
