### PR TITLE
Fixes rounded search box input in iOS.

### DIFF
--- a/app/assets/stylesheets/modules/_search.scss
+++ b/app/assets/stylesheets/modules/_search.scss
@@ -1,6 +1,8 @@
 .records-search {
   .search-input {
+    appearance: none;
     border: 2px solid $black;
+    border-radius: 0;
     font-size: 16px;
     height: 20px;
     padding: 7px;


### PR DESCRIPTION
### Context
The collection page search box had rounded corners when viewed on iOS. These CSS changes override the browser's default stylesheet.

Before:
![screen shot 2018-10-05 at 16 12 45](https://user-images.githubusercontent.com/1732331/46543888-f3d30d00-c8b9-11e8-9d42-6a6eb2193156.png)

After:
![screen shot 2018-10-05 at 16 13 16](https://user-images.githubusercontent.com/1732331/46543893-f897c100-c8b9-11e8-9fac-08dd817a5ed1.png)

### Changes proposed in this pull request
Removes the rounded input box by resetting the appearance and border-radius.

### Guidance to review
None.