### PR TITLE
Remove links to deprecated feedback form in upcoming registers.

### DIFF
--- a/app/views/registers/_register.html.haml
+++ b/app/views/registers/_register.html.haml
@@ -14,6 +14,6 @@
           %span= register.register_authority.data['name']
   %td
     - if register.register_phase == 'Alpha'
-      = link_to 'Open for feedback', support_question_path
+      %p Open for feedback
     - else
       = link_to 'Express interest', request_registers_path(register_title: register.name)

--- a/app/views/registers/in_progress.html.haml
+++ b/app/views/registers/in_progress.html.haml
@@ -17,7 +17,6 @@
     .column-two-thirds
       %h1.heading-large Upcoming registers
       %p These registers are being worked on and are not ready to use. This means the data is still changing and open to user feedback.
-      %p You can #{link_to 'contact the GOV.UK Registers team', support_path} to give feedback on a register.
       %p You can also see all the #{link_to 'registers you can use', registers_path}.
 
     .column-one-third

--- a/app/views/registers/show.html.haml
+++ b/app/views/registers/show.html.haml
@@ -8,7 +8,7 @@
       .column-two-thirds
         .panel.panel-border-wide
           %span.phase-banner In progress
-          %p This data is in progress and it’s not ready for use. #{link_to 'Contact the team', support_question_path} to give us feedback.
+          %p This data is in progress and it’s not ready for use.
 
   .register-meta-data
     .grid-row
@@ -65,14 +65,14 @@
                                   = label_tag 'Both', nil, for: 'status_all'
                               = submit_tag 'Search', name: nil, class: 'button filter-search-submit'
 
-              
+
               - if @records.any?
                 .records-count
                   %span#records-count
                     = render partial: 'showing'
                   - if params[:q].present? || params[:status].present?
                     = link_to 'Reset', register_path(@register.slug, anchor: 'records_wrapper'), class: 'reset-link'
-              
+
               - if @register.is_empty? || @records.any?
                 .fullscreen-content{data: {module: 'scrolling-tables'}}
                   %table.table.register-data-table


### PR DESCRIPTION
### Context
There were links to the general feedback form, which was felt to clash with the register specific feedback form, as well as confusing the upcoming registers page with multiple call to actions.

### Changes proposed in this pull request
The links were removed on the list of upcoming registers, and on the upcoming register page as well.

### Guidance to review
None.