### PR TITLE
bind registers app to ha-encrypted db

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -20,7 +20,7 @@ applications:
   health-check-http-endpoint: /health_check/standard
   services:
     # TODO: This block overrides to add prometheus but we should do this using inheritence if possible
-    - registers-frontend
+    - registers-frontend-ha-encrypted
     - registers-product-site-environment-variables
     - logit-ssl-drain
     - prometheus


### PR DESCRIPTION
### Context
Follow-up to #405. I forgot to bind `registers` app as its services are defined in a separate block.

### Changes proposed in this pull request
bind `registers` app to `ha-encrypted` db.

### Guidance to review
Should deploy successfully in travis CI.
