### PR TITLE
Update default meta description

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -31,7 +31,7 @@
   = canonical_tag
   = stylesheet_link_tag 'application'
   = csrf_meta_tags
-  %meta{ name: 'description', content: "#{@page_description.present? ? @page_description : 'GOV.UK Registers provides a secure API that is easy to integrate with so you can get the most up-to-date data from across government.'}" }
+  %meta{ name: 'description', content: "#{@page_description.present? ? @page_description : 'Registers are lists of information that are managed and approved by government. GOV.UK Registers helps government design and build services on a consistent and high quality data infrastructure via our secure API.'}" }
   = render partial: 'layouts/analytics'
 
 - content_for :body_end do


### PR DESCRIPTION
### Context
This string is the meta description used on the homepage and other pages. The only place we override it is on the register show pages.

### Changes proposed in this pull request
Replace the text with some other text

### Guidance to review
Check it matches the intent of this card: https://trello.com/c/Kp5CCsew/2810-update-meta-description-for-the-hompage