### PR TITLE
fix rake authorities perform_now rake task

### DIFF
--- a/lib/tasks/populate_authorities.rake
+++ b/lib/tasks/populate_authorities.rake
@@ -1,9 +1,11 @@
 namespace :registers_frontend do
   namespace :populate_authorities do
-    desc "Populate Authorities using Government Organisation register."
+    desc "Add task to queue: Populate Authorities using Government Organisation register."
     task fetch_later: :environment do
       PopulateAuthoritiesJob.perform_later
     end
+
+    desc "Perform now: Populate Authorities using Government Organisation register."
     task fetch_now: :environment do
       PopulateAuthoritiesJob.perform_now
     end


### PR DESCRIPTION
### Context
Rake task was not previously appearing in `rake --tasks`

### Changes proposed in this pull request
Fix rake task syntax

### Guidance to review
`rake registers_frontend:populate_authorities:fetch_now` should appear in `rake --tasks`