### PR TITLE
Extend query param sanitisation to show action

### DIFF
--- a/app/controllers/entries_controller.rb
+++ b/app/controllers/entries_controller.rb
@@ -26,9 +26,11 @@ class EntriesController < ApplicationController
 private
 
   def recover_entries_history(register_id, fields, params, page_size = 100)
+    @search_term = search_term
+
     page = params.fetch(:page) { 1 }.to_i
     user_entries = Entry.where(register_id: register_id, entry_type: 'user')
-                        .search_for(fields, search_term)
+                        .search_for(fields, @search_term)
     query = user_entries.with_limit(page, page_size)
 
     previous_entries_numbers = query.reject { |entry| entry.previous_entry_number.nil? }.map(&:previous_entry_number)

--- a/app/controllers/entries_controller.rb
+++ b/app/controllers/entries_controller.rb
@@ -28,7 +28,7 @@ private
   def recover_entries_history(register_id, fields, params, page_size = 100)
     page = params.fetch(:page) { 1 }.to_i
     user_entries = Entry.where(register_id: register_id, entry_type: 'user')
-                        .search_for(fields, params[:q])
+                        .search_for(fields, search_term)
     query = user_entries.with_limit(page, page_size)
 
     previous_entries_numbers = query.reject { |entry| entry.previous_entry_number.nil? }.map(&:previous_entry_number)
@@ -40,5 +40,9 @@ private
       entries = previous_entries_query.select { |previous_entry| previous_entry.entry_number == entry.previous_entry_number }.first
       { current_entry: entry, previous_entry: entries }
     end
+  end
+
+  def search_term
+    params.permit(:q)[:q]
   end
 end

--- a/app/controllers/registers_controller.rb
+++ b/app/controllers/registers_controller.rb
@@ -5,8 +5,6 @@ class RegistersController < ApplicationController
   helper_method :field_link_resolver
 
   def index
-    search_term = params.permit(:q)[:q]
-
     @registers = Register.available
                          .in_beta
                          .search_registers(search_term)
@@ -43,6 +41,10 @@ private
     @register_whitelist ||= Register.has_records.pluck(:slug)
   end
 
