### PR TITLE
Migrate authorities to own table

### DIFF
--- a/app/controllers/admin/registers_controller.rb
+++ b/app/controllers/admin/registers_controller.rb
@@ -66,7 +66,6 @@ module Admin
       params.require(:register).permit(:name,
                                         :slug,
                                         :register_phase,
-                                        :authority,
                                         :description,
                                         :contextual_data,
                                         :related_registers,
@@ -75,7 +74,8 @@ module Admin
                                         :seo_title,
                                         :meta_description,
                                         :featured,
-                                        :theme_id)
+                                        :theme_id,
+                                        authority_attributes: %i[name id])
     end
   end
 end

--- a/app/jobs/populate_authorities_job.rb
+++ b/app/jobs/populate_authorities_job.rb
@@ -1,0 +1,11 @@
+class PopulateAuthoritiesJob < ApplicationJob
+  queue_as :default
+
+  def perform
+    Register.find_by(slug: 'government-organisation')&.records&.where(entry_type: 'user')&.find_each do |r|
+      a = Authority.find_or_initialize_by(government_organisation_key: r.key)
+      a.name = r.data['name']
+      a.save
+    end
+  end
+end

--- a/app/models/authority.rb
+++ b/app/models/authority.rb
@@ -1,0 +1,3 @@
+class Authority < ApplicationRecord
+  has_many :registers
+end

--- a/app/models/register.rb
+++ b/app/models/register.rb
@@ -27,7 +27,7 @@ class Register < ApplicationRecord
     available
       .in_beta
       .distinct
-      .count(:authority)
+      .count(:authority_id)
   }
   scope :available_count, -> { available.in_beta.count }
 
@@ -35,6 +35,8 @@ class Register < ApplicationRecord
   has_many :records, dependent: :destroy
   has_many :register_search_results
   belongs_to :theme
+  belongs_to :authority
+  accepts_nested_attributes_for :authority
 
   def register_last_updated
     Record.select('timestamp')
@@ -55,10 +57,6 @@ class Register < ApplicationRecord
     Record.where(register_id: id, key: ordered_field_keys)
           .order(Arel.sql("position(key::text in '#{ordered_field_keys.join(',')}')"))
           .map { |entry| entry[:data] }
-  end
-
-  def register_authority
-    Register.find_by(slug: 'government-organisation')&.records&.find_by(key: authority)
   end
 
   def number_of_records

--- a/app/views/admin/registers/_form.html.haml
+++ b/app/views/admin/registers/_form.html.haml
@@ -5,8 +5,9 @@
     = f.label :register_phase, class: 'form-label'
     = f.select :register_phase, Register::CURRENT_PHASES, {}, include_blank: 'Select current phase', class: 'form-control'
   .form-group
-    = f.label :authority, class: 'form-label'
-    = f.select :authority, @government_organisations.all.collect{ |org| [org.data['name'], org.key] }, {}, class: 'form-control'
+    = f.fields_for :authority do |authority_field|
+      = authority_field.label :name, 'Authority', class: 'form-label'
+      = authority_field.select :name, Authority.all.pluck(:name, :id), {}, class: 'form-control'
   = f.text_area :contextual_data
   .form-group
     = f.label :theme_id, class: 'form-label'
