### PR TITLE
Add a new job to redownload a register

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ If you need to use the Zendesk service you need to add 3 environment variables
 
 Add any registers using the `/admin` UI.
 
+If you need to redownload an existing register from scratch, you can run the job `bundle exec rake registers_frontend:populate_db:force_full_register_download[SLUG]` where `SLUG` is the slug of the register.
+
 ### prod
 
 When running in production the `registers-frontend-scheduler` app periodically calls `rake registers_frontend:populate_db:fetch_later` which adds a job to a queue maintained by the `registers-frontend-queue` app. When the job runs it refreshes the data for all registers listed in the database.  

--- a/app/jobs/force_full_register_download_job.rb
+++ b/app/jobs/force_full_register_download_job.rb
@@ -1,4 +1,4 @@
-class RedownloadRegisterJob < ApplicationJob
+class ForceFullRegisterDownloadJob < ApplicationJob
   queue_as :default
 
   class FrontendInvalidRegisterError < StandardError; end
@@ -15,13 +15,7 @@ class RedownloadRegisterJob < ApplicationJob
 
       logger.info("Updating #{register.name} in database")
 
-      begin
-        RegisterDownloader.download(register)
-      rescue InvalidRegisterError => e
-        logger.error("Failed to redownload #{register.name}")
-        raise FrontendInvalidRegisterError.new("#{register.name}: #{e}")
-      end
-
+      RegisterDownloader.download(register)
       RegisterSearchResult.refresh
     end
   end

--- a/app/jobs/force_full_register_download_job.rb
+++ b/app/jobs/force_full_register_download_job.rb
@@ -6,14 +6,14 @@ class ForceFullRegisterDownloadJob < ApplicationJob
   # Redownload all the entries in a register
   def perform(register)
     ActiveRecord::Base.transaction do
-      logger.info("Removing existing #{register.name} records from database")
+      Delayed::Worker.logger.info("Removing existing #{register.name} records from database")
 
       Record.where(register_id: register.id).delete_all
       Entry.where(register_id: register.id).delete_all
       register.root_hash = nil
       register.save
 
-      logger.info("Updating #{register.name} in database")
+      Delayed::Worker.logger.info("Updating #{register.name} in database")
 
       RegisterDownloader.download(register)
       RegisterSearchResult.refresh

--- a/app/jobs/populate_register_data_in_db_job.rb
+++ b/app/jobs/populate_register_data_in_db_job.rb
@@ -7,7 +7,7 @@ class PopulateRegisterDataInDbJob < ApplicationJob
     RegisterDownloader.download(register)
     RegisterSearchResult.refresh
   rescue InvalidRegisterError
-    logger.info "Failed to update #{register.name}, so forcing a full reload instead"
-    RedownloadRegisterJob.perform_now(register)
+    logger.info "Root hash has changed for #{register.name}, so forcing a full reload instead"
+    ForceFullRegisterDownloadJob.perform_now(register)
   end
 end

--- a/app/jobs/populate_register_data_in_db_job.rb
+++ b/app/jobs/populate_register_data_in_db_job.rb
@@ -7,7 +7,7 @@ class PopulateRegisterDataInDbJob < ApplicationJob
     RegisterDownloader.download(register)
     RegisterSearchResult.refresh
   rescue InvalidRegisterError
-    logger.info "Root hash has changed for #{register.name}, so forcing a full reload instead"
+    Delayed::Worker.logger.info "Root hash has changed for #{register.name}, so forcing a full reload instead"
     ForceFullRegisterDownloadJob.perform_now(register)
   end
 end

--- a/app/jobs/redownload_register_job.rb
+++ b/app/jobs/redownload_register_job.rb
@@ -1,0 +1,32 @@
+class RedownloadRegisterJob < ApplicationJob
+  queue_as :default
+
+  class FrontendInvalidRegisterError < StandardError; end
+
+  # Redownload all the entries in a register
+  def perform(register)
+    ActiveRecord::Base.transaction do
+      logger.info("Removing existing #{register.name} records from database")
+
+      Record.where(register_id: register.id).delete_all
+      Entry.where(register_id: register.id).delete_all
+      register.root_hash = nil
+      register.save
+
+      logger.info("Updating #{register.name} in database")
+
+      begin
+        RegisterDownloader.download(register)
+      rescue InvalidRegisterError => e
+        logger.error("Failed to redownload #{register.name}")
+        raise FrontendInvalidRegisterError.new("#{register.name}: #{e}")
+      end
+
+      RegisterSearchResult.refresh
+    end
+  end
+
+private
+
+  attr_reader :registers_client_manager
+end

