### PR TITLE
Uses the correct name when listing registers.

### DIFF
--- a/app/views/layouts/_list-of-registers.html.haml
+++ b/app/views/layouts/_list-of-registers.html.haml
@@ -2,6 +2,6 @@
   - @collection.registers_by_this_collection.each do |register|
     %li.list-of-registers__register
       %h3.list-of-registers__heading
-        =link_to "#{register.name} register", register_path(register.slug), {class: 'govuk-heading-s govuk-!-margin-bottom-0'}
+        =link_to "#{register.register_name} register", register_path(register.slug), {class: 'govuk-heading-s govuk-!-margin-bottom-0'}
       %p.list-of-registers__description= register.register_description
       %p.list-of-registers__authority= register.authority.name


### PR DESCRIPTION
### Context
Registers were being listed with the wrong name - this pull request corrects that.

### Changes proposed in this pull request
When listed, the register now uses `register_name` rather than `name` - this gives the more human readable name.

### Guidance to review
None.