### PR TITLE
Fixes signup form reporting

### DIFF
--- a/app/views/sign_up/index.html.haml
+++ b/app/views/sign_up/index.html.haml
@@ -46,7 +46,7 @@
       document.querySelector('.js--ga-submit')
         .addEventListener('submit', function(event) {
           var form = event.target;
-          var emailDomain = getValue(form.querySelector('input[name="email-address"]'))
+          var emailDomain = getValue(form.querySelector('input[type="email"]'))
 
           ga('send', {
             hitType: 'event',


### PR DESCRIPTION
### Context
The signup form wasn't reporting correctly into Google Analytics, as the DOM selector wasn't correct.

### Changes proposed in this pull request
DOM selector changed to pick up on the form input element correctly.

### Guidance to review
None