### PR TITLE
Only run database migrations on one instance

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: rake db:migrate && bin/rails server
+web: rake cf:on_first_instance db:migrate && bin/rails server

--- a/Rakefile
+++ b/Rakefile
@@ -6,3 +6,11 @@ task default: :about
 require_relative 'config/application'
 
 Rails.application.load_tasks
+
+namespace :cf do
+  desc "Only run on the first application instance"
+  task :on_first_instance do
+      instance_index = JSON.parse(ENV["VCAP_APPLICATION"])["instance_index"] rescue nil
+  exit(0) unless instance_index == 0
+  end
+end


### PR DESCRIPTION
### Context
Today we tried to deploy some changes that included a long
running database migration.

Although the site didn't go down, cloudfoundry said it couldn't
start the app. In the logs we noticed it was throwing
`ActiveRecord::ConcurrentMigrationError`.

### Changes proposed in this pull request
This implements the approach from
https://docs.cloudfoundry.org/buildpacks/ruby/rake-config.html
to ensure migrations only get run on one instance. With this
change the migrations ran OK on registers-frontend-research.

### Guidance to review
