### PR TITLE
Bring back numbers

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -6,6 +6,7 @@ class PagesController < ApplicationController
 
     @ready_registers = Register.available.where(register_phase: 'Beta')
     @upcoming_registers = Register.available.where.not(register_phase: 'Beta')
+    @organisation_count = @ready_registers.distinct.count(:authority)
   end
 
   def services_using_registers; end

--- a/app/views/pages/home.html.haml
+++ b/app/views/pages/home.html.haml
@@ -50,9 +50,22 @@
 
     %section.content-section.content-section--with-top-border
       .grid-row
-        .column-full
-          %h2.heading-medium.content-section__title Get started
-          %p{data: {"click-events" => "", "click-category" => "Content", "click-action" => "Navigation Link Clicked"}} Search all the #{link_to 'registers you can use', registers_path} to see what government data is available.
+        %h2.heading-medium.content-section__title.column-full Registers in numbers
+        .column-one-third
+          .data
+            = link_to registers_path do
+              %span.data-item.bold-xxlarge= @ready_registers.count
+              %span.bold-xsmall registers available
+        .column-one-third
+          .data
+            = link_to registers_path do
+              %span.data-item.bold-xxlarge= @organisation_count
+              %span.bold-xsmall government organisations providing registers
+        .column-one-third
+          .data
+            = link_to services_using_registers_path do
+              %span.data-item.bold-xxlarge 13
+              %span.bold-xsmall services using registers
 
 = content_for :javascript do
   :javascript

--- a/app/views/pages/services_using_registers.html.haml
+++ b/app/views/pages/services_using_registers.html.haml
@@ -33,7 +33,7 @@
             %td
               = link_to 'Local Authority England', '/registers/local-authority-eng'
               %br/
-              = link_to 'Local Authority Scotland', '/registers/principal-local-authority'
+              = link_to 'Local Authority Scotland', '/registers/local-authority-sct'
               %br/
               = link_to 'Principal Local Authority', '/registers/principal-local-authority'
               %br/


### PR DESCRIPTION
### Context
We used to have a section on the homepage that displayed numbers. This got removed in 7ed92fa81ab09f223bcee306c663ccaf3690fcd8 but we want to add back something similar, instead of the get started section at the bottom of the page, which just links to the registers available.

### Changes proposed in this pull request
Show the number of registers, the number of organisations providing registers, and the number of services using registers.

<img width="1013" alt="screen shot 2018-07-19 at 16 07 44" src="https://user-images.githubusercontent.com/87579/42951911-384a38ba-8b6f-11e8-8670-b4f6e54755de.png">

- The first two numbers aren't accurate, as this is based on my dev environment. They both link to the registers available.
- The last one is hardcoded and counts the services listed on https://www.registers.service.gov.uk/services-using-registers.

Trello: https://trello.com/c/OEbrZQtu/2659-add-registers-stats-to-homepage

### Guidance to review
- Is it showing the right thing?
- Is the markup ok?

I'm counting the number of distinct authorities, which is set by the admin tool. This should reflect the number of distinct logos on https://www.registers.service.gov.uk/registers (which can be agencies and other groups besides departments)