### PR TITLE
Analytics rationalisation and update (take two)

### DIFF
--- a/app/assets/javascripts/accordion-with-descriptions.js
+++ b/app/assets/javascripts/accordion-with-descriptions.js
@@ -276,13 +276,9 @@
       }
 
       function fireTracking($node) {
-        var action = ''
         if ($($node).parent().hasClass('subsection--is-open')) {
-          action = 'Open'
-        } else {
-          action = 'Closed'
+          ga('send', 'event', 'Content', 'Open', $node[0].innerText);
         }
-        ga('send', 'event', 'Content', action, $node[0].innerText);
       }
     }
   };

--- a/app/views/feedback/_form.html.haml
+++ b/app/views/feedback/_form.html.haml
@@ -19,10 +19,46 @@
     var showHideContent = new GOVUK.ShowHideContent();
     showHideContent.init();
 
-    document.getElementById('feedback_useful_yes').onclick = function() {
-      ga('send', 'event', 'Feedback', 'Radio - Yes', 'Is this register useful?');
-    }
+    document.getElementById('new_feedback')
+      .addEventListener('submit', function(event) {
+        event.preventDefault();
+        var form = event.target;
 
-    document.getElementById('feedback_useful_no').onclick = function() {
-      ga('send', 'event', 'Feedback', 'Radio - No', 'Is this register useful?');
-    }
+        var checkedRadios = form.querySelectorAll('input[type="radio"]:checked');
+
+        for (var i = 0; i < checkedRadios.length; i += 1) {
+          var action = 'Radio - ' + checkedRadios[i].parentElement.querySelector('label').innerText;
+          var label = checkedRadios[i].parentElement.parentElement.querySelector('legend').innerText;
+          ga('send',  {
+            hitType: 'event',
+            eventCategory: 'Feedback',
+            eventAction: action,
+            eventLabel: label,
+            nonInteraction: true
+          });
+        }
+
+        // Lets us know whether or not the Additional comments part of the
+        // feedback form is being used.
+        var additonalComments = form.querySelector('#feedback_message');
+        var checkedUsefulInput = form.querySelector('input[name="feedback[useful]"]:checked');
+        var eventAction = '';
+
+        if (checkedUsefulInput.value === 'yes') {
+          eventAction = 'Text - useful';
+        }
+        else if (checkedUsefulInput.value === 'no') {
+          eventAction = 'Text - not useful';
+        }
+
+        if (additonalComments.value.length >= 1) {
+          ga('send',  {
+            hitType: 'event',
+            eventCategory: 'Feedback',
+            eventAction: eventAction,
+            eventLabel: 'Is this register useful?',
+            nonInteraction: true
+          });
+        }
+        form.submit();
+    })

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -5,7 +5,7 @@
 - content_for :after_header do
   %header{class: "header #{current_page?(root_path) ? 'header--without-border' : ''}"}
     .header__container
-      .header__brand{data: {"click-events" => "", "click-category" => "Header", "click-action" => "Logo Clicked"}}
+      .header__brand
         = link_to root_path do
           %span.govuk-logo
             = image_tag 'gov_uk_logotype_crown_invert_trans.png', height: 32, width: 36, class: 'govuk-logo__printable-crown'
@@ -19,7 +19,7 @@
       = check_box_tag 'show-menu', nil, false, class: 'header__navigation-toggle-checkbox', "aria-controls" => "navigation", "aria-expanded" => "false"
       = label_tag 'show-menu', 'Menu', class: 'header__navigation-toggle'
       %nav{id: "navigation", class: "header__navigation", role: "Navigation", "aria-label" => "Top Level Navigation", "aria-hidden" => "true"}
-        %ul{data: {"click-events" => "", "click-category" => "Header", "click-action" => "Navigation Link Clicked"}}
+        %ul
           %li{class: "#{'active' if current_page?(registers_path)}"}
             = link_to "Get data", registers_path
           %li{class: "#{'active' if current_page?(support_path)}"}
@@ -43,7 +43,7 @@
     .footer-categories-wrapper
       .grid-row
         .column-one-quarter
-          %ul{data: {"click-events" => "", "click-category" => "Footer", "click-action" => "Internal Link Clicked"}}
+          %ul
             %li
               = link_to "Get data", registers_path
             %li

