### PR TITLE
Require records to exist before linking to a register

### DIFF
--- a/app/controllers/registers_controller.rb
+++ b/app/controllers/registers_controller.rb
@@ -26,41 +26,19 @@ class RegistersController < ApplicationController
   end
 
   def field_link_resolver(field, field_value, register_slug: @register.slug, whitelist: register_whitelist)
+    resolver = LinkResolver.new(current_register_slug: register_slug, register_whitelist: whitelist)
+
     if field_value.is_a?(Array)
-      field_value.map { |fv| resolve_single_link(field, fv, register_slug: register_slug, whitelist: whitelist) }.join(', ').html_safe
+      field_value.map { |fv| resolver.resolve(field, fv) }.join(', ').html_safe
     else
-      resolve_single_link(field, field_value, register_slug: register_slug, whitelist: whitelist)
+      resolver.resolve(field, field_value)
     end
   end
 
-  private
+private
 
   def register_whitelist
     @register_whitelist ||= Register.has_records.pluck(:slug)
-  end
-
-  def resolve_single_link(f, fv, register_slug: @register.slug, whitelist: register_whitelist)
-    field_register_slug = f['register']
-    field_name = f['field']
-
-    if f['datatype'] == 'curie' && fv.include?(':')
-      curie_register, curie_key = fv.split(':')
-
-      if !whitelist.include?(curie_register)
-        fv
-      elsif curie_key.present?
-        link_to(fv, register_record_path(curie_register, curie_key))
-      else
-        link_to(fv, register_path(curie_register))
-      end
-
-    elsif field_register_slug.present? && field_name != register_slug && whitelist.include?(field_register_slug)
-      link_to(fv, register_record_path(field_register_slug, fv))
-    elsif f['datatype'] == 'url'
-      link_to(fv, fv)
-    else
-      fv
-    end
   end
 
   def recover_records(fields, params)

--- a/app/lib/link_resolver.rb
+++ b/app/lib/link_resolver.rb
@@ -12,9 +12,13 @@ class LinkResolver
     field_name = field['field']
     field_datatype = field['datatype']
 
+    foreign_key_resolvable = field_register_slug.present? && \
+      field_name != current_register_slug && \
+      register_whitelist.include?(field_register_slug)
+
     if field_datatype == 'curie' && field_value.include?(':')
       resolve_curie(field_value)
-    elsif field_register_slug.present? && field_name != current_register_slug && register_whitelist.include?(field_register_slug)
+    elsif foreign_key_resolvable
       resolve_foreign_key(field_register_slug, field_value)
     elsif field_datatype == 'url'
       link_to(field_value, field_value)

--- a/app/lib/link_resolver.rb
+++ b/app/lib/link_resolver.rb
@@ -1,0 +1,47 @@
+class LinkResolver
+  include ActionView::Helpers::UrlHelper
+
+  def initialize(current_register_slug:, register_whitelist:)
+    @current_register_slug = current_register_slug
+    @register_whitelist = register_whitelist
+    @url_helpers = Rails.application.routes.url_helpers
+  end
+
+  def resolve(field, field_value)
+    field_register_slug = field['register']
+    field_name = field['field']
+    field_datatype = field['datatype']
+
+    if field_datatype == 'curie' && field_value.include?(':')
+      resolve_curie(field_value)
+    elsif field_register_slug.present? && field_name != current_register_slug && register_whitelist.include?(field_register_slug)
+      resolve_foreign_key(field_register_slug, field_value)
+    elsif field_datatype == 'url'
+      link_to(field_value, field_value)
+    else
+      field_value
+    end
+  end
+
+private
+
+  attr_reader :current_register_slug
+  attr_reader :register_whitelist
+  attr_reader :url_helpers
+
+  def resolve_curie(curie)
+    curie_register, curie_key = curie.split(':')
+
+    if !register_whitelist.include?(curie_register)
+      curie
+    elsif curie_key.present?
+      link_to(curie, url_helpers.register_record_path(curie_register, curie_key))
+    else
+      link_to(curie, url_helpers.register_path(curie_register))
+    end
+  end
+
+  def resolve_foreign_key(register_slug, key)
+    link_to(key, url_helpers.register_record_path(register_slug, key))
+  end
+end

