### PR TITLE
Optionally include an API key when requesting data for downloads

### DIFF
--- a/app/controllers/download_controller.rb
+++ b/app/controllers/download_controller.rb
@@ -39,12 +39,12 @@ class DownloadController < ApplicationController
   def success; end
 
   def download_json
-    data = download_format("json")
+    data = RegisterDownloader.new(@register).download_format('json')
     send_data data, type: "application/json; header=present", disposition: "attachment; filename=#{@register.slug}.json"
   end
 
   def download_csv
-    data = download_format("csv")
+    data = RegisterDownloader.new(@register).download_format('csv')
     send_data data, type: "application/csv; header=present", disposition: "attachment; filename=#{@register.slug}.csv"
   end
 
@@ -63,22 +63,5 @@ private
       :is_government,
       :register
     )
-  end
-
-  def api_key
-    Rails.configuration.try(:user_download_api_key)
-  end
-
-  def download_format(format)
-    uri = "#{@register.url}/records.#{format}?page-size=5000"
-    headers = {}
-    headers['Authorization'] = api_key if api_key.present?
-
-    response = HTTParty.get(uri, headers: headers)
-    if response.code == 200
-      response.body
-    else
-      raise "#{response.status}: #{response.message}"
-    end
   end
 end

--- a/app/services/register_records_downloader.rb
+++ b/app/services/register_records_downloader.rb
@@ -1,0 +1,26 @@
+class RegisterRecordsDownloader
+  class DownloadError < StandardError; end
+
+  def initialize(register, api_key: Rails.configuration.try(:user_download_api_key))
+    @register = register
+    @api_key = api_key
+  end
+
+  def download_format(format)
+    uri = "#{register.url}/records.#{format}?page-size=5000"
+    headers = {}
+    headers['Authorization'] = api_key if api_key.present?
+
+    response = HTTParty.get(uri, headers: headers)
+    if response.code == 200
+      response.body
+    else
+      raise DownloadError.new("#{response.code}: #{response.message}")
+    end
+  end
+
+private
+
+  attr_reader :register
+  attr_reader :api_key
+end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -103,4 +103,6 @@ Rails.application.configure do # rubocop:disable Metrics/BlockLength
   config.public_file_server.headers = {
     'Cache-Control' => 'public, max-age=31536000'
   }
+
+  config.user_download_api_key = ENV.fetch('USER_DOWNLOAD_API_KEY')
 end

--- a/spec/services/register_records_downloader_spec.rb
+++ b/spec/services/register_records_downloader_spec.rb
@@ -1,0 +1,53 @@
+require 'rails_helper'
+
+RSpec.describe RegisterRecordsDownloader do
+  let(:url) { 'https://country.register.gov.uk' }
+  let(:register) { create(:register, url: url) }
+  let(:downloader) { RegisterRecordsDownloader.new(register) }
+
+  it "fetches CSV" do
+    csv = "c,s,v\n,foo,bar,baz"
+
+    stub_request(:get, url + "/records.csv?page-size=5000").to_return(
+      body: csv
+    )
+
+    response = downloader.download_format("csv")
+    expect(response).to eq(csv)
+  end
+
+  it "fetches JSON" do
+    json = '{"foo":"bar"}'
+
+    stub_request(:get, url + "/records.json?page-size=5000").to_return(
+      body: json
+    )
+
+    response = downloader.download_format("json")
+    expect(response).to eq(json)
+  end
+
+  it "raises DownloadError on non-200 responses" do
+    stub_request(:get, url + "/records.json?page-size=5000").to_return(
+      status: 500
+    )
+
+    expect { downloader.download_format("json") }.to raise_error(RegisterRecordsDownloader::DownloadError)
+  end
+
+  it "passes an API key if set" do
+    downloader_with_key = RegisterRecordsDownloader.new(register, api_key: 'foo')
+    json = '{"foo":"bar"}'
+    download_url = url + "/records.json?page-size=5000"
+
+    stub_request(:get, download_url).to_return(
+      body: json
+    )
+
+    downloader_with_key.download_format("json")
+
+    expect(WebMock).to have_requested(:get, download_url).with(
+      headers: { 'Authorization' => 'foo' }
+    )
+  end
+end


### PR DESCRIPTION
### Context
When data is downloaded through registers frontend, it requests the data from ORJ without a key. We want this to use a key on production so that we can separate this traffic out in the analytics.

### Changes proposed in this pull request
Instead of calling `open` with a URL, use HTTParty, and pass an API key if it exsits.

This sets the API key from the environment in production, but ignores it on other environments.

I originally had this just read from environment whenever its present (which is how I tested it locally), but I've changed the config to be consistent with how `config.registers_api_key` is set.

### Guidance to review