--- a/app/views/pages/home.html.haml
+++ b/app/views/pages/home.html.haml
@@ -3,7 +3,7 @@
 %main{role:'main'}
   .masthead
     %nav.breadcrumbs.breadcrumbs--inverse{"aria-label" => "Breadcrumb"}
-      %ol{data: {"click-events" => "", "click-category" => "Header", "click-action" => "Breadcrumb Clicked"}}
+      %ol
         %li.breadcrumbs__item
           = link_to 'Components', 'https://www.gov.uk/service-toolkit#components'
         %li.breadcrumbs__item.breadcrumbs__item--active

--- a/app/views/registers/index.html.haml
+++ b/app/views/registers/index.html.haml
@@ -2,7 +2,7 @@
 - content_for :body_classes, 'register-index'
 
 %nav.breadcrumbs{role: "Navigation", "aria-label" => "Breadcrumb"}
-  %ol{data: {"click-events" => "", "click-category" => "Header", "click-action" => "Breadcrumb Clicked"}}
+  %ol
     %li.breadcrumbs__item
       = link_to 'Components', 'https://www.gov.uk/service-toolkit#components'
     %li.breadcrumbs__item
@@ -74,6 +74,8 @@
         .search-results
           %p
             No results found for <strong>"#{@search_term}"</strong>
+            %script
+              ga('send', 'event', 'Search', 'No results', '#{@search_term}', {nonInteraction: true});
             = link_to 'Reset', registers_path, class: 'reset-link'
 
 = content_for :javascript do

--- a/app/views/registers/show.html.haml
+++ b/app/views/registers/show.html.haml
@@ -110,7 +110,6 @@
                     - if @search_term.present?
                       No results found for <strong>"#{@search_term}"</strong>
                       %script
-                        var selectedInput = '';
                         var searchFilter = document.getElementById('search_records').querySelector('input[type="radio"]:checked').parentElement.querySelector('label').innerText.toLowerCase();
                         ga('send', 'event', 'Search', 'No results filtered by: ' + searchFilter, '#{@search_term}', {nonInteraction: true});
                     - else

--- a/app/views/registers/show.html.haml
+++ b/app/views/registers/show.html.haml
@@ -77,11 +77,11 @@
                 .fullscreen-content{data: {module: 'scrolling-tables'}}
                   %table.table.register-data-table
                     %thead
-                      %tr{data: {"click-events" => true, "click-category" => "Register Table", "click-action" => "Sort"}}
+                      %tr
                         - @register.register_fields.each do |field|
                           %th{class: "#{field['field']}"}
                             = field['cardinality'] == '1' ? records_table_sort_link(field['field'], request.query_parameters) : field['field'].tr('-', ' ').humanize
-                            = link_to register_field_url(@register.slug, field['field']), class: 'info-icon', remote: true do
+                            = link_to register_field_url(@register.slug, field['field']), class: 'info-icon', remote: true, data: {"click-events" => true, "click-category" => "Register Table", "click-action" => "Help"} do
                               %span.visually-hidden
                                 What does #{field['field']} mean
                               ?
@@ -109,8 +109,14 @@
                   %p
                     - if @search_term.present?
                       No results found for <strong>"#{@search_term}"</strong>
+                      %script
+                        var selectedInput = '';
+                        var searchFilter = document.getElementById('search_records').querySelector('input[type="radio"]:checked').parentElement.querySelector('label').innerText.toLowerCase();
+                        ga('send', 'event', 'Search', 'No results filtered by: ' + searchFilter, '#{@search_term}', {nonInteraction: true});
                     - else
                       No results found.
+                      %script
+                        ga('send', 'event', 'Search', 'No results', 'Search term not present');
                     - if @search_term.present? || params[:status].present?
                       = link_to 'Reset', register_path(@register.slug, anchor: 'search_wrapper'), class: 'reset-link'
           - if @records.any?


### PR DESCRIPTION
### Context
The analytics audit showed that there was a lot of tracking where it wasn't needed, and an absence of tracking where it was needed.

### Changes proposed in this pull request
Events no longer fire when links the header and the footer of the page are clicked
Events no longer fire when a register is sorted
The feedback form now includes the 'No' sub-options, and only fires when the form is submitted
Accordions only fire an event when opened, not when closed
Unsuccessful searches now fire an event to let us know what query wasn't found

### Guidance to review
This has been tested in all of the supported browsers - but extra eyes are always welcome!