### PR TITLE
Adds banner about the upcoming data format changes.

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -35,6 +35,12 @@
   %meta{ name: 'description', content: "#{@page_description.present? ? @page_description : 'Registers are lists of information that are managed and approved by government. GOV.UK Registers helps government design and build services on a consistent and high quality data infrastructure via our secure API.'}" }
   = render partial: 'layouts/analytics'
 
+- content_for :after_header do
+  %aside.notice
+    .container
+      %h2.visually-hidden Upcoming data format changes
+      %p{data: {"click-events" => "", "click-category" => "Content", "click-action" => "Notice link clicked"}} GOV.UK Registers will stop supporting data formats other than JSON and CSV from 1 December 2018. #{link_to "Read more about format changes", data_format_changes_path}
+
 - content_for :body_end do
   = javascript_include_tag 'application'
   = yield(:javascript)


### PR DESCRIPTION
### Context
The page detailing the data format changes has gone live with  #380 - this now adds the banner at the top of each page on the registers frontend.

### Changes proposed in this pull request
 - HAML that attaches a banner to the top of every page.

### Guidance to review
This is just the HAML - the CSS is in #380, which has already been tested and deployed. 