### PR TITLE
Registers stats on upcoming page

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -4,9 +4,8 @@ class PagesController < ApplicationController
   def home
     @registers = Register.available.all
 
-    @ready_registers = Register.available.where(register_phase: 'Beta')
-    @upcoming_registers = Register.available.where.not(register_phase: 'Beta')
-    @organisation_count = @ready_registers.distinct.count(:authority)
+    @registers_available = Register.available.where(register_phase: 'Beta')
+    @organisation_count = @registers_available.distinct.count(:authority)
   end
 
   def services_using_registers; end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -4,8 +4,8 @@ class PagesController < ApplicationController
   def home
     @registers = Register.available.all
 
-    @registers_available = Register.available.where(register_phase: 'Beta')
-    @organisation_count = @registers_available.distinct.count(:authority)
+    @registers_available = Register.available_count
+    @organisation_count = Register.organisation_count
   end
 
   def services_using_registers; end

--- a/app/controllers/registers_controller.rb
+++ b/app/controllers/registers_controller.rb
@@ -20,7 +20,7 @@ class RegistersController < ApplicationController
   def in_progress
     @registers = Register.available.where(register_phase: 'Alpha').sort_by_phase_name_asc.by_name
 
-    @registers_available = Register.available.where(register_phase: 'Beta')
+    @registers_available = Register.available_count
     @organisation_count = Register.organisation_count
   end
 

--- a/app/controllers/registers_controller.rb
+++ b/app/controllers/registers_controller.rb
@@ -21,7 +21,7 @@ class RegistersController < ApplicationController
     @registers = Register.available.where(register_phase: 'Alpha').sort_by_phase_name_asc.by_name
 
     @registers_available = Register.available.where(register_phase: 'Beta')
-    @organisation_count = @registers_available.distinct.count(:authority)
+    @organisation_count = Register.organisation_count
   end
 
   def show

--- a/app/controllers/registers_controller.rb
+++ b/app/controllers/registers_controller.rb
@@ -19,6 +19,10 @@ class RegistersController < ApplicationController
 
   def in_progress
     @registers = Register.available.where(register_phase: 'Alpha').sort_by_phase_name_asc.by_name
+    
+    @ready_registers = Register.available.where(register_phase: 'Beta')
+    @upcoming_registers = Register.available.where.not(register_phase: 'Beta')
+    @organisation_count = @ready_registers.distinct.count(:authority)
   end
 
   def show

--- a/app/controllers/registers_controller.rb
+++ b/app/controllers/registers_controller.rb
@@ -19,10 +19,9 @@ class RegistersController < ApplicationController
 
   def in_progress
     @registers = Register.available.where(register_phase: 'Alpha').sort_by_phase_name_asc.by_name
-    
-    @ready_registers = Register.available.where(register_phase: 'Beta')
-    @upcoming_registers = Register.available.where.not(register_phase: 'Beta')
-    @organisation_count = @ready_registers.distinct.count(:authority)
+
+    @registers_available = Register.available.where(register_phase: 'Beta')
+    @organisation_count = @registers_available.distinct.count(:authority)
   end
 
   def show

--- a/app/models/register.rb
+++ b/app/models/register.rb
@@ -23,6 +23,13 @@ class Register < ApplicationRecord
   scope :sort_registers, ->(sort_by) { sort_by == 'name' ? by_name : by_popularity }
   scope :featured, -> { where(featured: true) }
   scope :not_featured, -> { where(featured: false) }
+  scope :organisation_count, lambda {
+    available
+      .in_beta
+      .distinct
+      .count(:authority)
+  }
+  scope :available_count, -> { available.in_beta.count }
 
   has_many :entries, dependent: :destroy
   has_many :records, dependent: :destroy

--- a/app/views/layouts/_registers-in-numbers.html.haml
+++ b/app/views/layouts/_registers-in-numbers.html.haml
@@ -4,12 +4,12 @@
     .column-one-third
       .data
         = link_to registers_path do
-          %span.data-item.bold-xxlarge= @registers_available.count
+          %span.data-item.bold-xxlarge= @registers_available
           %span.data-item.bold-small registers available
     .column-one-third
       .data
         = link_to registers_path do
-          %span.data-item.bold-xxlarge= Register.organisation_count
+          %span.data-item.bold-xxlarge= @organisation_count
           %span.data-item.bold-small government organisations providing&nbsp;registers
     .column-one-third
       .data

--- a/app/views/layouts/_registers-in-numbers.html.haml
+++ b/app/views/layouts/_registers-in-numbers.html.haml
@@ -9,7 +9,7 @@
     .column-one-third
       .data
         = link_to registers_path do
-          %span.data-item.bold-xxlarge= @organisation_count
+          %span.data-item.bold-xxlarge= Register.organisation_count
           %span.data-item.bold-small government organisations providing&nbsp;registers
     .column-one-third
       .data