@@ -30,7 +31,7 @@
 = content_for :javascript do
   :javascript
     document.addEventListener('DOMContentLoaded', function() {
-      var element = document.getElementById('register_authority');
+      var element = document.getElementById('register_authority_attributes_name');
 
       if (element) {
         accessibleAutocomplete.enhanceSelectElement({

--- a/app/views/registers/_register.html.haml
+++ b/app/views/registers/_register.html.haml
@@ -8,10 +8,10 @@
       - else
         = register.register_description
   %td
-    - if register.register_authority.present?
-      %div{class: "govuk-organisation-logo #{register.register_authority.data['name'].parameterize}"}
-        %div{class: "logo-container #{crest_class_name(register.register_authority.data['name'].parameterize)}"}
-          %span= register.register_authority.data['name']
+    - if register.authority.present?
+      %div{class: "govuk-organisation-logo #{register.authority&.name.parameterize}"}
+        %div{class: "logo-container #{crest_class_name(register.authority&.name.parameterize)}"}
+          %span= register&.authority&.name
   %td
     - if register.register_phase == 'Alpha'
       %p Open for feedback

--- a/app/views/registers/_register.html.haml
+++ b/app/views/registers/_register.html.haml
@@ -9,8 +9,8 @@
         = register.register_description
   %td
     - if register.authority.present?
-      %div{class: "govuk-organisation-logo #{register.authority&.name.parameterize}"}
-        %div{class: "logo-container #{crest_class_name(register.authority&.name.parameterize)}"}
+      %div{class: "govuk-organisation-logo #{register.authority&.name&.parameterize}"}
+        %div{class: "logo-container #{crest_class_name(register.authority&.name&.parameterize)}"}
           %span= register&.authority&.name
   %td
     - if register.register_phase == 'Alpha'

--- a/app/views/registers/_structured_data.html.erb
+++ b/app/views/registers/_structured_data.html.erb
@@ -3,7 +3,7 @@
   "@context": "http://schema.org",
   "@type": "Table",
   "about": "<%= register.register_name %> register",
-  "author": "<%= register.register_authority.data['name'] %>",
+  "author": "<%= register&.authority&.name %>",
   "publisher": "Government Digital Service (GDS)",
   "dateModified": "<%= formatted_date(register.register_last_updated) %>"
 }

--- a/app/views/registers/index.html.haml
+++ b/app/views/registers/index.html.haml
@@ -41,10 +41,10 @@
                     .app-c-highlight-boxes__item
                       %h3.app-c-highlight-boxes__title= link_to register.register_name, register_path(register.slug)
                       %p.app-c-highlight-boxes__description= register.register_description
-                      - if register.register_authority.present?
-                        %div{class: "govuk-organisation-logo #{register.register_authority.data['name'].parameterize}"}
-                          %div{class: "logo-container #{crest_class_name(register.register_authority.data['name'].parameterize)}"}
-                            %span= register.register_authority.data['name']
+                      - if register.authority.present?
+                        %div{class: "govuk-organisation-logo #{register&.authority&.name.parameterize}"}
+                          %div{class: "logo-container #{crest_class_name(register&.authority&.name.parameterize)}"}
+                            %span= register&.authority&.name
 
 
             %table.register-status-table.table-collapsible
@@ -65,10 +65,10 @@
                         %br
                         = register.register_description
                     %td
-                      - if register.register_authority.present?
-                        %div{class: "govuk-organisation-logo #{register.register_authority.data['name'].parameterize}"}
-                          %div{class: "logo-container #{crest_class_name(register.register_authority.data['name'].parameterize)}"}
-                            %span= register.register_authority.data['name']
+                      - if register.authority.present?
+                        %div{class: "govuk-organisation-logo #{register&.authority&.name&.parameterize}"}
+                          %div{class: "logo-container #{crest_class_name(register&.authority&.name&.parameterize)}"}
+                            %span= register&.authority&.name
 
       - else
         .search-results

--- a/app/views/registers/show.html.haml
+++ b/app/views/registers/show.html.haml
@@ -20,12 +20,12 @@
           %p.font-xsmall Last updated: #{link_to formatted_date(@register.register_last_updated), register_entries_path(@register.slug)}
 
       .column-one-third
-        - if @register.register_authority.present?
+        - if @register.authority.present?
           .related-items
             %p.bold-small Managed by:
-            %div{class: "govuk-organisation-logo #{@register.register_authority.data['name'].parameterize}"}
-              %div{class: "logo-container #{crest_class_name(@register.register_authority.data['name'].parameterize)}"}
-                %span= @register.register_authority.data['name']
+            %div{class: "govuk-organisation-logo #{@register&.authority&.name&.parameterize}"}
+              %div{class: "logo-container #{crest_class_name(@register&.authority&.name&.parameterize)}"}
+                %span= @register&.authority&.name
 
   .grid-row
     .column-full

--- a/db/migrate/20180906105312_create_authorities.rb
+++ b/db/migrate/20180906105312_create_authorities.rb
@@ -1,0 +1,14 @@
+class CreateAuthorities < ActiveRecord::Migration[5.2]
+  def change
+    create_table :authorities do |t|
+      t.string :government_organisation_key, null: false
+      t.string :registers_description
+      t.string :name
+      t.index :government_organisation_key, unique: true
+      t.timestamps
+    end
+
+    add_column :registers, :authority_id, :bigint
+    add_foreign_key :registers, :authorities
+  end
+end

--- a/db/migrate/20180906135506_populate_authorities_table.rb
+++ b/db/migrate/20180906135506_populate_authorities_table.rb
@@ -1,0 +1,9 @@
+class PopulateAuthoritiesTable < ActiveRecord::Migration[5.2]
+  def change
+    # Create Authorities for existing registers even if gov-org register is not populated
+    existing_authorities = Register.all.distinct.pluck(:authority).map { |a| { government_organisation_key: a } }
+    Authority.create!(existing_authorities)
+
+    PopulateAuthoritiesJob.perform_now
+  end
+end

--- a/db/migrate/20180906140011_associate_authority_with_register.rb
+++ b/db/migrate/20180906140011_associate_authority_with_register.rb
@@ -1,0 +1,9 @@
+class AssociateAuthorityWithRegister < ActiveRecord::Migration[5.2]
+  def change
+    Register.find_each do |r|
+      r.authority_id = Authority.find_by(government_organisation_key: r[:authority]).id
+      r.save
+    end
+    remove_column :registers, :authority
+  end
+end

--- a/db/migrate/20180911130514_populate_authority_register_descriptions.rb
+++ b/db/migrate/20180911130514_populate_authority_register_descriptions.rb
@@ -1,0 +1,18 @@
+class PopulateAuthorityRegisterDescriptions < ActiveRecord::Migration[5.2]
+  def change
+    Authority.find_by(government_organisation_key: 'D2')&.update(registers_description: 'Includes government organisations and services, gov.uk domain names and a register of all registers')
+    Authority.find_by(government_organisation_key: 'OT1173')&.update(registers_description: 'Includes local authorities in Northern Ireland')
+    Authority.find_by(government_organisation_key: 'D7')&.update(registers_description: 'Includes internal drainage boards')
+    Authority.find_by(government_organisation_key: 'D10')&.update(registers_description: 'Includes jobcentres')
+    Authority.find_by(government_organisation_key: 'D102')&.update(registers_description: 'Includes allergens')
+    Authority.find_by(government_organisation_key: 'D13')&.update(registers_description: 'Includes countries and territories')
+    Authority.find_by(government_organisation_key: 'OT1056')&.update(registers_description: 'Includes approved open standards and Digital, Data and Technology Profession Capability Framework')
+    Authority.find_by(government_organisation_key: 'EA66')&.update(registers_description: 'Includes registration districts')
+    Authority.find_by(government_organisation_key: 'D4')&.update(registers_description: 'Includes local authorities in England')
+    Authority.find_by(government_organisation_key: 'D18')&.update(registers_description: 'Includes prison estate')
+    Authority.find_by(government_organisation_key: 'D303')&.update(registers_description: 'Includes statistical geography')
+    Authority.find_by(government_organisation_key: 'D109')&.update(registers_description: 'Includes qualification subject areas and assessment methods')
+    Authority.find_by(government_organisation_key: 'DA1020')&.update(registers_description: 'Includes local authorities in Scotland')
+    Authority.find_by(government_organisation_key: 'DA1019')&.update(registers_description: 'Includes principal local authorities in Wales')
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_09_05_090146) do
+ActiveRecord::Schema.define(version: 2018_09_11_130514) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "authorities", force: :cascade do |t|
+    t.string "government_organisation_key", null: false
+    t.string "registers_description"
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["government_organisation_key"], name: "index_authorities_on_government_organisation_key", unique: true
+  end
 
   create_table "delayed_jobs", force: :cascade do |t|
     t.integer "priority", default: 0, null: false
@@ -65,7 +74,6 @@ ActiveRecord::Schema.define(version: 2018_09_05_090146) do
     t.text "contextual_data"
     t.string "register_phase"
     t.string "slug"
-    t.string "authority"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "description"
@@ -78,6 +86,7 @@ ActiveRecord::Schema.define(version: 2018_09_05_090146) do
     t.text "meta_description"
     t.boolean "featured", default: false
     t.bigint "theme_id"
+    t.bigint "authority_id"
   end
 
   create_table "themes", force: :cascade do |t|
@@ -100,6 +109,7 @@ ActiveRecord::Schema.define(version: 2018_09_05_090146) do
     t.datetime "password_reset_sent_at"
   end
 
+  add_foreign_key "registers", "authorities"
   add_foreign_key "registers", "themes"
 
   create_view "register_search_results", materialized: true,  sql_definition: <<-SQL

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,65 +1,74 @@
 User.create(name: 'admin', email: 'registerteam@digital.cabinet-office.gov.uk', password: 'password123', admin: true)
 
+d13 = Authority.find_or_create_by!(government_organisation_key: 'D13', name: 'Foreign & Commonwealth Office', registers_description: 'Includes countries and territories')
+d4 = Authority.find_or_create_by!(government_organisation_key: 'D4', name: 'Ministry of Housing, Communities and Local Government', registers_description: 'Includes local authorities in Northern Ireland')
+d6 = Authority.find_or_create_by!(government_organisation_key: 'D6', name: 'Department for Education')
+d18 = Authority.find_or_create_by!(government_organisation_key: 'D18', name: 'Ministry of Justice', registers_description: 'Includes prison estate')
+d10 = Authority.find_or_create_by!(government_organisation_key: 'D10', name: 'Department for Work and Pensions', registers_description: 'Includes jobcentres')
+d2 = Authority.find_or_create_by!(government_organisation_key: 'D2', name: 'Cabinet Office', registers_description: 'Includes government organisations and services, gov.uk domain names and a register of all registers')
+d98 = Authority.find_or_create_by!(government_organisation_key: 'D98', name: 'The Charity Commission')
+puts('Created Authorities')
+
 Register.create(
   name: "Country",
   register_phase: "Beta",
-  authority: "D13",
+  authority: d13,
 )
 puts "Created Country Register"
 
 Register.create(
   name: "Territory",
   register_phase: "Beta",
-  authority: "D13",
+  authority: d13,
 )
 puts "Created Territory Register"
 
 Register.create(
   name: "Local authority eng",
   register_phase: "Beta",
-  authority: "D4",
+  authority: d4,
 )
 puts "Created Local authority eng Register"
 
 Register.create(
   name: "School eng",
   register_phase: "Alpha",
-  authority: "D6",
+  authority: d6,
 )
 puts "Created School eng Register"
 
 Register.create(
   name: "Prison estate",
   register_phase: "Beta",
-  authority: "D18",
+  authority: d18,
 )
 puts "Created Prison Register"
 
 Register.create(
   name: "Jobcentre",
   register_phase: "Beta",
-  authority: "D10",
+  authority: d10,
 )
 puts "Created Jobcentre Register"
 
 Register.create(
   name: "Government organisation",
   register_phase: "Beta",
-  authority: "D2",
+  authority: d2,
 )
 puts "Created Government organisation Register"
 
 Register.create(
   name: "Government domain",
   register_phase: "Beta",
-  authority: "D2",
+  authority: d2,
 )
 puts "Created Government domain Register"
 
 Register.create(
   name: "Charity",
   register_phase: "Discovery",
-  authority: "D98",
+  authority: d98,
   )
 puts "Created Charity Register"
 

--- a/lib/clock.rb
+++ b/lib/clock.rb
@@ -10,7 +10,11 @@ module Clockwork
     system(job)
   end
 
-  every(30.minute, 'Update database') {
+  every(30.minute, 'Update register data') {
     `rake registers_frontend:populate_db:fetch_later`
+  }
+
+  every(30.minute, 'Update authorities') {
+    `rake registers_frontend:populate_authorities:fetch_later`
   }
 end

--- a/lib/tasks/populate_authorities.rake
+++ b/lib/tasks/populate_authorities.rake
@@ -1,0 +1,11 @@
+namespace :registers_frontend do
+  namespace :populate_authorities do
+    desc "Populate Authorities using Government Organisation register."
+    task fetch_later: :environment do
+      PopulateAuthoritiesJob.perform_later
+    end
+    task fetch_now: :environment do
+      PopulateAuthoritiesJob.perform_now
+    end
+  end
+end

--- a/lib/tasks/populate_register_data_in_db.rake
+++ b/lib/tasks/populate_register_data_in_db.rake
@@ -15,6 +15,9 @@ namespace :registers_frontend do
         puts("populating register #{register.name}")
         PopulateRegisterDataInDbJob.perform_now(register)
       end
+
+      puts('populating authorities')
+      PopulateAuthoritiesJob.perform_now
     end
 
     desc 'For local envs: Force a full redownload of a single register'

--- a/spec/controllers/entries_controller_spec.rb
+++ b/spec/controllers/entries_controller_spec.rb
@@ -18,9 +18,9 @@ RSpec.describe EntriesController, type: :controller do
     charity_proof = File.read('./spec/support/charity_proof.json')
     territory_proof = File.read('./spec/support/territory_proof.json')
 
-    ObjectsFactory.new.create_register('country', 'Beta', 'D587')
-    ObjectsFactory.new.create_register('charity', 'Beta', 'D587')
-    ObjectsFactory.new.create_register('territory', 'Beta', 'D587')
+    ObjectsFactory.new.create_register('country', 'Beta')
+    ObjectsFactory.new.create_register('charity', 'Beta')
+    ObjectsFactory.new.create_register('territory', 'Beta')
 
     # RSF stubs
     stub_request(:get, 'https://country.register.gov.uk/download-rsf/0')

--- a/spec/controllers/registers_controller_spec.rb
+++ b/spec/controllers/registers_controller_spec.rb
@@ -18,9 +18,9 @@ RSpec.describe RegistersController, type: :controller do
     territory_proof = File.read('./spec/support/territory_proof.json')
 
 
-    ObjectsFactory.new.create_register('country', 'Beta', 'D587')
-    ObjectsFactory.new.create_register('charity', 'Beta', 'D587')
-    ObjectsFactory.new.create_register('territory', 'Beta', 'D587')
+    ObjectsFactory.new.create_register('country', 'Beta')
+    ObjectsFactory.new.create_register('charity', 'Beta')
+    ObjectsFactory.new.create_register('territory', 'Beta')
 
     # RSF stubs
     stub_request(:get, 'https://country.register.gov.uk/download-rsf/0')

--- a/spec/factories/objects_factory.rb
+++ b/spec/factories/objects_factory.rb
@@ -1,7 +1,7 @@
 class ObjectsFactory
   include FactoryBot::Syntax::Methods
 
-  def create_register(name, phase, authority)
-    create(:register, name: name, register_phase: phase, authority: authority)
+  def create_register(name, phase)
+    create(:register, name: name, register_phase: phase)
   end
 end

--- a/spec/factories/registers.rb
+++ b/spec/factories/registers.rb
@@ -2,6 +2,5 @@ FactoryBot.define do
   factory :register do
     name { Faker::Name.name }
     register_phase { Faker::Name.name }
-    authority { Faker::Name.name }
   end
 end

--- a/spec/features/view_register_spec.rb
+++ b/spec/features/view_register_spec.rb
@@ -44,9 +44,9 @@ RSpec.feature 'View register', type: :feature do
     with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip, deflate', 'Host' => 'government-organisation.register.gov.uk' }).
     to_return(status: 200, body: "assert-root-hash\tsha-256:f42d8409df99cceb6c92e5b6b2eb24cd51075d1aa23924fcbdbabf57fbc4ab98")
 
-    country = ObjectsFactory.new.create_register('Country', 'Beta', 'D587')
-    industrial_classification = ObjectsFactory.new.create_register('industrial classification 2003', 'Discovery', 'D587')
-    government_organisation = ObjectsFactory.new.create_register('government-organisation', 'Beta', 'D587')
+    country = ObjectsFactory.new.create_register('Country', 'Beta')
+    industrial_classification = ObjectsFactory.new.create_register('industrial classification 2003', 'Discovery')
+    government_organisation = ObjectsFactory.new.create_register('government-organisation', 'Beta')
     PopulateRegisterDataInDbJob.perform_now(country)
     PopulateRegisterDataInDbJob.perform_now(industrial_classification)
     PopulateRegisterDataInDbJob.perform_now(government_organisation)

--- a/spec/jobs/handle_invalid_register_spec.rb
+++ b/spec/jobs/handle_invalid_register_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe 'handling invalid register exceptions' do
       :register,
       name: 'country',
       register_phase: 'beta',
-      authority: 'D587'
     )
 
     country_data = File.read('./spec/support/country.rsf')

--- a/spec/jobs/populate_register_data_in_db_job_spec.rb
+++ b/spec/jobs/populate_register_data_in_db_job_spec.rb
@@ -9,7 +9,7 @@ RSpec.configure do |config|
 end
 
 RSpec.describe PopulateRegisterDataInDbJob, type: :job do
-  let!(:register) { ObjectsFactory.new.create_register('country', 'beta', 'D587') }
+  let!(:register) { ObjectsFactory.new.create_register('country', 'beta') }
 
   before do
     country_data = File.read('./spec/support/country.rsf')


### PR DESCRIPTION
### Context
Forthcoming design changes require that an authority can have a custom description of its registers, in addition to grouping by authority.

### Changes proposed in this pull request
Migrates authorities from reading the government-organisation records to its own table.
This happens over a number of migrations:
* Creating authorities table
* populating authorities from government-organisation records
* associating existing registers with an `authority_id`
* deleting the `authority` field from register
* Populates the `registers_description` field for authorities

It also adds a rake task to synchronise the table with the government-organisation register and updates all frontend and admin references to use this new table. As with themes there is no admin UI to update authority register descriptions as they should change infrequently and itg is not required for MVP.

### Guidance to review
`rake db:migrate` should create and populate Authorities table.
You should continue to be able to read and set an authority in the /admin UI
