### PR TITLE
[DO NOT MERGE] Remove " register" suffix from register names

### DIFF
--- a/app/views/download/index.html.haml
+++ b/app/views/download/index.html.haml
@@ -1,4 +1,4 @@
-- @page_title = "Download - #{@register.register_name} register"
+- @page_title = "Download - #{@register.register_name}"
 - content_for :body_classes, 'api-key-page'
 
 %main#content{role: 'main'}

--- a/app/views/download/show.html.haml
+++ b/app/views/download/show.html.haml
@@ -1,10 +1,10 @@
-- @page_title = "Download - #{@register.register_name} register"
+- @page_title = "Download - #{@register.register_name}"
 - content_for :body_classes, 'api-key-page'
 
 %main#content{role: 'main'}
   .grid-row
     .column-full
-      %h1.heading-large Download the #{@register.register_name} register
+      %h1.heading-large Download the #{@register.register_name}
       %p You can download the latest data in this register as:
       %ul.list.list-bullet{data: {"click-events" => true, "click-category" => "Content", "click-action" => "Register Download"}}
         %li= link_to 'CSV', register_download_csv_path(@register.slug)

--- a/app/views/entries/index.html.haml
+++ b/app/views/entries/index.html.haml
@@ -1,4 +1,4 @@
-- @page_title = "#{@register.register_name} register updates"
+- @page_title = "#{@register.register_name} updates"
 - content_for :body_classes, 'entries-index'
 
 %nav.breadcrumbs{role: "Navigation", "aria-label" => "Breadcrumb"}
@@ -6,7 +6,7 @@
     %li.breadcrumbs__item
       = link_to 'Get data', registers_path
     %li.breadcrumbs__item
-      = link_to "#{@register.register_name} register", register_path(@register.slug)
+      = link_to @register.register_name, register_path(@register.slug)
     %li.breadcrumbs__item.breadcrumbs__item--active
       = link_to 'Register updates', '#content', 'aria-current' => 'page'
 

--- a/app/views/records/show.html.haml
+++ b/app/views/records/show.html.haml
@@ -1,11 +1,11 @@
-- @page_title = "Record #{params[:id]} in the #{@register.register_name} register"
+- @page_title = "Record #{params[:id]} in #{@register.register_name}"
 - content_for :body_classes, 'records-show'
 
 %main#content.container{role:'main'}
   .grid-row
     .column-two-thirds
       #link-back
-      %h1.heading-large Record <strong>#{params[:id]}</strong> in the <strong>#{@register.register_name}</strong> register
+      %h1.heading-large Record <strong>#{params[:id]}</strong> in <strong>#{@register.register_name}</strong>
   .grid-row
     .column-full
       %table.table
@@ -24,7 +24,7 @@
                 =  field_value.is_a?(Array) ? field_value.join(', ') : link_to_if(field['datatype'] == 'url', field_value, field_value)
   .grid-row
     .column-two-thirds
-      %p This is a record from the #{link_to @register.register_name, register_path(@register.slug)} register
+      %p This record is part of: #{link_to @register.register_name, register_path(@register.slug)}
       = content_for :javascript do
         :javascript
             var isInternalReferrer = document.referrer.indexOf(location.protocol + "//" + location.host) === 0;

--- a/app/views/registers/_structured_data.html.erb
+++ b/app/views/registers/_structured_data.html.erb
@@ -2,7 +2,7 @@
 {
   "@context": "http://schema.org",
   "@type": "Table",
-  "about": "<%= register.register_name %> register",
+  "about": "<%= register.register_name %>",
   "author": "<%= register.register_authority.data['name'] %>",
   "publisher": "Government Digital Service (GDS)",
   "dateModified": "<%= formatted_date(register.register_last_updated) %>"

--- a/app/views/registers/show.html.haml
+++ b/app/views/registers/show.html.haml
@@ -1,4 +1,4 @@
-- @page_title = "#{[@register.seo_title, @register.register_name + ' register'].find(&:present?)}"
+- @page_title = "#{[@register.seo_title, @register.register_name].find(&:present?)}"
 - @page_description = "#{[@register.meta_description, @register.register_description].find(&:present?)}"
 - content_for :body_classes, 'register-show'
 
@@ -14,7 +14,7 @@
     .grid-row
       .column-two-thirds
         %h1.heading-large
-          #{@register.register_name} register
+          #{@register.register_name}
           %span.heading-secondary= @register.register_description
         - unless @register.is_empty?
           %p.font-xsmall Last updated: #{link_to formatted_date(@register.register_last_updated), register_entries_path(@register.slug)}


### PR DESCRIPTION
### Context
Friendly register names can now contain the " register" suffix, so adding it in the templates generates redundant redundancy.

I found this out the hard way by updating the government service register, which resulted in the frontend displaying "Government service register register".

This is a problem as right now we can't refresh the data in registers-frontend without breaking all the copy on the site.

### Changes proposed in this pull request
We think that register frontend shouldn't impose any constraints over the naming of registers - it should be flexible enough to handle whatever we want to call them.

This PR changes all the places where register names are referred to like "the XYZ register" or just "XYZ register" to just "XYZ". This needs content review before merging. In particular, the copy on the updates page doesn't work anymore so I had to change the sentence structure.

### Screenshots
These screenshots show what the website will look like with the current names (some of them will end with " register").

Note that this suffix will not show up when this is first deployed, because production still has old data. The goal of this PR is for registers frontend to work with both naming conventions.

<img width="872" alt="screen shot 2018-09-06 at 17 29 52" src="https://user-images.githubusercontent.com/87579/45172094-2e368500-b1fc-11e8-8610-0aadb29f4409.png">
<img width="904" alt="screen shot 2018-09-06 at 17 30 27" src="https://user-images.githubusercontent.com/87579/45172096-342c6600-b1fc-11e8-937a-b916256e278e.png">
<img width="364" alt="screen shot 2018-09-06 at 17 31 08" src="https://user-images.githubusercontent.com/87579/45172102-37bfed00-b1fc-11e8-89e9-1a23a3d414cc.png">

The new names will also be surfaced in page titles and JSON-LD metadata that gets included in the HTML.