--- a/app/views/layouts/_registers-in-numbers.html.haml
+++ b/app/views/layouts/_registers-in-numbers.html.haml
@@ -1,0 +1,18 @@
+%section.content-section.content-section--with-top-border.column-full
+  .grid-row
+    %h2.heading-medium.content-section__title.column-full Registers in numbers
+    .column-one-third
+      .data
+        = link_to registers_path do
+          %span.data-item.bold-xxlarge= @registers_available.count
+          %span.data-item.bold-small registers available
+    .column-one-third
+      .data
+        = link_to registers_path do
+          %span.data-item.bold-xxlarge= @organisation_count
+          %span.data-item.bold-small government organisations providing&nbsp;registers
+    .column-one-third
+      .data
+        = link_to services_using_registers_path do
+          %span.data-item.bold-xxlarge 13
+          %span.data-item.bold-small services using registers

--- a/app/views/pages/home.html.haml
+++ b/app/views/pages/home.html.haml
@@ -38,33 +38,16 @@
       .grid-row
         .column-one-half
           %h2.heading-medium.content-section__title Trusted by government services
-          %p By using registers you can: 
+          %p By using registers you can:
           %ul.list.list-bullet
             %li reduce the time and cost of sourcing data from across government
-            %li be confident that your service is using the most up&#8209;to&#8209;date government data 
+            %li be confident that your service is using the most up&#8209;to&#8209;date government data
             %li receive data that is ready to use with no need for data cleansing
 
         .column-one-half
           = image_tag('country-register.png', alt: 'Screenshot showing the country register page')
 
-    %section.content-section.content-section--with-top-border
-      .grid-row
-        %h2.heading-medium.content-section__title.column-full Registers in numbers
-        .column-one-third
-          .data
-            = link_to registers_path do
-              %span.data-item.bold-xxlarge= @ready_registers.count
-              %span.data-item.bold-small registers available
-        .column-one-third
-          .data
-            = link_to registers_path do
-              %span.data-item.bold-xxlarge= @organisation_count
-              %span.data-item.bold-small government organisations providing&nbsp;registers
-        .column-one-third
-          .data
-            = link_to services_using_registers_path do
-              %span.data-item.bold-xxlarge 13
-              %span.data-item.bold-small services using registers
+    = render partial: 'layouts/registers-in-numbers'
 
 = content_for :javascript do
   :javascript

--- a/app/views/registers/in_progress.html.haml
+++ b/app/views/registers/in_progress.html.haml
@@ -37,3 +37,22 @@
         %tbody
           - @registers.each do |register|
             = render partial: 'registers/register', object: register
+
+    %section.content-section.content-section--with-top-border.column-full
+      .grid-row
+        %h2.heading-medium.content-section__title.column-full Registers in numbers
+        .column-one-third
+          .data
+            = link_to registers_path do
+              %span.data-item.bold-xxlarge= @ready_registers.count
+              %span.data-item.bold-small registers available
+        .column-one-third
+          .data
+            = link_to registers_path do
+              %span.data-item.bold-xxlarge= @organisation_count
+              %span.data-item.bold-small government organisations providing&nbsp;registers
+        .column-one-third
+          .data
+            = link_to services_using_registers_path do
+              %span.data-item.bold-xxlarge 13
+              %span.data-item.bold-small services using registers

--- a/app/views/registers/in_progress.html.haml
+++ b/app/views/registers/in_progress.html.haml
@@ -38,21 +38,4 @@
           - @registers.each do |register|
             = render partial: 'registers/register', object: register
 
-    %section.content-section.content-section--with-top-border.column-full
-      .grid-row
-        %h2.heading-medium.content-section__title.column-full Registers in numbers
-        .column-one-third
-          .data
-            = link_to registers_path do
-              %span.data-item.bold-xxlarge= @ready_registers.count
-              %span.data-item.bold-small registers available
-        .column-one-third
-          .data
-            = link_to registers_path do
-              %span.data-item.bold-xxlarge= @organisation_count
-              %span.data-item.bold-small government organisations providing&nbsp;registers
-        .column-one-third
-          .data
-            = link_to services_using_registers_path do
-              %span.data-item.bold-xxlarge 13
-              %span.data-item.bold-small services using registers
+  = render partial: 'layouts/registers-in-numbers'


### PR DESCRIPTION
### Context
We need to consistently promote our available registers and usage across government across the frontend - particularly for users who may not necessarily see the homepage. 

### Changes proposed in this pull request
 - Adds the three statistics near the bottom of the 'Upcoming registers' page.
 - Put the layout block in a partial HAML file so it can be included, making the one hard coded number easier to update.

### Guidance to review

