### PR TITLE
create back link on client side

### DIFF
--- a/app/views/records/show.html.haml
+++ b/app/views/records/show.html.haml
@@ -4,8 +4,7 @@
 %main#content.container{role:'main'}
   .grid-row
     .column-two-thirds
-      - if request.referer.present?
-        = link_to "Back", :back, class: 'link-back'
+      %div#link-back
       %h1.heading-large Record <strong>#{params[:id]}</strong> in the <strong>#{@register.register_name}</strong> register
   .grid-row
     .column-full
@@ -26,3 +25,14 @@
   .grid-row
     .column-two-thirds
       %p This is a record from the #{link_to @register.register_name, register_path(@register.slug)} register
+      = content_for :javascript do
+        :javascript
+            var isInternalReferrer = document.referrer.indexOf(location.protocol + "//" + location.host) === 0;
+            if (isInternalReferrer) {
+              var backLink = document.createElement("a");
+              backLink.setAttribute("href", "javascript:history.back()");
+              backLink.setAttribute("class", "link-back");
+              backLink.textContent = "Back";
+              document.getElementById("link-back").appendChild(backLink);
+            }
+


### PR DESCRIPTION
### Context
The back link introduced in #366 was not working on production as the `referer` header is stripped by the CDN

### Changes proposed in this pull request
Create back link on client-side.

### Guidance to review
Back link should appear only where user comes from internal link

(note this introduces some jank due to the DOM mutation but I am not sure how to avoid that)