### PR TITLE
Upcoming registers link made more prominent.

### DIFF
--- a/app/views/registers/index.html.haml
+++ b/app/views/registers/index.html.haml
@@ -15,7 +15,9 @@
     .column-two-thirds
       %h1.heading-large
         Registers available
+      %p.heading-large
         %span.heading-secondary Registers are up-to-date lists of information that are managed and approved by government. You can use this data to build and maintain your service.
+      %p You can also see #{link_to 'registers that are coming soon', registers_in_progress_path}.
     .column-one-third
       = form_tag registers_path(anchor: 'content'), class: 'records-search', method: 'get' do
         = label_tag :q, 'Search', class: 'visually-hidden'
@@ -73,7 +75,6 @@
           %p
             No results found for <strong>"#{@search_term}"</strong>
             = link_to 'Reset', registers_path, class: 'reset-link'
-      %p You can also see #{link_to 'registers that are coming soon', registers_in_progress_path}.
 
 = content_for :javascript do
   :javascript


### PR DESCRIPTION
### Context
The list of registers page has a link to upcoming registers at the bottom of the page. This was moved to the top of the page to sit just underneath the introduction.

### Changes proposed in this pull request
 - Link to upcoming registers moved to top of page.
 - Link to upcoming registers at the bottom of the page has been removed.
 - Heading tweaked to make semantic sense and play better with a screenreader - with no visual difference.

### Guidance to review
[Trello card](https://trello.com/c/rfxVfBfc/2664-update-upcoming-registers-information-on-the-registers-available-page)