### PR TITLE
Prevents records with a future end date being displayed as archived.

### DIFF
--- a/app/models/record.rb
+++ b/app/models/record.rb
@@ -3,8 +3,15 @@ class Record < ApplicationRecord
 
   include SearchScope
   belongs_to :register
-  scope :current, -> { where(Arel.sql("data->> 'end-date' is null")) }
-  scope :archived, -> { where(Arel.sql("data->> 'end-date' is not null")) }
+  scope :current, -> {
+    where(Arel.sql("data->> 'end-date' is null or data->> 'end-date' > '#{Date.today}'"))
+  }
+
+  scope :archived, -> {
+    # where("data->> 'end-date' < ?", Date.today)
+    where(Arel.sql("data->> 'end-date' < '#{Date.today}'"))
+  }
+
   scope :status, lambda { |status|
     case status
     when 'archived', 'current'

--- a/app/models/record.rb
+++ b/app/models/record.rb
@@ -4,7 +4,7 @@ class Record < ApplicationRecord
   include SearchScope
   belongs_to :register
   scope :current, -> {
-    where(Arel.sql("data->> 'end-date' is null or data->> 'end-date' > '#{Date.today}'"))
+    where(Arel.sql("data->> 'end-date' is null or data->> 'end-date' >= '#{Date.today}'"))
   }
 
   scope :archived, -> {


### PR DESCRIPTION
### Context
Any record that had any end date was filtered into the archive - whether the date was in the future or not. This isn't the desired behaviour.

### Changes proposed in this pull request
* Changes the archive filter to only include past end dates
* Changes the current filter to include future end dates and no end dates

### Guidance to review
Line 11 and 12 contain two queries (one commented out) that give the same displayed results. Which of these is preferable?