### PR TITLE
The archived scope should exclude records ending in the future

### DIFF
--- a/app/models/record.rb
+++ b/app/models/record.rb
@@ -1,8 +1,8 @@
 class Record < ApplicationRecord
   include SearchScope
   belongs_to :register
-  scope :current, -> { where("data->> 'end-date' is null") }
-  scope :archived, -> { where("data->> 'end-date' is not null") }
+  scope :current, -> { where("end_date is null or end_date > now() at time zone 'utc'") }
+  scope :archived, -> { where("end_date <= now() at time zone 'utc'") }
   scope :status, lambda { |status|
     case status
     when 'archived', 'current'

--- a/spec/factories/records.rb
+++ b/spec/factories/records.rb
@@ -1,0 +1,11 @@
+FactoryBot.define do
+  factory :record do
+    entry_type "user"
+    data("favourite-colour" => "blue")
+    sequence :key do |n|
+      "key-#{n}"
+    end
+    hash_value { Digest::SHA256.hexdigest(data.sort.to_h.to_json) }
+    register
+  end
+end

--- a/spec/models/record_spec.rb
+++ b/spec/models/record_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+RSpec.describe(Record) do
+  describe("#status") do
+    before do
+      create(:record, key: "past", end_date: Time.utc(1990, 10, 2, 0, 0, 0))
+      create(:record, key: "future", end_date: Time.utc(2999, 10, 2, 0, 0, 0))
+      create(:record, key: "nil", end_date: nil)
+    end
+
+    context "archived" do
+      it "includes only records with an end date in the past" do
+        expect(Record.status("archived").pluck(:key)).to eq(%w(past))
+      end
+    end
+
+    context "current" do
+      it "includes records with an end date in the future" do
+        expect(Record.status("current").pluck(:key)).to include("future")
+      end
+
+      it "excludes records with an end date in the past" do
+        expect(Record.status("current").pluck(:key)).not_to include("past")
+      end
+
+      it "includes records with a nil end date" do
+        expect(Record.status("current").pluck(:key)).to include("nil")
+      end
+    end
+
+    context "all" do
+      it "includes all records" do
+        keys = Record.status("all").pluck(:key)
+        expect(keys.sort).to eq(%w(future nil past))
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context
This is the second part of https://trello.com/c/r48dv7N1/2662-archived-filter-should-not-include-end-dates-that-are-in-the-future
Please review https://github.com/openregister/registers-frontend/pull/393 first. 🙇 

Currently we use the presence of an "end-date" value in the data to indicate that a record is archived. This is surfaced by the filters on the register page, eg https://www.registers.service.gov.uk/registers/country?utf8=%E2%9C%93&q=&status=archived#records_wrapper

This doesn't work as intended, because that value could be a date in the future, in which case the record should still be considered current.

### Changes proposed in this pull request
This changes the logic to only make records archived if the end date is set and in the past.

### Guidance to review
- [ ] Review https://github.com/openregister/registers-frontend/pull/393 - I'll merge and deploy this first.
- [ ] Review this PR