### PR TITLE
Analytics rationalisation and update

### DIFF
--- a/app/assets/javascripts/accordion-with-descriptions.js
+++ b/app/assets/javascripts/accordion-with-descriptions.js
@@ -1,10 +1,9 @@
 (function (Modules) {
-  "use strict";
+  /* globals $, ga */
+  'use strict';
 
-  Modules.AccordionWithDescriptions = function() {
-
-    this.start = function($element) {
-
+  Modules.AccordionWithDescriptions = function () {
+    this.start = function ($element) {
       // Indicate that js has worked
       $element.addClass('js-accordion-with-descriptions');
 
@@ -18,7 +17,7 @@
       var $openOrCloseAllButton;
       var GOVUKServiceManualTopic = serviceManualTopicPrefix();
 
-      //addOpenCloseAllButton();
+      // addOpenCloseAllButton();
       addButtonsToSubsections();
       addIconsToSubsections();
       addAriaControlsAttrForOpenCloseAllButton();
@@ -30,44 +29,44 @@
       bindToggleForSubsections();
       bindToggleOpenCloseAllButton();
 
-      function getserviceManualTopic() {
+      function getserviceManualTopic () {
         return $('h1').text();
       }
 
-      function replaceSpacesWithUnderscores(str) {
-        return str.replace(/\s+/g,"_");
+      function replaceSpacesWithUnderscores (str) {
+        return str.replace(/\s+/g, '_');
       }
 
-      function serviceManualTopicPrefix() {
+      function serviceManualTopicPrefix () {
         var topic = getserviceManualTopic();
         topic = replaceSpacesWithUnderscores(topic);
         topic = topic.toLowerCase();
 
-        return "GOVUK_service_manual_" + topic + "_";
+        return 'GOVUK_service_manual_' + topic + '_';
       }
 
-      function addOpenCloseAllButton() {
-        $element.prepend( '<div class="subsection-controls js-subsection-controls"><button aria-expanded="false">Open all</button></div>' );
+      function addOpenCloseAllButton () {
+        $element.prepend('<div class="subsection-controls js-subsection-controls"><button aria-expanded="false">Open all</button></div>');
       }
 
-      function addButtonsToSubsections() {
+      function addButtonsToSubsections () {
         var $subsectionTitle = $element.find('.subsection__title');
 
         // Wrap each title in a button, with aria controls matching the ID of the subsection
-        $subsectionTitle.each(function(index) {
-          $(this).wrapInner( '<button class="subsection__button" aria-expanded="false" aria-controls="subsection_content_' + index +'"></a>' );
+        $subsectionTitle.each(function (index) {
+          $(this).wrapInner('<button class="subsection__button" aria-expanded="false" aria-controls="subsection_content_' + index + '"></a>');
         });
       }
 
-      function addIconsToSubsections() {
-        $subsectionHeader.append( '<span class="subsection__icon"></span>' );
+      function addIconsToSubsections () {
+        $subsectionHeader.append('<span class="subsection__icon"></span>');
       }
 
-      function addAriaControlsAttrForOpenCloseAllButton() {
+      function addAriaControlsAttrForOpenCloseAllButton () {
         // For each of the sections, create a string with all the subsection content IDs
-        var ariaControlsValue = "";
+        var ariaControlsValue = '';
         for (var i = 0; i < totalSubsections; i++) {
-          ariaControlsValue += "subsection_content_"+i+" ";
+          ariaControlsValue += 'subsection_content_' + i + ' ';
         }
 
         $openOrCloseAllButton = $element.find('.js-subsection-controls button');
@@ -76,14 +75,14 @@
         $openOrCloseAllButton.attr('aria-controls', ariaControlsValue);
       }
 
-      function closeOpenSections() {
+      function closeOpenSections () {
         var $subsectionContent = $element.find('.subsection__content');
         closeSection($subsectionContent);
       }
 
-      function openLinkedSection() {
+      function openLinkedSection () {
         var anchor = getActiveAnchor(),
-            section;
+          section;
 
         if (!anchor.length) {
           return;
@@ -98,54 +97,53 @@
         }
       }
 
-      function getActiveAnchor() {
+      function getActiveAnchor () {
         return GOVUK.getCurrentLocation().hash;
       }
 
-      function checkSessionStorage() {
-
+      function checkSessionStorage () {
         var $subsectionContent = $element.find('.subsection__content');
 
-        $subsectionContent.each(function(index) {
+        $subsectionContent.each(function (index) {
           var subsectionContentId = $(this).attr('id');
-          if(sessionStorage.getItem(GOVUKServiceManualTopic+subsectionContentId)){
-            openStoredSections($("#"+subsectionContentId));
+          if (sessionStorage.getItem(GOVUKServiceManualTopic + subsectionContentId)) {
+            openStoredSections($('#' + subsectionContentId));
           }
         });
 
-        //setOpenCloseAllText();
+        // setOpenCloseAllText();
       }
 
-      function setSessionStorage() {
+      function setSessionStorage () {
         var isOpenSubsections = $('.subsection--is-open').length;
         if (isOpenSubsections) {
           var $openSubsections = $('.subsection--is-open');
-          $openSubsections.each(function(index) {
+          $openSubsections.each(function (index) {
             var subsectionOpenContentId = $(this).find('.subsection__content').attr('id');
-            sessionStorage.setItem( GOVUKServiceManualTopic+subsectionOpenContentId , 'Opened');
+            sessionStorage.setItem(GOVUKServiceManualTopic + subsectionOpenContentId, 'Opened');
           });
         }
       }
 
-      function removeSessionStorage() {
+      function removeSessionStorage () {
         var isClosedSubsections = $('.subsection').length;
         if (isClosedSubsections) {
           var $closedSubsections = $('.subsection');
-          $closedSubsections.each(function(index) {
+          $closedSubsections.each(function (index) {
             var subsectionClosedContentId = $(this).find('.subsection__content').attr('id');
-            sessionStorage.removeItem( GOVUKServiceManualTopic+subsectionClosedContentId , subsectionClosedContentId);
+            sessionStorage.removeItem(GOVUKServiceManualTopic + subsectionClosedContentId, subsectionClosedContentId);
           });
         }
       }
 
-      function bindToggleForSubsections() {
+      function bindToggleForSubsections () {
         // Add toggle functionality individual sections
-        $subsectionHeader.on('click', function(e) {
+        $subsectionHeader.on('click', function (e) {
           toggleSection($(this).next());
           toggleIcon($(this));
           toggleState($(this).find('.subsection__button'));
-          //setOpenCloseAllText();
-          if(window.ga && ga.create) {
+          // setOpenCloseAllText();
+          if (window.ga && ga.create) {
             fireTracking($(this));
           }
           setSessionStorage();
@@ -153,44 +151,44 @@
           return false;
         });
 
-        $subsectionButton.on('click', function(e) {
+        $subsectionButton.on('click', function (e) {
           toggleSection($(this).parent().parent().next());
           toggleIcon($(this).parent().parent());
           toggleState($(this));
-          //setOpenCloseAllText();
+          // setOpenCloseAllText();
           setSessionStorage();
           removeSessionStorage();
           return false;
         });
       }
 
-      function bindToggleOpenCloseAllButton() {
+      function bindToggleOpenCloseAllButton () {
         $openOrCloseAllButton = $element.find('.js-subsection-controls button');
-        $openOrCloseAllButton.on('click', function(e) {
+        $openOrCloseAllButton.on('click', function (e) {
           var action = '';
 
           // update button text
-          if ($openOrCloseAllButton.text() == "Open all") {
-            $openOrCloseAllButton.text("Close all");
-            $openOrCloseAllButton.attr("aria-expanded", "true");
+          if ($openOrCloseAllButton.text() == 'Open all') {
+            $openOrCloseAllButton.text('Close all');
+            $openOrCloseAllButton.attr('aria-expanded', 'true');
             action = 'open';
           } else {
-            $openOrCloseAllButton.text("Open all");
-            $openOrCloseAllButton.attr("aria-expanded", "false");
+            $openOrCloseAllButton.text('Open all');
+            $openOrCloseAllButton.attr('aria-expanded', 'false');
             action = 'close';
           }
 
           // Set aria-expanded for each button
-          $subsectionButton.each(function( index ) {
+          $subsectionButton.each(function (index) {
             if (action == 'open') {
-              setExpandedState($(this), "true");
+              setExpandedState($(this), 'true');
             } else {
-              setExpandedState($(this), "false");
+              setExpandedState($(this), 'false');
             }
           });
 
           // show/hide content
-          $subsectionHeader.each(function( index ) {
+          $subsectionHeader.each(function (index) {
             if (action == 'open') {
               openSection($(this).next());
               showOpenIcon($(this));
@@ -210,14 +208,14 @@
         });
       }
 
-      function openStoredSections($section) {
+      function openStoredSections ($section) {
         toggleSection($section);
         toggleIcon($section);
         toggleState($section.parent().find('.subsection__button'));
         // setOpenCloseAllText();
       }
 
-      function setOpenCloseAllText() {
+      function setOpenCloseAllText () {
         var openSubsections = $('.subsection--is-open').length;
         // Find out if the number of is-opens == total number of sections
         if (openSubsections === totalSubsections) {
@@ -227,7 +225,7 @@
         }
       }
 
-      function toggleSection($node) {
+      function toggleSection ($node) {
         if ($($node).hasClass('js-hidden')) {
           openSection($node);
         } else {
@@ -235,7 +233,7 @@
         }
       }
 
-      function toggleIcon($node) {
+      function toggleIcon ($node) {
         if ($($node).parent().hasClass('subsection--is-open')) {
           $node.parent().removeClass('subsection--is-open');
           $node.parent().addClass('subsection');
@@ -245,45 +243,41 @@
         }
       }
 
-      function toggleState($node) {
-        if ($($node).attr('aria-expanded') == "true") {
-          $node.attr("aria-expanded", "false");
+      function toggleState ($node) {
+        if ($($node).attr('aria-expanded') == 'true') {
+          $node.attr('aria-expanded', 'false');
         } else {
-          $node.attr("aria-expanded", "true");
+          $node.attr('aria-expanded', 'true');
         }
       }
 
-      function openSection($node) {
+      function openSection ($node) {
         $node.removeClass('js-hidden');
       }
 
-      function closeSection($node) {
+      function closeSection ($node) {
         $node.addClass('js-hidden');
       }
 
-      function showOpenIcon($node) {
+      function showOpenIcon ($node) {
         $node.parent().removeClass('subsection');
         $node.parent().addClass('subsection--is-open');
       }
 
-      function showCloseIcon($node) {
+      function showCloseIcon ($node) {
         $node.parent().removeClass('subsection--is-open');
         $node.parent().addClass('subsection');
       }
 
-      function setExpandedState($node, state) {
-        $node.attr("aria-expanded", state);
+      function setExpandedState ($node, state) {
+        $node.attr('aria-expanded', state);
       }
 
-      function fireTracking($node) {
-        var action = ''
+      function fireTracking ($node) {
         if ($($node).parent().hasClass('subsection--is-open')) {
-          action = 'Open'
-        } else {
-          action = 'Closed'
+          ga('send', 'event', 'Content', 'Open', $node[0].innerText);
         }
-        ga('send', 'event', 'Content', action, $node[0].innerText);
       }
-    }
+    };
   };
 })(window.GOVUK.Modules);

--- a/app/views/feedback/_form.html.haml
+++ b/app/views/feedback/_form.html.haml
@@ -19,10 +19,44 @@
     var showHideContent = new GOVUK.ShowHideContent();
     showHideContent.init();
 
-    document.getElementById('feedback_useful_yes').onclick = function() {
-      ga('send', 'event', 'Feedback', 'Radio - Yes', 'Is this register useful?');
-    }
+    document.getElementById('new_feedback')
+      .addEventListener('submit', function(event) {
+        event.preventDefault();
+        var form = event.target;
 
-    document.getElementById('feedback_useful_no').onclick = function() {
-      ga('send', 'event', 'Feedback', 'Radio - No', 'Is this register useful?');
-    }
+        var checkedRadios = form.querySelectorAll('input[type="radio"]:checked');
+
+        for (var i = 0; i < checkedRadios.length; i += 1) {
+          ga('send',  {
+            hitType: 'event',
+            eventCategory: 'Feedback',
+            eventAction: 'Radio - ' + checkedRadios[i].parentElement.querySelector('label').innerText,
+            eventLabel: checkedRadios[i].parentElement.parentElement.querySelector('legend').innerText,
+            nonInteraction: true
+          });
+        }
+
+      // Lets us know whether or not the Additional comments part of the
+      // feedback form is being used.
+      var additonalComments = form.querySelector('#feedback_message');
+      var checkedUsefulInput = form.querySelector('input[name="feedback[useful]"]:checked');
+      var eventAction = '';
+
+      if (checkedUsefulInput.value === 'yes') {
+        eventAction = 'Text - useful';
+      }
+      else if (checkedUsefulInput.value === 'no') {
+        eventAction = 'Text - not useful';
+      }
+
+      if (additonalComments.value.length >= 1) {
+        ga('send',  {
+          hitType: 'event',
+          eventCategory: 'Feedback',
+          eventAction: eventAction,
+          eventLabel: 'Is this register useful?',
+          nonInteraction: true
+        });
+      }
+      form.submit();
+    })

--- a/app/views/feedback/_form.html.haml
+++ b/app/views/feedback/_form.html.haml
@@ -27,11 +27,13 @@
         var checkedRadios = form.querySelectorAll('input[type="radio"]:checked');
 
         for (var i = 0; i < checkedRadios.length; i += 1) {
+          var action = 'Radio - ' + checkedRadios[i].parentElement.querySelector('label').innerText;
+          var label = checkedRadios[i].parentElement.parentElement.querySelector('legend').innerText;
           ga('send',  {
             hitType: 'event',
             eventCategory: 'Feedback',
-            eventAction: 'Radio - ' + checkedRadios[i].parentElement.querySelector('label').innerText,
-            eventLabel: checkedRadios[i].parentElement.parentElement.querySelector('legend').innerText,
+            eventAction: action,
+            eventLabel: label,
             nonInteraction: true
           });
         }

--- a/app/views/layouts/_analytics.html.erb
+++ b/app/views/layouts/_analytics.html.erb
@@ -10,7 +10,7 @@ var dimensions = {
   }
 };
 
-ga('create', 'UA-72121642-8', 'auto');
+ga('create', 'UA-86101042-3', 'auto');
 ga('set', 'anonymizeIp', true);
 ga('set', 'displayFeaturesTask', null);
 ga('set', dimensions.version.dimension, dimensions.version.payload);

--- a/app/views/layouts/_analytics.html.erb
+++ b/app/views/layouts/_analytics.html.erb
@@ -1,17 +1,20 @@
 <!-- Google Analytics -->
 <script>
+/* global ga, window */
+window.ga = window.ga || function () { (ga.q = ga.q || []).push(arguments); };
 
-(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+const dimensions = {
+  version: {
+    dimension: 'dimension2',
+    payload: 'v1'
+  }
+};
 
-ga('create', 'UA-86101042-3', 'auto');
+ga('create', 'UA-72121642-8', 'auto');
 ga('set', 'anonymizeIp', true);
 ga('set', 'displayFeaturesTask', null);
-ga('set', 'transport', 'beacon');
-
+ga('set', dimensions.version.dimension, dimensions.version.payload);
 ga('send', 'pageview');
-
 </script>
+<script src="https://www.google-analytics.com/analytics.js" async></script>
 <!-- End Google Analytics -->

--- a/app/views/layouts/_analytics.html.erb
+++ b/app/views/layouts/_analytics.html.erb
@@ -3,7 +3,7 @@
 /* global ga, window */
 window.ga = window.ga || function () { (ga.q = ga.q || []).push(arguments); };
 
-const dimensions = {
+var dimensions = {
   version: {
     dimension: 'dimension2',
     payload: 'v1'

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -5,7 +5,7 @@
 - content_for :after_header do
   %header{class: "header #{current_page?(root_path) ? 'header--without-border' : ''}"}
     .header__container
-      .header__brand{data: {"click-events" => "", "click-category" => "Header", "click-action" => "Logo Clicked"}}
+      .header__brand
         = link_to root_path do
           %span.govuk-logo
             = image_tag 'gov_uk_logotype_crown_invert_trans.png', height: 32, width: 36, class: 'govuk-logo__printable-crown'
@@ -19,7 +19,7 @@
       = check_box_tag 'show-menu', nil, false, class: 'header__navigation-toggle-checkbox', "aria-controls" => "navigation", "aria-expanded" => "false"
       = label_tag 'show-menu', 'Menu', class: 'header__navigation-toggle'
       %nav{id: "navigation", class: "header__navigation", role: "Navigation", "aria-label" => "Top Level Navigation", "aria-hidden" => "true"}
-        %ul{data: {"click-events" => "", "click-category" => "Header", "click-action" => "Navigation Link Clicked"}}
+        %ul
           %li{class: "#{'active' if current_page?(registers_path)}"}
             = link_to "Get data", registers_path
           %li{class: "#{'active' if current_page?(support_path)}"}
@@ -43,7 +43,7 @@
     .footer-categories-wrapper
       .grid-row
         .column-one-quarter
-          %ul{data: {"click-events" => "", "click-category" => "Footer", "click-action" => "Internal Link Clicked"}}
+          %ul
             %li
               = link_to "Get data", registers_path
             %li

--- a/app/views/pages/home.html.haml
+++ b/app/views/pages/home.html.haml
@@ -3,7 +3,7 @@
 %main{role:'main'}
   .masthead
     %nav.breadcrumbs.breadcrumbs--inverse{"aria-label" => "Breadcrumb"}
-      %ol{data: {"click-events" => "", "click-category" => "Header", "click-action" => "Breadcrumb Clicked"}}
+      %ol
         %li.breadcrumbs__item
           = link_to 'Components', 'https://www.gov.uk/service-toolkit#components'
         %li.breadcrumbs__item.breadcrumbs__item--active

--- a/app/views/registers/index.html.haml
+++ b/app/views/registers/index.html.haml
@@ -2,7 +2,7 @@
 - content_for :body_classes, 'register-index'
 
 %nav.breadcrumbs{role: "Navigation", "aria-label" => "Breadcrumb"}
-  %ol{data: {"click-events" => "", "click-category" => "Header", "click-action" => "Breadcrumb Clicked"}}
+  %ol
     %li.breadcrumbs__item
       = link_to 'Components', 'https://www.gov.uk/service-toolkit#components'
     %li.breadcrumbs__item

--- a/app/views/registers/index.html.haml
+++ b/app/views/registers/index.html.haml
@@ -74,6 +74,8 @@
         .search-results
           %p
             No results found for <strong>"#{@search_term}"</strong>
+            %script
+              ga('send', 'event', 'Search', 'No results', '#{@search_term}', {nonInteraction: true});
             = link_to 'Reset', registers_path, class: 'reset-link'
 
 = content_for :javascript do

--- a/app/views/registers/show.html.haml
+++ b/app/views/registers/show.html.haml
@@ -111,7 +111,7 @@
                       No results found for <strong>"#{@search_term}"</strong>
                       %script
                         var selectedInput = '';
-                        var searchFilter = document.getElementById('search_records').querySelector('input[type="radio"]:checked').labels[0].innerText.toLowerCase();
+                        var searchFilter = document.getElementById('search_records').querySelector('input[type="radio"]:checked').parentElement.querySelector('label').innerText.toLowerCase();
                         ga('send', 'event', 'Search', 'No results filtered by: ' + searchFilter, '#{@search_term}', {nonInteraction: true});
                     - else
                       No results found.

--- a/app/views/registers/show.html.haml
+++ b/app/views/registers/show.html.haml
@@ -77,11 +77,11 @@
                 .fullscreen-content{data: {module: 'scrolling-tables'}}
                   %table.table.register-data-table
                     %thead
-                      %tr{data: {"click-events" => true, "click-category" => "Register Table", "click-action" => "Sort"}}
+                      %tr
                         - @register.register_fields.each do |field|
                           %th{class: "#{field['field']}"}
                             = field['cardinality'] == '1' ? records_table_sort_link(field['field'], request.query_parameters) : field['field'].tr('-', ' ').humanize
-                            = link_to register_field_url(@register.slug, field['field']), class: 'info-icon', remote: true do
+                            = link_to register_field_url(@register.slug, field['field']), class: 'info-icon', remote: true, data: {"click-events" => true, "click-category" => "Register Table", "click-action" => "Help"} do
                               %span.visually-hidden
                                 What does #{field['field']} mean
                               ?

--- a/app/views/registers/show.html.haml
+++ b/app/views/registers/show.html.haml
@@ -109,8 +109,14 @@
                   %p
                     - if @search_term.present?
                       No results found for <strong>"#{@search_term}"</strong>
+                      %script
+                        var selectedInput = '';
+                        var searchFilter = document.getElementById('search_records').querySelector('input[type="radio"]:checked').labels[0].innerText.toLowerCase();
+                        ga('send', 'event', 'Search', 'No results filtered by: ' + searchFilter, '#{@search_term}', {nonInteraction: true});
                     - else
                       No results found.
+                      %script
+                        ga('send', 'event', 'Search', 'No results', 'Search term not present');
                     - if @search_term.present? || params[:status].present?
                       = link_to 'Reset', register_path(@register.slug, anchor: 'search_wrapper'), class: 'reset-link'
           - if @records.any?


### PR DESCRIPTION
### Context
The analytics audit showed that there was a lot of tracking where it wasn't needed, and an absence of tracking where it was needed. 

### Changes proposed in this pull request
 * Events no longer fire when links the header and the footer of the page are clicked
 * Events no longer fire when a register is sorted
 * The feedback form now includes the 'No' sub-options, and only fires when the form is submitted
 * Accordions only fire an event when opened, not when closed
 * Unsuccessful searches now fire an event to let us know what query wasn't found

### Guidance to review
(Apologies for the mass of linting changes that have become inextricably linked to this PR).
This has been tested in all of the supported browsers - but extra eyes are always welcome!