### PR TITLE
Fix authority picker

### DIFF
--- a/app/controllers/admin/registers_controller.rb
+++ b/app/controllers/admin/registers_controller.rb
@@ -75,7 +75,7 @@ module Admin
                                         :meta_description,
                                         :featured,
                                         :theme_id,
-                                        authority_attributes: %i[name id])
+                                        :authority_id)
     end
   end
 end

--- a/app/controllers/admin/registers_controller.rb
+++ b/app/controllers/admin/registers_controller.rb
@@ -1,7 +1,6 @@
 module Admin
   class RegistersController < AdminController
     before_action :set_register, only: %i[edit update destroy]
-    before_action :set_government_organisations, except: :index
 
     def index
       @featured_registers = Register.featured.by_popularity

--- a/app/models/register.rb
+++ b/app/models/register.rb
@@ -36,7 +36,6 @@ class Register < ApplicationRecord
   has_many :register_search_results
   belongs_to :theme
   belongs_to :authority
-  accepts_nested_attributes_for :authority
 
   def register_last_updated
     Record.select('timestamp')

--- a/app/views/admin/registers/_form.html.haml
+++ b/app/views/admin/registers/_form.html.haml
@@ -5,9 +5,8 @@
     = f.label :register_phase, class: 'form-label'
     = f.select :register_phase, Register::CURRENT_PHASES, {}, include_blank: 'Select current phase', class: 'form-control'
   .form-group
-    = f.fields_for :authority do |authority_field|
-      = authority_field.label :name, 'Authority', class: 'form-label'
-      = authority_field.select :name, Authority.all.pluck(:name, :id), {}, class: 'form-control'
+    = f.label :authority_id, class: 'form-label'
+    = f.select :authority_id, Authority.all.pluck(:name, :id), {}, class: 'form-control'
   = f.text_area :contextual_data
   .form-group
     = f.label :theme_id, class: 'form-label'
@@ -31,7 +30,7 @@
 = content_for :javascript do
   :javascript
     document.addEventListener('DOMContentLoaded', function() {
-      var element = document.getElementById('register_authority_attributes_name');
+      var element = document.getElementById('register_authority_id');
 
       if (element) {
         accessibleAutocomplete.enhanceSelectElement({

--- a/spec/factories/authorities.rb
+++ b/spec/factories/authorities.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :authority do
+    name { Faker::Name.name }
+    government_organisation_key { Faker::Number.number }
+  end
+end

--- a/spec/factories/objects_factory.rb
+++ b/spec/factories/objects_factory.rb
@@ -4,4 +4,8 @@ class ObjectsFactory
   def create_register(name, phase)
     create(:register, name: name, register_phase: phase)
   end
+
+  def create_authority(name, government_organisation_key)
+    create(:authority, name: name, government_organisation_key: government_organisation_key)
+  end
 end

--- a/spec/features/admin/registers_spec.rb
+++ b/spec/features/admin/registers_spec.rb
@@ -23,7 +23,7 @@ RSpec.feature "Admin registers", type: :feature do
       visit "/admin/registers/#{register_id}/edit"
       select 'Foreign & Commonwealth Office', from: 'Authority'
       click_button 'Save'
-      expect(Register.first.authority.name).to eq('Foreign & Commonwealth Office')
+      expect(Register.find(register_id).authority.name).to eq('Foreign & Commonwealth Office')
     end
   end
 end

--- a/spec/features/admin/registers_spec.rb
+++ b/spec/features/admin/registers_spec.rb
@@ -1,15 +1,29 @@
 require 'rails_helper'
 
 RSpec.feature "Admin registers", type: :feature do
-  describe 'listing registers' do
+  describe 'updating registers' do
     let!(:user) { FactoryBot.create :user }
     let!(:register) { FactoryBot.create_list :register, 3 }
 
-    before { sign_in(User.first) }
+    before do
+      sign_in(User.first)
+      ObjectsFactory.new.create_authority('Foreign & Commonwealth Office', 'D13')
+    end
 
     it 'shows all the registers' do
       visit '/admin/registers'
       expect(page).to have_css '.sortable li', count: 3
+    end
+
+    it 'Updates a register\'s authority' do
+      job = class_double(PopulateRegisterDataInDbJob).
+      as_stubbed_const(perform_later: true)
+      expect(job).to receive(:perform_later)
+      register_id = Register.first.id
+      visit "/admin/registers/#{register_id}/edit"
+      select 'Foreign & Commonwealth Office', from: 'Authority'
+      click_button 'Save'
+      expect(Register.first.authority.name).to eq('Foreign & Commonwealth Office')
     end
   end
 end

--- a/spec/features/admin/registers_spec.rb
+++ b/spec/features/admin/registers_spec.rb
@@ -7,6 +7,7 @@ RSpec.feature "Admin registers", type: :feature do
 
     before do
       sign_in(User.first)
+      ObjectsFactory.new.create_authority('Cabinet Office', 'D2')
       ObjectsFactory.new.create_authority('Foreign & Commonwealth Office', 'D13')
     end
 
@@ -24,6 +25,9 @@ RSpec.feature "Admin registers", type: :feature do
       select 'Foreign & Commonwealth Office', from: 'Authority'
       click_button 'Save'
       expect(Register.find(register_id).authority.name).to eq('Foreign & Commonwealth Office')
+
+      visit "/admin/registers/#{register_id}/edit"
+      expect(page).to have_select('Authority', selected: 'Foreign & Commonwealth Office')
     end
   end
 end


### PR DESCRIPTION
### Context
Bugfix following #427

### Changes proposed in this pull request
The authority picker was erroneously updating the authorities table values instead of the `authority_id` on the register.

This PR fixes issue and adds test for functionality.

### Guidance to review
* Authority picker should work
* Tests should pass in travis
* If you have been effected locally by the corruption caused by the previous bug you may want to reload your database.
