### PR TITLE
switch to ha, encrypted db

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -4,7 +4,7 @@ defaults: &defaults
   memory: 1GB
   services:
     # postgres database
-    - registers-frontend
+    - registers-frontend-ha-encrypted
     # environment variables (persisted for blue/green deploys)
     - registers-product-site-environment-variables
     # logging


### PR DESCRIPTION
### Context
We need to migrate to high availability database as per [production checklist](https://docs.cloud.service.gov.uk/deploying_apps.html#production-checklist)

### Changes proposed in this pull request
change binding to ha-encrypted database

### Guidance to review
travis CI should deploy successfully with new binding
