### PR TITLE
add dropdown for theme to admin interface

### DIFF
--- a/app/controllers/admin/registers_controller.rb
+++ b/app/controllers/admin/registers_controller.rb
@@ -74,7 +74,8 @@ module Admin
                                         :position,
                                         :seo_title,
                                         :meta_description,
-                                        :featured)
+                                        :featured,
+                                        :theme_id)
     end
   end
 end

--- a/app/views/admin/registers/_form.html.haml
+++ b/app/views/admin/registers/_form.html.haml
@@ -8,6 +8,10 @@
     = f.label :authority, class: 'form-label'
     = f.select :authority, @government_organisations.all.collect{ |org| [org.data['name'], org.key] }, {}, class: 'form-control'
   = f.text_area :contextual_data
+  .form-group
+    = f.label :theme_id, class: 'form-label'
+    = f.select :theme_id, Theme.all.pluck(:name, :id), { include_blank: 'Select theme' }, class: 'form-control'
+  = f.text_area :contextual_data
   = f.text_area :related_registers
   .form-group
     .multiple-choice


### PR DESCRIPTION
### Context
We need to provide a way to set a theme for a register

### Changes proposed in this pull request
Adds dropdown to select a theme for a register to /admin

### Guidance to review
Paired with @MatMoore 
