### PR TITLE
Don't parse nested search paramaters for /registers

### DIFF
--- a/app/controllers/registers_controller.rb
+++ b/app/controllers/registers_controller.rb
@@ -5,9 +5,11 @@ class RegistersController < ApplicationController
   helper_method :field_link_resolver
 
   def index
+    search_term = params.permit(:q)[:q]
+
     @registers = Register.available
                          .in_beta
-                         .search_registers(params[:q])
+                         .search_registers(search_term)
 
     # Redirect legacy URL to ensure we don't break anyone
     if params[:phase] == 'in progress'


### PR DESCRIPTION
### Context
This request currently causes a 500 due to rails interpreting q as a nested
parameter when our code is expecting a string:

https://www.registers.service.gov.uk/registers?q[s]=name%20asc

This was showing up as an error in kibana so I raised a card here: https://trello.com/c/Y5JP9MzW/2645-500-error-handle-invalid-query-parameters-to-registers

### Changes proposed in this pull request
By using `#permit` we can stop rails from parsing parameters like this as
hashes or arrays:
http://guides.rubyonrails.org/action_controller_overview.html#permitted-scalar-values


### Guidance to review