--- a/spec/controllers/registers_controller_spec.rb
+++ b/spec/controllers/registers_controller_spec.rb
@@ -206,7 +206,7 @@ RSpec.describe RegistersController, type: :controller do
     it "links to external URL" do
       field = { "text" => "The website for a register entry.", "field" => "website", "phase" => "beta", "datatype" => "url", "cardinality" => "1" }
       field_value = "https://www.gov.uk/government/organisations/academy-for-justice-commissioning"
-      expect(subject.field_link_resolver(field, field_value, 'government-organisation')).to eq("<a href=\"https://www.gov.uk/government/organisations/academy-for-justice-commissioning\">https://www.gov.uk/government/organisations/academy-for-justice-commissioning</a>")
+      expect(subject.field_link_resolver(field, field_value, register_slug: 'government-organisation')).to eq("<a href=\"https://www.gov.uk/government/organisations/academy-for-justice-commissioning\">https://www.gov.uk/government/organisations/academy-for-justice-commissioning</a>")
     end
   end
 
@@ -214,13 +214,19 @@ RSpec.describe RegistersController, type: :controller do
     it "does not link primary key field" do
       field = { "text" => "The unique code for a government organisation.", "field" => "government-organisation", "phase" => "beta", "datatype" => "string", "register" => "government-organisation", "cardinality" => "1" }
       field_value = "D13"
-      expect(subject.field_link_resolver(field, field_value, 'government-organisation')).to eq("D13")
+      expect(subject.field_link_resolver(field, field_value, register_slug: 'government-organisation')).to eq("D13")
     end
 
     it "links register type fields" do
       field = { "text" => "The unique code for a government organisation.", "field" => "government-organisation", "phase" => "beta", "datatype" => "string", "register" => "government-organisation", "cardinality" => "1" }
       field_value = "D13"
-      expect(subject.field_link_resolver(field, field_value, 'government-service')).to eq("<a href=\"/registers/government-organisation/records/D13\">D13</a>")
+      expect(subject.field_link_resolver(field, field_value, register_slug: 'government-service', whitelist: %w(government-organisation))).to eq("<a href=\"/registers/government-organisation/records/D13\">D13</a>")
+    end
+
+    it "does not link if the register is not in the whitelist" do
+      field = { "text" => "The unique code for a government organisation.", "field" => "government-organisation", "phase" => "beta", "datatype" => "string", "register" => "government-organisation", "cardinality" => "1" }
+      field_value = "D13"
+      expect(subject.field_link_resolver(field, field_value, register_slug: 'government-service', whitelist: [])).to eq("D13")
     end
   end
 
@@ -228,13 +234,25 @@ RSpec.describe RegistersController, type: :controller do
     it "resolves CURIE to record" do
       field = { "text" => "The unique code for a government organisation.", "field" => "government-organisation", "phase" => "beta", "datatype" => "curie", "cardinality" => "1" }
       field_value = "government-organisation:D13"
-      expect(subject.field_link_resolver(field, field_value, 'government-organisation')).to eq("<a href=\"/registers/government-organisation/records/D13\">government-organisation:D13</a>")
+      expect(subject.field_link_resolver(field, field_value, register_slug: 'government-organisation', whitelist: %w(government-organisation))).to eq("<a href=\"/registers/government-organisation/records/D13\">government-organisation:D13</a>")
+    end
+
+    it "does not resolve CURIE to a record if the register doesn't contain records" do
+      field = { "text" => "The unique code for a government organisation.", "field" => "government-organisation", "phase" => "beta", "datatype" => "curie", "cardinality" => "1" }
+      field_value = "government-organisation:D13"
+      expect(subject.field_link_resolver(field, field_value, register_slug: 'government-organisation', whitelist: [])).to eq("government-organisation:D13")
     end
 
     it "links one sided CURIE to register" do
       field = { "text" => "The unique code for a government organisation.", "field" => "government-organisation", "phase" => "beta", "datatype" => "curie", "cardinality" => "1" }
       field_value = "government-organisation:"
