### PR TITLE
Send backtraces to logit

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -77,6 +77,12 @@ Rails.application.configure do # rubocop:disable Metrics/BlockLength
     logger = ActiveSupport::Logger.new(STDOUT)
     logger.formatter = config.log_formatter
     config.logger = ActiveSupport::Logger.new(STDOUT)
+
+    config.lograge.custom_options = lambda do |event|
+      {
+        error_backtrace: event.payload[:exception_object]&.backtrace&.join("\n")
+      }.compact
+    end
   end
 
   # Do not dump schema after migrations.

--- a/manifest-research.yml
+++ b/manifest-research.yml
@@ -7,6 +7,7 @@ defaults: &defaults
     - registers-frontend-research
     # environment variables (persisted for blue/green deploys)
     - registers-product-site-environment-variables
+    - logit-ssl-drain
 
 applications:
 - name: registers-frontend-research


### PR DESCRIPTION
### Context
Currently we only send the first line of the exception to logit, and there is no way to see where in the code it came from.

This would help with cards like https://trello.com/c/1QSgzqkE/2620-fix-registers-frontend-5xx-errors

### Changes proposed in this pull request
This adds the backtrace of the exception to a separate kibana field, following the approach here: https://github.com/roidrage/lograge#logging-errors--exceptions

The lograge authors recommend using a separate stack trace tracking service, but we don't have one yet. I raised a card in our backlog to investigate that.

I've also enabled logstash for the research app.
### Guidance to review
