### PR TITLE
Changes Google Analytics loading method; adds versioning.

### DIFF
--- a/app/views/layouts/_analytics.html.erb
+++ b/app/views/layouts/_analytics.html.erb
@@ -1,17 +1,20 @@
 <!-- Google Analytics -->
 <script>
+/* global ga, window */
+window.ga = window.ga || function () { (ga.q = ga.q || []).push(arguments); };
 
-(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+var dimensions = {
+  version: {
+    dimension: 'dimension2',
+    payload: 'v1'
+  }
+};
 
 ga('create', 'UA-86101042-3', 'auto');
 ga('set', 'anonymizeIp', true);
 ga('set', 'displayFeaturesTask', null);
-ga('set', 'transport', 'beacon');
-
+ga('set', dimensions.version.dimension, dimensions.version.payload);
 ga('send', 'pageview');
-
 </script>
+<script src="https://www.google-analytics.com/analytics.js" async></script>
 <!-- End Google Analytics -->


### PR DESCRIPTION
### Context
The standard method of loading Google Analytics that comes out of the box is okay - but can be made better without affecting a user's experience.

### Changes proposed in this pull request
 * `analytics.js` loaded with an asynchronous `script` tag, rather than script tag being injected. Unlike the out of the box method, this allows browser to look ahead and speculatively look for any assets.
 * Versioning added as custom dimension; allows for GA dashboard to segment based on tracking setup
 * Beacon method of tracking turned off because beacon isn't supported by Internet Explorer.

### Guidance to review
None.