-      expect(subject.field_link_resolver(field, field_value, 'government-organisation')).to eq("<a href=\"/registers/government-organisation\">government-organisation:</a>")
+      expect(subject.field_link_resolver(field, field_value, register_slug: 'government-domain', whitelist: %w(government-organisation))).to eq("<a href=\"/registers/government-organisation\">government-organisation:</a>")
+    end
+
+    it "doesn't link a one sided CURIE to the register if the register has no records" do
+      field = { "text" => "The unique code for a government organisation.", "field" => "government-organisation", "phase" => "beta", "datatype" => "curie", "cardinality" => "1" }
+      field_value = "government-organisation:"
+      expect(subject.field_link_resolver(field, field_value, register_slug: 'government-domain', whitelist: [])).to eq("government-organisation:")
     end
   end
 
@@ -242,7 +260,13 @@ RSpec.describe RegistersController, type: :controller do
     it "links each field value in cardinality N fields" do
       field = { "text" => "The classes that a charity falls into.", "field" => "charity-classes", "phase" => "discovery", "datatype" => "string", "register" => "charity-class", "cardinality" => "n" }
       field_value = %w[307 302 301 207 103 102 101]
-      expect(subject.field_link_resolver(field, field_value, 'charity')).to eq("<a href=\"/registers/charity-class/records/307\">307</a>, <a href=\"/registers/charity-class/records/302\">302</a>, <a href=\"/registers/charity-class/records/301\">301</a>, <a href=\"/registers/charity-class/records/207\">207</a>, <a href=\"/registers/charity-class/records/103\">103</a>, <a href=\"/registers/charity-class/records/102\">102</a>, <a href=\"/registers/charity-class/records/101\">101</a>")
+      expect(subject.field_link_resolver(field, field_value, register_slug: 'charity', whitelist: %w(charity-class))).to eq("<a href=\"/registers/charity-class/records/307\">307</a>, <a href=\"/registers/charity-class/records/302\">302</a>, <a href=\"/registers/charity-class/records/301\">301</a>, <a href=\"/registers/charity-class/records/207\">207</a>, <a href=\"/registers/charity-class/records/103\">103</a>, <a href=\"/registers/charity-class/records/102\">102</a>, <a href=\"/registers/charity-class/records/101\">101</a>")
+    end
+
+    it "does not link field values if a cardinality N field references registers without records" do
+      field = { "text" => "The classes that a charity falls into.", "field" => "charity-classes", "phase" => "discovery", "datatype" => "string", "register" => "charity-class", "cardinality" => "n" }
+      field_value = %w[307 302 301 207 103 102 101]
+      expect(subject.field_link_resolver(field, field_value, register_slug: 'charity', whitelist: [])).to eq("307, 302, 301, 207, 103, 102, 101")
     end
   end
 end


### PR DESCRIPTION
### Context
When new registers are being developed, the frontend can get into a state where there are registers than reference records in registers that do not show up on the frontend. So the user follows a link to a 404.

This happens because:

- Populating the frontend is an asynchronous process
- Registers have to be whitelisted to show up in the frontend

Trello: https://trello.com/c/FUnf29SI/2621-link-resolver-should-only-link-to-available-registers

### Changes proposed in this pull request
The change is to only link to a record or register if the register being linked to has records in it. If it doesn't have records, just show the value without creating a link.

### Guidance to review
I've tried to factor out the link resolution code from the controller by creating a new class, so that I can extract some of the business logic to helper methods. I'm not sure if this is the best way of implementing it, so I've kept this as a separate commit - let me know if you'd prefer to revert it.

I also considered making it a rails helper, but it meant I couldn't extract methods out without having to keep passing around the 4 state variables, so I abandoned that approach.