+  def search_term
+    params.permit(:q)[:q]
+  end
+
   def recover_records(fields, params)
     default_sort_by = lambda {
       has_name_field = fields.include?('name')
@@ -54,7 +56,7 @@ private
 
     @register.records
              .where(entry_type: 'user')
-             .search_for(fields, params[:q])
+             .search_for(fields, search_term)
              .status(params[:status])
              .sort_by_field(sort_by, sort_direction)
              .page(params[:page])

--- a/app/controllers/registers_controller.rb
+++ b/app/controllers/registers_controller.rb
@@ -5,9 +5,10 @@ class RegistersController < ApplicationController
   helper_method :field_link_resolver
 
   def index
+    @search_term = search_term
     @registers = Register.available
                          .in_beta
-                         .search_registers(search_term)
+                         .search_registers(@search_term)
 
     # Redirect legacy URL to ensure we don't break anyone
     if params[:phase] == 'in progress'
@@ -20,6 +21,7 @@ class RegistersController < ApplicationController
   end
 
   def show
+    @search_term = search_term
     @register = Register.has_records.find_by_slug!(params[:id])
     @records = recover_records(@register.fields_array, params)
     @feedback = Feedback.new

--- a/app/views/entries/index.html.haml
+++ b/app/views/entries/index.html.haml
@@ -20,7 +20,7 @@
       = form_tag register_entries_path(@register.slug, anchor: 'updates_wrapper'), method: :get do
         .records-search#updates_wrapper
           = label_tag 'Search updates', nil, class: 'visually-hidden', for: 'q'
-          = search_field_tag 'q', nil, class: 'search-input', value: params[:q], placeholder: 'Search', autocomplete: 'off'
+          = search_field_tag 'q', nil, class: 'search-input', value: @search_term, placeholder: 'Search', autocomplete: 'off'
           = submit_tag 'Search', class: 'search-submit', name: nil
 
   .grid-row
@@ -40,5 +40,5 @@
       - else
         .no-search-results
           %p
-            No results found for <strong>"#{params[:q]}"</strong>
+            No results found for <strong>"#{@search_term}"</strong>
             = link_to 'Reset', register_entries_path(@register.slug, anchor: 'search_wrapper'), class: 'reset-link'

--- a/app/views/registers/_showing.html.haml
+++ b/app/views/registers/_showing.html.haml
@@ -1,3 +1,3 @@
 = page_entries_info(@records)
-- if params[:q].present?
-  for <strong>"#{params[:q]}"</strong>
+- if @search_term.present?
+  for <strong>"#{@search_term}"</strong>

--- a/app/views/registers/in_progress.html.haml
+++ b/app/views/registers/in_progress.html.haml
@@ -46,5 +46,5 @@
       - else
         .no-search-results
           %p
-            No results found for <strong>"#{params[:q][:name_cont]}"</strong>
+            No results found for <strong>"#{@search_term}"</strong>
             = link_to 'Reset', registers_path, class: 'reset-link'

--- a/app/views/registers/index.html.haml
+++ b/app/views/registers/index.html.haml
@@ -19,15 +19,15 @@
     .column-one-third
       = form_tag registers_path(anchor: 'content'), class: 'records-search', method: 'get' do
         = label_tag :q, 'Search', class: 'visually-hidden'
-        = search_field_tag :q, params[:q], class: 'search-input', placeholder: 'Search', autocomplete: 'off'
+        = search_field_tag :q, @search_term, class: 'search-input', placeholder: 'Search', autocomplete: 'off'
         = submit_tag 'Search', name: nil, class: 'search-submit'
 
     .column-full
       - if @registers.present?
-        - if params[:q]
+        - if @search_term
           .search-results
             %p
-              Results found for <strong>"#{params[:q]}"</strong>
+              Results found for <strong>"#{@search_term}"</strong>
               = link_to 'Reset', registers_path, class: 'reset-link'
         .grid-row
           .column-full
@@ -71,7 +71,7 @@
       - else
         .search-results
           %p
-            No results found for <strong>"#{params[:q]}"</strong>
+            No results found for <strong>"#{@search_term}"</strong>
             = link_to 'Reset', registers_path, class: 'reset-link'
       %p You can also see #{link_to 'registers that are coming soon', registers_in_progress_path}.
 

--- a/app/views/registers/show.html.haml
+++ b/app/views/registers/show.html.haml
@@ -42,7 +42,7 @@
                       .column-one-third
                         .records-search
                           = label_tag 'Search', nil, for: 'q', class: 'visually-hidden'
-                          = search_field_tag 'q', nil, class: 'search-input', placeholder: 'Search', value: params[:q], autocomplete: 'off'
+                          = search_field_tag 'q', nil, class: 'search-input', placeholder: 'Search', value: @search_term, autocomplete: 'off'
                           = submit_tag 'Search', name: nil, class: 'search-submit'
                     %details{role: "group", open: (params[:status].present? ? 'open' : nil)}
                       %summary{"aria-controls" => "details-content-0", "aria-expanded" => "#{params[:status].present? ? 'true' : 'false'}", role: "button"}
@@ -65,14 +65,14 @@
                                   = label_tag 'Both', nil, for: 'status_all'
                               = submit_tag 'Search', name: nil, class: 'button filter-search-submit'
 
-              
+
               - if @records.any?
                 .records-count
                   %span#records-count
                     = render partial: 'showing'
-                  - if params[:q].present? || params[:status].present?
+                  - if @search_term.present? || params[:status].present?
                     = link_to 'Reset', register_path(@register.slug, anchor: 'records_wrapper'), class: 'reset-link'
-              
+
               - if @register.is_empty? || @records.any?
                 .fullscreen-content{data: {module: 'scrolling-tables'}}
                   %table.table.register-data-table
@@ -107,11 +107,11 @@
               - unless @records.any? || @register.is_empty?
                 .no-search-results
                   %p
-                    - if params[:q].present?
-                      No results found for <strong>"#{params[:q]}"</strong>
+                    - if @search_term.present?
+                      No results found for <strong>"#{@search_term}"</strong>
                     - else
                       No results found.
-                    - if params[:q].present? || params[:status].present?
+                    - if @search_term.present? || params[:status].present?
                       = link_to 'Reset', register_path(@register.slug, anchor: 'search_wrapper'), class: 'reset-link'
           - if @records.any?
             .subsection.js-subsection

--- a/app/views/registers/show.js.erb
+++ b/app/views/registers/show.js.erb
@@ -1,5 +1,5 @@
 $("#records-tbody").append("<%= j(render(partial: 'record', collection: @records)) %>");
-$("#records-count").html('Showing <strong>1 &ndash; <%= @records.count + @records.offset_value %></strong> of <strong><%= @records.total_count %></strong> records <% if params[:q].present? %>for <strong>"<%= params[:q] %>"</strong><% end %>')
+$("#records-count").html('Showing <strong>1 &ndash; <%= @records.count + @records.offset_value %></strong> of <strong><%= @records.total_count %></strong> records <% if @search_term.present? %>for <strong>"<%= search_term %>"</strong><% end %>')
 
 <% if @records.last_page? %>
   $("#load-more-records").hide();


### PR DESCRIPTION
### Context
We have seen some errors in our logs due to nested parameters not being handled. For example, passing a query string like `q[s]=foo` instead of `q=foo` on search pages.

I fixed this for the index page in https://github.com/openregister/registers-frontend/pull/387, but I missed some other pages that have the same problem.

### Changes proposed in this pull request
This extends the same parameter validation to the search bars on these pages:

- https://www.registers.service.gov.uk/registers/country
- https://www.registers.service.gov.uk/registers/country/updates

While working on this I also noticed that the search bar doesn't work on the in progress page:
https://www.registers.service.gov.uk/registers-in-progress

But I haven't fixed this yet.

### Guidance to review
