### PR TITLE
Fixes `li` to be nested inside `ul`.

### DIFF
--- a/app/views/layouts/_registers-in-numbers.html.haml
+++ b/app/views/layouts/_registers-in-numbers.html.haml
@@ -1,19 +1,19 @@
 %aside{ class: "#{current_page?(about_path) ? 'registers-in-numbers--about-page' : 'registers-in-numbers'}"}
   %h2{ class: "#{current_page?(about_path) ? 'govuk-heading-s' : 'govuk-heading-m'}"} GOV.UK Registers in numbers
   %ul
-  - if current_page?(about_path)
+    - if current_page?(about_path)
+      %li{class: 'registers-in-numbers__item govuk-!-margin-bottom-4'}
+        %span{role: "presentation", class: 'govuk-heading-xl govuk-!-margin-bottom-0'} 862k
+        %a{role: "presentation", class: 'data-item govuk-body-s govuk-!-margin-bottom-0', href: "https://www.gov.uk/performance/govuk-registers"}total API requests
     %li{class: 'registers-in-numbers__item govuk-!-margin-bottom-4'}
-      %span{role: "presentation", class: 'govuk-heading-xl govuk-!-margin-bottom-0'} 862k
-      %a{role: "presentation", class: 'data-item govuk-body-s govuk-!-margin-bottom-0', href: "https://www.gov.uk/performance/govuk-registers"}total API requests
-  %li{class: 'registers-in-numbers__item govuk-!-margin-bottom-4'}
-    -# = link_to registers_path do
-    %span{role: "presentation", class: "#{current_page?(about_path) ? 'govuk-heading-xl' : 'govuk-!-font-size-80 govuk-!-font-weight-bold'} govuk-!-margin-bottom-0"}= Register.available_count
-    %span{role: "presentation", class: "#{current_page?(about_path) ? 'govuk-body-s' : 'govuk-body'} govuk-!-margin-bottom-0 data-item"} government registers available
-  %li{class: 'registers-in-numbers__item govuk-!-margin-bottom-4'}
-    -# = link_to registers_path do
-    %span{role: "presentation", class: "#{current_page?(about_path) ? 'govuk-heading-xl' : 'govuk-!-font-size-80 govuk-!-font-weight-bold'} govuk-!-margin-bottom-0"}= Register.organisation_count
-    %span{role: "presentation", class: "#{current_page?(about_path) ? 'govuk-body-s' : 'govuk-body'} govuk-!-margin-bottom-0 data-item"} government organisations managing&nbsp;registers
-  %li{class: 'registers-in-numbers__item govuk-!-margin-bottom-4'}
-    -# = link_to services_using_registers_path do
-    %span{role: "presentation", class: "#{current_page?(about_path) ? 'govuk-heading-xl' : 'govuk-!-font-size-80 govuk-!-font-weight-bold'} govuk-!-margin-bottom-0"} 8
-    %span{role: "presentation", class: "#{current_page?(about_path) ? 'govuk-body-s' : 'govuk-body'} govuk-!-margin-bottom-0 data-item"} government services using&nbsp;registers
+      -# = link_to registers_path do
+      %span{role: "presentation", class: "#{current_page?(about_path) ? 'govuk-heading-xl' : 'govuk-!-font-size-80 govuk-!-font-weight-bold'} govuk-!-margin-bottom-0"}= Register.available_count
+      %span{role: "presentation", class: "#{current_page?(about_path) ? 'govuk-body-s' : 'govuk-body'} govuk-!-margin-bottom-0 data-item"} government registers available
+    %li{class: 'registers-in-numbers__item govuk-!-margin-bottom-4'}
+      -# = link_to registers_path do
+      %span{role: "presentation", class: "#{current_page?(about_path) ? 'govuk-heading-xl' : 'govuk-!-font-size-80 govuk-!-font-weight-bold'} govuk-!-margin-bottom-0"}= Register.organisation_count
+      %span{role: "presentation", class: "#{current_page?(about_path) ? 'govuk-body-s' : 'govuk-body'} govuk-!-margin-bottom-0 data-item"} government organisations managing&nbsp;registers
+    %li{class: 'registers-in-numbers__item govuk-!-margin-bottom-4'}
+      -# = link_to services_using_registers_path do
+      %span{role: "presentation", class: "#{current_page?(about_path) ? 'govuk-heading-xl' : 'govuk-!-font-size-80 govuk-!-font-weight-bold'} govuk-!-margin-bottom-0"} 8
+      %span{role: "presentation", class: "#{current_page?(about_path) ? 'govuk-body-s' : 'govuk-body'} govuk-!-margin-bottom-0 data-item"} government services using&nbsp;registers


### PR DESCRIPTION
### Context
Each list item in the `register-in-numbers` partial was not nesting inside the `ul` element as they were not appropriately indented.

### Changes proposed in this pull request
 * `li` elements in the `register-in-numbers` partial indented - they should now render inside the `ul` element.

### Guidance to review
* Links are purposely left commented out.