### PR TITLE
do not show featured box if performing search

### DIFF
--- a/app/views/registers/index.html.haml
+++ b/app/views/registers/index.html.haml
@@ -33,7 +33,7 @@
               = link_to 'Reset', registers_path, class: 'reset-link'
         .grid-row
           .column-full
-            - if @registers.featured.present?
+            - if @registers.featured.present? && !@search_term
               %h2.heading-small Featured
               %ol.app-c-highlight-boxes
                 - @registers.featured.by_popularity.each do |register|


### PR DESCRIPTION
### Context
does not make sense to show featured box if user is performing a search

### Changes proposed in this pull request
If user is performing a search do not show featured box 

### Guidance to review
__before__
![screen shot 2018-07-30 at 12 47 47](https://user-images.githubusercontent.com/1764158/43395749-19519026-93f7-11e8-8e94-29c20c665655.png)

__after__
![screen shot 2018-07-30 at 12 48 02](https://user-images.githubusercontent.com/1764158/43395756-1ff75208-93f7-11e8-9ddb-935e420de87d.png)