--- a/app/services/register_downloader.rb
+++ b/app/services/register_downloader.rb
@@ -1,0 +1,21 @@
+module RegisterDownloader
+  def self.download(register)
+    # Deliberately reinstantiate the manager each time.
+    # This is because requesting a register has the side effect of downloading it,
+    # but only the *first* time you request that register from the same manager.
+    registers_client_manager = RegistersClient::RegisterClientManager.new(
+      {
+        api_key: Rails.configuration.try(:registers_api_key)
+      }.compact
+    )
+
+    register_client = registers_client_manager.get_register(register.name.parameterize, register.register_phase.downcase, data_store: PostgresDataStore.new(register))
+    register_url = register_client.instance_variable_get(:@register_url)
+
+    register.fields_array = Record.where(key: "register:#{register.slug}")
+                                .pluck("data -> 'fields' as fields")
+                                .first
+    register.url = register_url
+    register.save
+  end
+end

--- a/lib/tasks/populate_register_data_in_db.rake
+++ b/lib/tasks/populate_register_data_in_db.rake
@@ -18,7 +18,7 @@ namespace :registers_frontend do
     end
 
     desc 'For local envs: Force a full redownload of a single register'
-    task :force_full_register_download, [:slug] => [:environment] do |_t, args|
+    task :force_full_register_download_now, [:slug] => [:environment] do |_t, args|
       register = Register.find_by(slug: args.slug)
       puts("starting full redownload of register #{register.name}")
       ForceFullRegisterDownloadJob.perform_now(register)

--- a/lib/tasks/populate_register_data_in_db.rake
+++ b/lib/tasks/populate_register_data_in_db.rake
@@ -12,19 +12,22 @@ namespace :registers_frontend do
     desc 'For local envs: populate register data in the database now'
     task fetch_now: :environment do
       Register.where.not(register_phase: 'Backlog').find_each do |register|
-        begin
-          retries ||= 0
-          puts("populating register #{register.name}")
-          PopulateRegisterDataInDbJob.perform_now(register)
-        rescue PopulateRegisterDataInDbJob::Exceptions::FrontendInvalidRegisterError => e
-          retry if (retries += 1) < 2
-          puts "[Error] #{e.message}"
-          next
-        rescue StandardError => e
-          puts "[Error] #{e.message}"
-          next
-        end
+        puts("populating register #{register.name}")
+        PopulateRegisterDataInDbJob.perform_now(register)
       end
+    end
+
+    desc 'For local envs: Force a full redownload of a single register'
+    task :force_full_register_download, [:slug] => [:environment] do |_t, args|
+      register = Register.find_by(slug: args.slug)
+      puts("starting full redownload of register #{register.name}")
+      ForceFullRegisterDownloadJob.perform_now(register)
+    end
+
+    desc 'Add task to the queue to force a full redownload of a single register'
+    task :force_full_register_download, [:slug] => [:environment] do |_t, args|
+      register = Register.find_by(slug: args.slug)
+      ForceFullRegisterDownloadJob.perform_later(register)
     end
   end
 end

--- a/spec/jobs/handle_invalid_register_spec.rb
+++ b/spec/jobs/handle_invalid_register_spec.rb
@@ -1,34 +1,58 @@
 require 'rails_helper'
 
-RSpec.describe PopulateRegisterDataInDbJob, type: :job do
-  describe 'handle invalid register exception' do
-    before(:all) do
-      country_data = File.read('./spec/support/country.rsf')
-      stub_request(:get, "https://country.register.gov.uk/download-rsf/0").
+RSpec.describe 'handling invalid register exceptions' do
+  let!(:country) do
+    country = create(
+      :register,
+      name: 'country',
+      register_phase: 'beta',
+      authority: 'D587'
+    )
+
+    country_data = File.read('./spec/support/country.rsf')
+    stub_request(:get, "https://country.register.gov.uk/download-rsf/0").
       with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip, deflate', 'Host' => 'country.register.gov.uk' }).
       to_return(status: 200, body: country_data, headers: {})
 
