### PR TITLE
Underlines on the homepage stats are brought back.

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -313,8 +313,9 @@ table {
     font-size: 16px;
     text-decoration: none;
 
-    .data-item.bold-xsmall {
+    .data-item.bold-small {
       text-decoration: underline;
+      line-height: 1.3157894737;
     }
   }
 }

--- a/app/views/pages/home.html.haml
+++ b/app/views/pages/home.html.haml
@@ -55,17 +55,17 @@
           .data
             = link_to registers_path do
               %span.data-item.bold-xxlarge= @ready_registers.count
-              %span.bold-xsmall registers available
+              %span.data-item.bold-small registers available
         .column-one-third
           .data
             = link_to registers_path do
               %span.data-item.bold-xxlarge= @organisation_count
-              %span.bold-xsmall government organisations providing registers
+              %span.data-item.bold-small government organisations providing&nbsp;registers
         .column-one-third
           .data
             = link_to services_using_registers_path do
               %span.data-item.bold-xxlarge 13
-              %span.bold-xsmall services using registers
+              %span.data-item.bold-small services using registers
 
 = content_for :javascript do
   :javascript


### PR DESCRIPTION
<img width="982" alt="screen shot 2018-07-25 at 11 17 46" src="https://user-images.githubusercontent.com/1732331/43195255-63536040-8ffc-11e8-944a-7de4db61714e.png">

### Context
The three numbers on the homepage were links, but it wasn't obvious that they were clickable without the underlines present.

### Changes proposed in this pull request
 - Added underlines to the text by tweaking the application CSS
 - Returned line height to default
 - Made the text slightly larger for increased legibility
 - Avoid one word being on it's own line by using a non-breaking space

### Guidance to review
None.