### PR TITLE
Indents partial to make sure it's in the correct elements.

### DIFF
--- a/app/views/download/index.html.haml
+++ b/app/views/download/index.html.haml
@@ -13,4 +13,4 @@
       %ul.list.list-bullet{data: {"click-events" => true, "click-category" => "Content", "click-action" => "Register Download"}}
         %li= link_to 'CSV', register_download_csv_path(@register.slug)
         %li= link_to 'JSON', register_download_json_path(@register.slug)
-    = render partial: 'layouts/email_cta', locals: {method: 'download', register_slug: @register&.slug}
+      = render partial: 'layouts/email_cta', locals: {method: 'download', register_slug: @register&.slug}


### PR DESCRIPTION
### Context
The alignment of the sign up partial was slightly out, which meant that it wasn't contained within the correct element - giving a slightly janky look on the page:
<img width="636" alt="screen shot 2018-09-11 at 17 36 36" src="https://user-images.githubusercontent.com/1732331/45374223-57368b80-b5e9-11e8-9749-8b80f54daaa2.png">
Fix:
<img width="621" alt="screen shot 2018-09-11 at 17 36 46" src="https://user-images.githubusercontent.com/1732331/45374232-5e5d9980-b5e9-11e8-954c-ce8c6276cd95.png">


### Changes proposed in this pull request
The `email_cta` partial is indented by two spaces, placing it inside the `.column-full` element.

### Guidance to review
None