-      country_invalid_hash = File.read('./spec/support/country_invalid_hash.rsf')
-      stub_request(:get, "https://country.register.gov.uk/download-rsf/207").
-      with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip, deflate', 'Host' => 'country.register.gov.uk' }).
-      to_return(status: 200, body: country_invalid_hash, headers: {})
+    # Populate register with 208 records
+    PopulateRegisterDataInDbJob.perform_now(country)
 
-      country_proof = File.read('./spec/support/country_proof.json')
-      country_proof_update = File.read('./spec/support/country_proof_update.json')
-      stub_request(:get, "https://country.register.gov.uk/proof/register/merkle:sha-256").
+    country
+  end
+
+  let(:country_invalid_hash) { File.read('./spec/support/country_invalid_hash.rsf') }
+
+  before do
+    country_proof = File.read('./spec/support/country_proof.json')
+    country_proof_update = File.read('./spec/support/country_proof_update.json')
+
+    stub_request(:get, "https://country.register.gov.uk/proof/register/merkle:sha-256").
       with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip, deflate', 'Host' => 'country.register.gov.uk' }).
       to_return({ body: country_proof }, body: country_proof_update)
-    end
+  end
 
-    it 'throws exception when register invalid and deletes records and entries' do
-      country = ObjectsFactory.new.create_register('country', 'beta', 'D587')
-      expect { PopulateRegisterDataInDbJob.perform_now(country) }.to raise_error(PopulateRegisterDataInDbJob::Exceptions::FrontendInvalidRegisterError, 'country: Register has been reloaded with different data - root hashes do not match')
-      expect(Record.where(register_id: country.id).count).to equal(0)
-      expect(Entry.where(register_id: country.id).count).to equal(0)
+  describe PopulateRegisterDataInDbJob, type: :job do
+    it 'runs the redownload register job when the register is invalid' do
+      stub_request(:get, "https://country.register.gov.uk/download-rsf/207").
+        with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip, deflate', 'Host' => 'country.register.gov.uk' }).
+        to_return(status: 200, body: country_invalid_hash, headers: {})
+
+      expect(RedownloadRegisterJob).to receive(:perform_now)
+
+      PopulateRegisterDataInDbJob.perform_now(country)
     end
   end
 
-  after(:all) do
-    DatabaseCleaner.clean_with(:truncation)
+  describe RedownloadRegisterJob, type: :job do
+    it 'rolls back and raises an error if the register is invalid' do
+      stub_request(:get, "https://country.register.gov.uk/download-rsf/0").
+        with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip, deflate', 'Host' => 'country.register.gov.uk' }).
+        to_return(status: 200, body: country_invalid_hash, headers: {})
+
+      expect { RedownloadRegisterJob.perform_now(country) }.to raise_error(RedownloadRegisterJob::FrontendInvalidRegisterError, 'country: Register has been reloaded with different data - root hashes do not match')
+
+      expect(Record.where(register_id: country.id).count).to eq(208)
+      expect(Entry.where(register_id: country.id).count).to eq(219)
+    end
   end
 end


### PR DESCRIPTION
### Context
We want to be able to redownload a register from scratch with zero downtime ([trello](https://trello.com/c/z7xw1LGy/2706-ability-to-force-full-reload-of-registers-in-registers-frontend-with-0-downtime-to-pick-up-metadata-changes)).

We need this in two situations:

- For discovery/alpha registers, we don't enforce the append-only nature of the register. So when we go back and change history, we need to fetch everything again. This one we can do already as we don't care about downtime.

- The java implementation stores system entries seperately, and these are not currently retrievable as part of a partial update. So as a workaround we need to rebuild the register in registers-frontend whenever new system entries are added. This we can't do now.

### Changes proposed in this pull request
I've added a job which deletes a registers existing records, nullifies its root hash, and redownloads the register, inside a transaction.

The existing PopulateRegisterDataInDbJob job now calls the new job as a fallback if the register is invalid. This is equivalent to the existing behaviour - which would delete the data and then retry the job - but it does it inside a transaction.

I've factored out the part that calls the client library into a new class, and I've removed the `refresh_data` call, because I don't think we need it. The client library already calls this when you initialise a register client, so it was attempting to fetch data twice, which complicated the tests.

### Guidance to review
I've tested this locally by manually changing the root hash of a large register (charity) in register-frontend's database, then running the job. The website still works while the job is running, and after the job has run the root hash is correct and there is the correct number of records.