### PR TITLE
Preview the data changes

### DIFF
--- a/app/assets/javascripts/accordion-with-descriptions.js
+++ b/app/assets/javascripts/accordion-with-descriptions.js
@@ -141,8 +141,11 @@
       function bindToggleForSubsections() {
         // Add toggle functionality individual sections
         $subsectionHeader.on('click', function(e) {
-          toggleSection($(this).next());
-          toggleIcon($(this));
+          $(this).parent().find('.subsection__content').each( function() {
+            toggleSection( $(this) )
+            toggleIcon($(this));
+        })
+
           toggleState($(this).find('.subsection__button'));
           //setOpenCloseAllText();
           if(window.ga && ga.create) {

--- a/app/assets/javascripts/accordion-with-descriptions.js
+++ b/app/assets/javascripts/accordion-with-descriptions.js
@@ -16,7 +16,7 @@
       var totalSubsections = $element.find('.subsection__content').length;
 
       var $openOrCloseAllButton;
-      var GOVUKServiceManualTopic = serviceManualTopicPrefix();
+      var RegisterAccordionSection = serviceManualTopicPrefix();
 
       //addOpenCloseAllButton();
       addButtonsToSubsections();
@@ -108,7 +108,7 @@
 
         $subsectionContent.each(function(index) {
           var subsectionContentId = $(this).attr('id');
-          if(sessionStorage.getItem(GOVUKServiceManualTopic+subsectionContentId)){
+          if(sessionStorage.getItem(RegisterAccordionSection + subsectionContentId)){
             openStoredSections($("#"+subsectionContentId));
           }
         });
@@ -124,7 +124,7 @@
             $(this)
               .find('.subsection__content')
               .each(function(i) {
-                sessionStorage.setItem( GOVUKServiceManualTopic + $(this).attr('id') , 'Opened');
+                sessionStorage.setItem( RegisterAccordionSection + $(this).attr('id') , 'Opened');
               })
           })
         }
@@ -139,7 +139,7 @@
               .find('.subsection__content')
               .each(function(i) {
                 var subsectionClosedContentId = $(this).attr('id')
-                sessionStorage.removeItem( GOVUKServiceManualTopic + subsectionClosedContentId , subsectionClosedContentId);
+                sessionStorage.removeItem( RegisterAccordionSection + subsectionClosedContentId , subsectionClosedContentId);
               })
           })
         }

--- a/app/assets/javascripts/accordion-with-descriptions.js
+++ b/app/assets/javascripts/accordion-with-descriptions.js
@@ -51,12 +51,23 @@
       }
 
       function addButtonsToSubsections() {
-        var $subsectionTitle = $element.find('.subsection__title');
+        var $subsectionTitle = $element.find('.subsection__title')
 
-        // Wrap each title in a button, with aria controls matching the ID of the subsection
-        $subsectionTitle.each(function(index) {
-          $(this).wrapInner( '<button class="subsection__button" aria-expanded="false" aria-controls="subsection_content_' + index +'"></a>' );
-        });
+        // Wrap each title in a button, with aria controls matching the ID(s) of the subsection
+        $subsectionTitle.each( function(index) {
+          var $subsections = $(this)
+                                .closest('.js-accordion-with-descriptions')
+                                  .find('.js-accordion-subsection')
+
+          var subsectionsIds = [];
+
+          for (var i = 0; i < $subsections.length; i++) {
+            subsectionsIds.push($subsections[i].id)
+          }
+
+          $(this)
+            .wrapInner( '<button class="subsection__button" aria-expanded="false" aria-controls="' + subsectionsIds.join(' ') + '"></a>' )
+        })
       }
 
       function addIconsToSubsections() {
@@ -122,7 +133,7 @@
           var $openSubsections = $('.subsection--is-open');
           $openSubsections.each(function(index) {
             $(this)
-              .find('.subsection__content')
+              .find('.js-accordion-subsection')
               .each(function(i) {
                 sessionStorage.setItem( RegisterAccordionSection + $(this).attr('id') , 'Opened');
               })
@@ -136,7 +147,7 @@
           var $closedSubsections = $('.subsection');
           $closedSubsections.each(function(index) {
             $(this)
-              .find('.subsection__content')
+              .find('.js-accordion-subsection')
               .each(function(i) {
                 var subsectionClosedContentId = $(this).attr('id')
                 sessionStorage.removeItem( RegisterAccordionSection + subsectionClosedContentId , subsectionClosedContentId);
@@ -148,7 +159,7 @@
       function bindToggleForSubsections() {
         // Add toggle functionality individual sections
         $subsectionHeader.on('click', function(e) {
-          $(this).parent().find('.subsection__content').each( function() {
+          $(this).parent().find('.js-accordion-subsection').each( function() {
             toggleSection( $(this) )
             toggleIcon($(this));
         })

--- a/app/assets/javascripts/accordion-with-descriptions.js
+++ b/app/assets/javascripts/accordion-with-descriptions.js
@@ -121,9 +121,12 @@
         if (isOpenSubsections) {
           var $openSubsections = $('.subsection--is-open');
           $openSubsections.each(function(index) {
-            var subsectionOpenContentId = $(this).find('.subsection__content').attr('id');
-            sessionStorage.setItem( GOVUKServiceManualTopic+subsectionOpenContentId , 'Opened');
-          });
+            $(this)
+              .find('.subsection__content')
+              .each(function(i) {
+                sessionStorage.setItem( GOVUKServiceManualTopic + $(this).attr('id') , 'Opened');
+              })
+          })
         }
       }
 
@@ -132,9 +135,13 @@
         if (isClosedSubsections) {
           var $closedSubsections = $('.subsection');
           $closedSubsections.each(function(index) {
-            var subsectionClosedContentId = $(this).find('.subsection__content').attr('id');
-            sessionStorage.removeItem( GOVUKServiceManualTopic+subsectionClosedContentId , subsectionClosedContentId);
-          });
+            $(this)
+              .find('.subsection__content')
+              .each(function(i) {
+                var subsectionClosedContentId = $(this).attr('id')
+                sessionStorage.removeItem( GOVUKServiceManualTopic + subsectionClosedContentId , subsectionClosedContentId);
+              })
+          })
         }
       }
 

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -11,7 +11,11 @@
 //
 // Read Sprockets README (https://github.com/rails/sprockets#sprockets-directives) for details
 // about supported directives.
+
+// GOV.UK Design System
+//= require all.js
 //
+// Elements
 //= require jquery
 //= require jquery_ujs
 //= require dialog-polyfill
@@ -24,9 +28,6 @@
 //= require accordion-with-descriptions
 //= require jquery-ui/widget
 //= require jquery-ui/sortable
-
-// GOV.UK Design System
-//= require all.js
 
 // Adding a `js` class to the html element allows us to use CSS to do things
 // only when JavaScript is enabled - for example, hide the submit button for

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -658,14 +658,37 @@ details {
 }
 
 .registers__button--access {
+  // scss-lint:disable PlaceholderInExtend
+  // scss-lint:disable BangFormat
   @extend .govuk-button;
-  @extend .govuk-\!-font-size-24;
+  @extend .govuk-\!-font-size-19;
+  // scss-lint:enable PlaceholderInExtend
+  // scss-lint:enable BangFormat
 
   background-color: $govuk-link-colour;
-  line-height: 1 !important;
   font-weight: 700;
-  padding-left: 0.5em;
-  padding-right: 0.5em;
+  line-height: 1 !important;
+  padding: 0.85em 1.25em 0.65em 1.25em;
+
+  &:hover {
+    background-color: $govuk-link-hover-colour;
+  }
+}
+
+.registers__button--access-large {
+  // scss-lint:disable PlaceholderInExtend
+  // scss-lint:disable BangFormat
+  @extend .govuk-button;
+  @extend .govuk-\!-font-size-19;
+  // scss-lint:enable PlaceholderInExtend
+  // scss-lint:enable BangFormat
+
+  background-color: $govuk-link-colour;
+  font-weight: 700;
+  line-height: 1 !important;
+  padding: 0.85em 0.5em 0.65em 0.5em;
+  text-align: center;
+  width: 100%;
 
   &:hover {
     background-color: $govuk-link-hover-colour;
@@ -697,7 +720,8 @@ body:not(.home-page) .breadcrumbs {
 }
 
 .footer-meta {
-  @extend .govuk-width-container; // scss-lint:disable PlaceholderInExtend
+  // scss-lint:disable PlaceholderInExtend
+  @extend .govuk-width-container;
 }
 
 // Avoid two lots of left and right margins

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -129,10 +129,11 @@ a:visited {
 .govuk-metadata {
   font-size: 16px;
   margin-bottom: 20px;
+  @extend %contain-floats;
 
   @supports (display: grid) {
     display: grid;
-    grid-template-columns: max-content auto;
+    grid-template-columns: 6.25em auto;
     grid-column-gap: 0.35em;
   }
 

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -666,14 +666,14 @@ details {
   // scss-lint:disable PlaceholderInExtend
   // scss-lint:disable BangFormat
   @extend .govuk-button;
-  @extend .govuk-\!-font-size-19;
+  @extend .govuk-\!-font-size-24;
   // scss-lint:enable PlaceholderInExtend
   // scss-lint:enable BangFormat
 
   background-color: $govuk-link-colour;
   font-weight: 700;
   line-height: 1 !important;
-  padding: 0.85em 1.25em 0.65em 1.25em;
+  padding: 0.75em 1.15em 0.55em 1.15em;
 
   &:hover {
     background-color: $govuk-link-hover-colour;

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -130,6 +130,12 @@ a:visited {
   font-size: 16px;
   margin-bottom: 20px;
 
+  @supports (display: grid) {
+    display: grid;
+    grid-template-columns: max-content auto;
+    grid-column-gap: 0.35em;
+  }
+
   dl {
     overflow: hidden;
   }
@@ -140,7 +146,6 @@ a:visited {
     max-width: 150px;
     padding-bottom: 0.5rem;
     padding-right: 1%;
-    width: 24%;
   }
 
   dd {
@@ -148,7 +153,6 @@ a:visited {
     margin: 0;
     max-width: 480px;
     padding-bottom: 0.5rem;
-    width: 75%;
   }
 }
 

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -43,8 +43,11 @@ $govuk-font-family: "nta", Helvetica, Arial, sans-serif; // "Custom" font stack;
 @import "core/typography";
 @import "core/lists";
 @import "objects/all";
+@import 'components/button/button';
 @import 'components/radios/radios';
 @import 'components/input/input';
+@import 'components/inset-text/inset-text';
+@import 'components/tag/tag';
 @import 'overrides/spacing';
 @import 'overrides/typography';
 @import 'overrides/width';
@@ -652,6 +655,21 @@ details {
 .registers-\!-faded-colour {
   color: $grey-1;
   padding-left: 0.25em;
+}
+
+.registers__button--access {
+  @extend .govuk-button;
+  @extend .govuk-\!-font-size-24;
+
+  background-color: $govuk-link-colour;
+  line-height: 1 !important;
+  font-weight: 700;
+  padding-left: 0.5em;
+  padding-right: 0.5em;
+
+  &:hover {
+    background-color: $govuk-link-hover-colour;
+  }
 }
 
 .registers-\!-border-off {

--- a/app/assets/stylesheets/modules/_accordion.scss
+++ b/app/assets/stylesheets/modules/_accordion.scss
@@ -1,22 +1,5 @@
-.subsection__title--not-accordionised {
-  border-top: 1px solid $grey-2;
-  font-size: 16px;
-  font-weight: bold;
-  line-height: 1.25;
-
-  a {
-    color: $link-colour;
-    display: block;
-    padding: 18px 2px 17px 2px;
-    text-decoration: none;
-  }
-
-  &:hover {
-    background: $highlight-colour;
-  }
-
-  @media screen and (min-width: 641px) {
-    font-size: 19px;
-    line-height: 1.3157894737;
+.js-accordion-with-descriptions.subsection--is-open {
+  .subsection__icon {
+    background-position: 0 0;
   }
 }

--- a/app/assets/stylesheets/modules/_pagination.scss
+++ b/app/assets/stylesheets/modules/_pagination.scss
@@ -10,22 +10,18 @@
   }
 
   &-items {
-    display: none;
+    display: inline;
 
-    @include media(tablet) {
+    li {
       display: inline;
+      margin: 0 5px;
 
-      li {
-        display: inline;
-        margin: 0 5px;
+      &:first-child {
+        margin-left: 0;
+      }
 
-        &:first-child {
-          margin-left: 0;
-        }
-
-        &:last-child {
-          margin-right: 0;
-        }
+      &:last-child {
+        margin-right: 0;
       }
     }
   }
@@ -52,9 +48,7 @@
   }
 
   &-controls {
-    @include media(tablet) {
-      float: right;
-    }
+    text-align: right;
   }
 }
 

--- a/app/assets/stylesheets/modules/_subsections.scss
+++ b/app/assets/stylesheets/modules/_subsections.scss
@@ -156,7 +156,7 @@
   text-decoration: none;
 }
 
-.register-show main {
+.register-show.js-enabled main {
   border-bottom: 1px solid $border-colour;
   padding-bottom: 0 !important;
   margin-bottom: 90px !important;

--- a/app/assets/stylesheets/modules/_subsections.scss
+++ b/app/assets/stylesheets/modules/_subsections.scss
@@ -73,10 +73,10 @@
     }
 
     &__title {
-      padding-top: 14px;
-      padding-bottom: 12px;
       border-top: 1px solid $border-colour;
       margin-bottom: 0;
+      padding-bottom: 0.65em;
+      padding-top: 0.65em;
 
       // Change the background of the header on hover
       &:hover {
@@ -85,13 +85,15 @@
       }
 
       button {
-        color: $govuk-blue;
-        cursor: pointer;
+        @extend .govuk-\!-font-size-24;
 
-        @include bold-19;
         background: none;
         border: 0;
-        padding-left: 0;
+        color: $govuk-blue;
+        cursor: pointer;
+        font-weight: bold;
+        margin: 0;
+        padding: 0.25em 0 0 0;
         text-align: left;
       }
     }
@@ -107,18 +109,16 @@
     }
 
     &__icon {
+      height: 16px;
       position: absolute;
+      margin-top: -8px;
       right: 30px;
       top: 50%;
-
-      height: 16px;
       width: 16px;
-      margin-top: -8px;
-
       // PNG fallback for SVG
       background-image: image-url('icons-plus-minus.png');
       // SVG sprite
-      background: image-url("icons-plus-minus.svg"), linear-gradient(transparent, transparent);
+      background-image: image-url("icons-plus-minus.svg");
       background-repeat: no-repeat;
       background-position: 0 -16px;
     }

--- a/app/assets/stylesheets/modules/_subsections.scss
+++ b/app/assets/stylesheets/modules/_subsections.scss
@@ -5,7 +5,6 @@
 // scss-lint:disable SelectorFormat
 
 .subsection {
-  width: 100%;
   margin-bottom: $gutter;
 
   @include media(tablet) {

--- a/app/assets/stylesheets/modules/_subsections.scss
+++ b/app/assets/stylesheets/modules/_subsections.scss
@@ -5,11 +5,6 @@
 // scss-lint:disable SelectorFormat
 
 .subsection {
-  margin-bottom: $gutter;
-
-  @include media(tablet) {
-    margin-bottom: $gutter * 1.5;
-  }
 
   &__title {
     @include bold-24;
@@ -63,7 +58,6 @@
   // Wrapper for subsections
   .subsection-wrapper {
     @extend %contain-floats;
-    border-bottom: 1px solid $border-colour;
   }
 
   .subsection {
@@ -76,18 +70,20 @@
     &__header {
       color: $govuk-blue;
       position: relative;
+    }
+
+    &__title {
       padding-top: 14px;
       padding-bottom: 12px;
       border-top: 1px solid $border-colour;
+      margin-bottom: 0;
 
       // Change the background of the header on hover
       &:hover {
         cursor: pointer;
         background: $highlight-colour;
       }
-    }
 
-    &__title {
       button {
         color: $govuk-blue;
         cursor: pointer;
@@ -97,13 +93,6 @@
         border: 0;
         padding-left: 0;
         text-align: left;
-      }
-
-      margin-bottom: 0;
-      margin-right: $gutter-half;
-
-      @include media(tablet) {
-        margin-right: $gutter;
       }
     }
 
@@ -119,12 +108,8 @@
 
     &__icon {
       position: absolute;
+      right: 30px;
       top: 50%;
-      right: 0;
-
-      @include media (tablet) {
-        right: 15px;
-      }
 
       height: 16px;
       width: 16px;
@@ -157,7 +142,6 @@
         }
       }
     }
-
   }
 }
 
@@ -170,4 +154,10 @@
   padding: 14px 0 12px 0;
   text-align: left;
   text-decoration: none;
+}
+
+.register-show main {
+  border-bottom: 1px solid $border-colour;
+  padding-bottom: 0 !important;
+  margin-bottom: 90px !important;
 }

--- a/app/assets/stylesheets/modules/_subsections.scss
+++ b/app/assets/stylesheets/modules/_subsections.scss
@@ -85,7 +85,11 @@
       }
 
       button {
+        // scss-lint:disable PlaceholderInExtend
+        // scss-lint:disable BangFormat
         @extend .govuk-\!-font-size-24;
+        // scss-lint:enable PlaceholderInExtend
+        // scss-lint:enable BangFormat
 
         background: none;
         border: 0;
@@ -115,10 +119,12 @@
       right: 30px;
       top: 50%;
       width: 16px;
+      // scss-lint:disable DuplicateProperty
       // PNG fallback for SVG
       background-image: image-url('icons-plus-minus.png');
       // SVG sprite
       background-image: image-url("icons-plus-minus.svg");
+      // scss-lint:enable DuplicateProperty
       background-repeat: no-repeat;
       background-position: 0 -16px;
     }

--- a/app/controllers/registers_controller.rb
+++ b/app/controllers/registers_controller.rb
@@ -41,7 +41,7 @@ class RegistersController < ApplicationController
     @records = recover_records(@register.fields_array, params)
     @feedback = Feedback.new
     @register_category = Register.category(@register.category_id)
-    @register_records_total_count = @register.records.count;
+    @register_records_total_count = @register.number_of_records;
   end
 
   def field_link_resolver(field, field_value, register_slug: @register.slug, whitelist: register_whitelist)
@@ -94,7 +94,6 @@ private
     @register.records
              .where(entry_type: 'user')
              .search_for(fields, search_term)
-             .status(params[:status])
              .sort_by_field(sort_by, sort_direction)
              .page(params[:page])
              .per(10)

--- a/app/controllers/registers_controller.rb
+++ b/app/controllers/registers_controller.rb
@@ -41,6 +41,7 @@ class RegistersController < ApplicationController
     @records = recover_records(@register.fields_array, params)
     @feedback = Feedback.new
     @register_category = Register.category(@register.category_id)
+    @register_records_total_count = @register.records.count;
   end
 
   def field_link_resolver(field, field_value, register_slug: @register.slug, whitelist: register_whitelist)
@@ -96,7 +97,7 @@ private
              .status(params[:status])
              .sort_by_field(sort_by, sort_direction)
              .page(params[:page])
-             .per(100)
+             .per(10)
   end
 
   def feedback_params

--- a/app/controllers/registers_controller.rb
+++ b/app/controllers/registers_controller.rb
@@ -40,6 +40,7 @@ class RegistersController < ApplicationController
     @register = Register.has_records.find_by_slug!(params[:id])
     @records = recover_records(@register.fields_array, params)
     @feedback = Feedback.new
+    @register_category = Register.category(@register.category_id)
   end
 
   def field_link_resolver(field, field_value, register_slug: @register.slug, whitelist: register_whitelist)

--- a/app/controllers/registers_controller.rb
+++ b/app/controllers/registers_controller.rb
@@ -40,7 +40,6 @@ class RegistersController < ApplicationController
     @register = Register.has_records.find_by_slug!(params[:id])
     @records = recover_records(@register.fields_array, params)
     @feedback = Feedback.new
-    @register_category = Register.category(@register.category_id)
     @register_records_total_count = @register.number_of_records;
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,6 +1,6 @@
 module ApplicationHelper
   def page_entries_info(collection, options = {})
-    raw super(collection, options).gsub(/\d{4,}/, number_with_delimiter(collection.total_count))
+    raw super(collection, options).gsub(/(\d{4,})/) { |m| number_with_delimiter(m) }
   end
 
   def crest_class_name(authority)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,8 @@
 module ApplicationHelper
+  def page_entries_info(collection, options = {})
+    raw super(collection, options).gsub(/\d{4,}/, number_with_delimiter(collection.total_count))
+  end
+
   def crest_class_name(authority)
     case authority
     when 'home-office'

--- a/app/models/record.rb
+++ b/app/models/record.rb
@@ -3,18 +3,6 @@ class Record < ApplicationRecord
 
   include SearchScope
   belongs_to :register
-  scope :current, -> { where(Arel.sql("data->> 'end-date' is null")) }
-  scope :archived, -> { where(Arel.sql("data->> 'end-date' is not null")) }
-  scope :status, lambda { |status|
-    case status
-    when 'archived', 'current'
-      send(status)
-    when 'all'
-      nil
-    else
-      current
-    end
-  }
 
   scope :sort_by_field, lambda { |sort_by, sort_direction|
     if sort_by.match?(VALID_FIELD_NAME)

--- a/app/models/register.rb
+++ b/app/models/register.rb
@@ -73,6 +73,10 @@ class Register < ApplicationRecord
     records.where(entry_type: 'user').none?
   end
 
+  def show_category_link?
+    register_phase == 'Beta' && category.present?
+  end
+
 private
 
   def set_slug

--- a/app/models/register.rb
+++ b/app/models/register.rb
@@ -30,7 +30,6 @@ class Register < ApplicationRecord
       .count(:authority_id)
   }
   scope :available_count, -> { available.in_beta.count }
-  scope :category, -> { first.category }
 
   has_many :entries, dependent: :destroy
   has_many :records, dependent: :destroy

--- a/app/models/register.rb
+++ b/app/models/register.rb
@@ -30,14 +30,12 @@ class Register < ApplicationRecord
       .count(:authority_id)
   }
   scope :available_count, -> { available.in_beta.count }
-  scope :category, ->(category_id) {
-    Category.where(id: category_id).first
-  }
+  scope :category, -> { first.category }
 
   has_many :entries, dependent: :destroy
   has_many :records, dependent: :destroy
   has_many :register_search_results
-  belongs_to :theme
+  belongs_to :category
   belongs_to :authority
 
   def register_last_updated

--- a/app/models/register.rb
+++ b/app/models/register.rb
@@ -30,7 +30,7 @@ class Register < ApplicationRecord
       .count(:authority_id)
   }
   scope :available_count, -> { available.in_beta.count }
-  scope :category, ->(category_id){
+  scope :category, ->(category_id) {
     Category.where(id: category_id).first
   }
 

--- a/app/models/register.rb
+++ b/app/models/register.rb
@@ -30,6 +30,9 @@ class Register < ApplicationRecord
       .count(:authority_id)
   }
   scope :available_count, -> { available.in_beta.count }
+  scope :category, ->(category_id){
+    Category.where(id: category_id).first
+  }
 
   has_many :entries, dependent: :destroy
   has_many :records, dependent: :destroy

--- a/app/views/layouts/_categories.html.haml
+++ b/app/views/layouts/_categories.html.haml
@@ -6,7 +6,6 @@
         -if category.description.present?
           %p.register-theme__description.govuk-body-s= "#{category.description}"
         %p{class: "register-theme__count govuk-body-s"}= "#{pluralize(category.register_count, 'register')}"
-        -# category.taxon_content_id
   -if current_page?(root_path)
     %li.register-theme
       = link_to "View all registers", registers_path, {class: 'register-theme__view-all'}

--- a/app/views/layouts/_registers-in-numbers.html.haml
+++ b/app/views/layouts/_registers-in-numbers.html.haml
@@ -1,19 +1,19 @@
 %aside{ class: "#{current_page?(about_path) ? 'registers-in-numbers--about-page' : 'registers-in-numbers'}"}
   %h2{ class: "#{current_page?(about_path) ? 'govuk-heading-s' : 'govuk-heading-m'}"} GOV.UK Registers in numbers
   %ul
-  - if current_page?(about_path)
+    - if current_page?(about_path)
+      %li{class: 'registers-in-numbers__item govuk-!-margin-bottom-4'}
+        %span{role: "presentation", class: 'govuk-heading-xl govuk-!-margin-bottom-0'} 862k
+        %a{role: "presentation", class: 'data-item govuk-body-s govuk-!-margin-bottom-0', href: "https://www.gov.uk/performance/govuk-registers"}total API requests
     %li{class: 'registers-in-numbers__item govuk-!-margin-bottom-4'}
-      %span{role: "presentation", class: 'govuk-heading-xl govuk-!-margin-bottom-0'} 862k
-      %a{role: "presentation", class: 'data-item govuk-body-s govuk-!-margin-bottom-0', href: "https://www.gov.uk/performance/govuk-registers"}total API requests
-  %li{class: 'registers-in-numbers__item govuk-!-margin-bottom-4'}
-    -# = link_to registers_path do
-    %span{role: "presentation", class: "#{current_page?(about_path) ? 'govuk-heading-xl' : 'govuk-!-font-size-80 govuk-!-font-weight-bold'} govuk-!-margin-bottom-0"}= Register.available_count
-    %span{role: "presentation", class: "#{current_page?(about_path) ? 'govuk-body-s' : 'govuk-body'} govuk-!-margin-bottom-0 data-item"} government registers available
-  %li{class: 'registers-in-numbers__item govuk-!-margin-bottom-4'}
-    -# = link_to registers_path do
-    %span{role: "presentation", class: "#{current_page?(about_path) ? 'govuk-heading-xl' : 'govuk-!-font-size-80 govuk-!-font-weight-bold'} govuk-!-margin-bottom-0"}= Register.organisation_count
-    %span{role: "presentation", class: "#{current_page?(about_path) ? 'govuk-body-s' : 'govuk-body'} govuk-!-margin-bottom-0 data-item"} government organisations managing&nbsp;registers
-  %li{class: 'registers-in-numbers__item govuk-!-margin-bottom-4'}
-    -# = link_to services_using_registers_path do
-    %span{role: "presentation", class: "#{current_page?(about_path) ? 'govuk-heading-xl' : 'govuk-!-font-size-80 govuk-!-font-weight-bold'} govuk-!-margin-bottom-0"} 8
-    %span{role: "presentation", class: "#{current_page?(about_path) ? 'govuk-body-s' : 'govuk-body'} govuk-!-margin-bottom-0 data-item"} government services using&nbsp;registers
+      -# = link_to registers_path do
+      %span{role: "presentation", class: "#{current_page?(about_path) ? 'govuk-heading-xl' : 'govuk-!-font-size-80 govuk-!-font-weight-bold'} govuk-!-margin-bottom-0"}= Register.available_count
+      %span{role: "presentation", class: "#{current_page?(about_path) ? 'govuk-body-s' : 'govuk-body'} govuk-!-margin-bottom-0 data-item"} government registers available
+    %li{class: 'registers-in-numbers__item govuk-!-margin-bottom-4'}
+      -# = link_to registers_path do
+      %span{role: "presentation", class: "#{current_page?(about_path) ? 'govuk-heading-xl' : 'govuk-!-font-size-80 govuk-!-font-weight-bold'} govuk-!-margin-bottom-0"}= Register.organisation_count
+      %span{role: "presentation", class: "#{current_page?(about_path) ? 'govuk-body-s' : 'govuk-body'} govuk-!-margin-bottom-0 data-item"} government organisations managing&nbsp;registers
+    %li{class: 'registers-in-numbers__item govuk-!-margin-bottom-4'}
+      -# = link_to services_using_registers_path do
+      %span{role: "presentation", class: "#{current_page?(about_path) ? 'govuk-heading-xl' : 'govuk-!-font-size-80 govuk-!-font-weight-bold'} govuk-!-margin-bottom-0"} 8
+      %span{role: "presentation", class: "#{current_page?(about_path) ? 'govuk-body-s' : 'govuk-body'} govuk-!-margin-bottom-0 data-item"} government services using&nbsp;registers

--- a/app/views/registers/_showing.html.haml
+++ b/app/views/registers/_showing.html.haml
@@ -1,3 +1,0 @@
-= page_entries_info(@records)
-- if @search_term.present?
-    for &ldquo;<strong>#{@search_term}</strong>&rdquo;

--- a/app/views/registers/_showing.html.haml
+++ b/app/views/registers/_showing.html.haml
@@ -1,3 +1,3 @@
 = page_entries_info(@records)
 - if @search_term.present?
-  for <strong>"#{@search_term}"</strong>
+    for &ldquo;<strong>#{@search_term}</strong>&rdquo;

--- a/app/views/registers/show.html.haml
+++ b/app/views/registers/show.html.haml
@@ -2,132 +2,88 @@
 - @page_description = "#{[@register.meta_description, @register.register_description].find(&:present?)}"
 - content_for :body_classes, 'register-show'
 
-%main#content.container{role:'main'}
-  - if @register.register_phase != 'Beta'
-    .grid-row
-      .column-two-thirds
-        .panel.panel-border-wide
-          %span.phase-banner In progress
-          %p This data is in progress and it’s not ready for use.
-
-  .register-meta-data
-    .grid-row
-      .column-two-thirds
+.govuk-width-container
+  %main#content.govuk-main-wrapper{role:'main'}
+    .govuk-grid-row
+      .govuk-grid-column-two-thirds
+        - if @register.register_phase != 'Beta'
+          .govuk-inset-text
+            %strong.govuk-tag In progress
+            %p This data is in progress and it’s not ready for use.
         %h1{class: "govuk-heading-l govuk-!-margin-top-7 govuk-!-margin-bottom-1"}
           #{@register.register_name} register
         %p.govuk-body-l= @register.register_description
-        - unless @register.is_empty?
-          %p.font-xsmall Last updated: #{link_to formatted_date(@register.register_last_updated), register_entries_path(@register.slug)}
-
-      .column-one-third
-        - if @register.authority.present?
-          .related-items
-            %p.bold-small Managed by:
-            %div{class: "govuk-organisation-logo #{@register&.authority&.name&.parameterize}"}
-              %div{class: "logo-container #{crest_class_name(@register&.authority&.name&.parameterize)}"}
-                %span= @register&.authority&.name
-
-  .grid-row
-    .column-full
-      %div{class: "js-hidden", "data-module" => "accordion-with-descriptions"}
-        .subsection-wrapper
-          .subsection.js-subsection
-            .subsection__header
-              %h2.subsection__title Preview the data
-            .subsection__content.js-subsection-content#data_section
-              - unless @register.is_empty?
-                .search-records-wrapper#records_wrapper
-                  = form_tag register_path(@register.slug, anchor: 'records_wrapper'), method: :get, id: 'search_records' do
-                    .grid-row
-                      .column-one-third
-                        .records-search
-                          = label_tag 'Search', nil, for: 'q', class: 'visually-hidden'
-                          = search_field_tag 'q', nil, class: 'search-input', placeholder: 'Search', value: @search_term, autocomplete: 'off'
-                          = submit_tag 'Search', name: nil, class: 'search-submit'
-                    %details{role: "group", open: (params[:status].present? ? 'open' : nil)}
-                      %summary{"aria-controls" => "details-content-0", "aria-expanded" => "#{params[:status].present? ? 'true' : 'false'}", role: "button"}
-                        %span.summary Filter
-                      %div{id: "details-content-0", "aria-hidden" => "#{params[:status].present? && @records.present? ? 'false' : 'true'}"}
-
-                        .grid-row
-                          .column-two-thirds
-                            .form-group
-                              %fieldset.inline
-                                %legend.form-label.form-label-bold Filter data:
-                                .multiple-choice
-                                  = radio_button_tag 'status', 'current', params[:status] == 'current' || !params[:status].present? ?  'true' : nil
-                                  = label_tag 'Current records', nil, for: 'status_current'
-                                .multiple-choice
-                                  = radio_button_tag 'status', 'archived', params[:status] == 'archived' ?  'true' : nil
-                                  = label_tag 'Archived records', nil, for: 'status_archived'
-                                .multiple-choice
-                                  = radio_button_tag 'status', 'all', params[:status] == 'all' ?  'true' : nil
-                                  = label_tag 'Both', nil, for: 'status_all'
-                              = submit_tag 'Search', name: nil, class: 'button filter-search-submit'
-
-
-              - if @records.any?
-                .records-count
-                  %span#records-count
-                    = render partial: 'showing'
-                  - if @search_term.present? || params[:status].present?
-                    = link_to 'Reset', register_path(@register.slug, anchor: 'records_wrapper'), class: 'reset-link'
-
-              - if @register.is_empty? || @records.any?
-                .fullscreen-content{data: {module: 'scrolling-tables'}}
-                  %table.table.register-data-table
-                    %thead
-                      %tr
-                        - @register.register_fields.each do |field|
-                          %th{class: "#{field['field']}"}
-                            = field['cardinality'] == '1' ? records_table_sort_link(field['field'], request.query_parameters) : field['field'].tr('-', ' ').humanize
-                            = link_to register_field_url(@register.slug, field['field']), class: 'info-icon', remote: true, data: {"click-events" => true, "click-category" => "Register Table", "click-action" => "Help"} do
-                              %span.visually-hidden
-                                What does #{field['field']} mean
-                              ?
-                    %tbody#records-tbody
-                      - if @register.is_empty?
-                        %tr
-                          %td{colspan: @register.register_fields.count}
-                            .panel.panel-border-wide
-                              %p This register currently has no data. The owner of the register will publish the data once it has been gathered.
-                      - else
-                        = render partial: 'record', collection: @records
-
-              .pager.js-hidden
-                .pager-controls
-                  = paginate @records, outer_window: 0, window: 3
-                .pager-summary
-                  = render partial: 'showing'
-
-              - unless @records.last_page?
-                %div{data: { "click-events" => true, "click-category" => "Register Table", "click-action" => "Load More" }}
-                  = link_to_next_page @records, 'Load more', id: 'load-more-records', class: 'js-load-more', remote: true
-
-              - unless @records.any? || @register.is_empty?
-                .no-search-results
-                  %p
-                    - if @search_term.present?
-                      No results found for <strong>"#{@search_term}"</strong>
-                      %script
-                        var searchFilter = document.getElementById('search_records').querySelector('input[type="radio"]:checked').parentElement.querySelector('label').innerText.toLowerCase();
-                        ga('send', 'event', 'Search', 'No results filtered by: ' + searchFilter, '#{@search_term}', {nonInteraction: true});
-                    - else
-                      No results found.
-                      %script
-                        ga('send', 'event', 'Search', 'No results', 'Search term not present');
-                    - if @search_term.present? || params[:status].present?
-                      = link_to 'Reset', register_path(@register.slug, anchor: 'search_wrapper'), class: 'reset-link'
-          - if @records.any?
-            .subsection--not-accordionised
-              .subsection__header--not-accordionised
-                %h2.subsection__title--not-accordionised
-                  = link_to 'Access the data', register_choose_access_path(@register.slug)
-          .subsection.js-subsection
-            .subsection__header
-              %h2.subsection__title Give feedback
-            .subsection__content.js-subsection-content#feedback_section
-              = render partial: 'feedback/form'
+        %dl.govuk-metadata
+          - if @register.authority.present?
+            %dt.register-metadata__term Organisation:
+            %dd.register-metadata__definition= @register&.authority&.name
+          - if @register&.category_id&.present? or @register.register_phase != 'Beta'
+            %dt.register-metadata__term Category:
+            %dd.register-metadata__definition= link_to @register_category.name, category_path(@register_category.slug)
+          - unless @register.is_empty?
+            %dt.register-metadata__term Last updated:
+            %dd.register-metadata__definition= link_to formatted_date(@register.register_last_updated), register_entries_path(@register.slug)
+        %p= link_to 'Access the data', register_choose_access_path(@register.slug), { class: 'registers__button--access govuk-!-margin-top-5'}
+    .govuk-grid-row#records_wrapper
+      .govuk-grid-column-two-thirds
+        %h2{class: "govuk-heading-m"}
+          About the data
+        %p This register has #{number_with_delimiter(@records.total_count)} records and #{@register.register_fields.count} fields.
+      .govuk-grid-column-one-third
+        = form_tag register_path(@register.slug, anchor: 'records_wrapper'), method: :get, id: 'search_records' do
+          = label_tag 'Search', nil, for: 'q', class: 'visually-hidden'
+          = search_field_tag 'q', nil, class: 'search-input', placeholder: 'Search', value: @search_term, autocomplete: 'off'
+          = submit_tag 'Search', name: nil, class: 'search-submit'
+      .govuk-grid-column-full
+        %p{class: 'govuk-!-margin-bottom-2'}
+          - unless @search_term.present? || params[:status].present?
+            Showing
+            %strong 1 &ndash; #{@records.count + @records.offset_value}
+            of
+            %strong= @records.total_count
+            records.
+          - if @search_term.present? || params[:status].present?
+            Showing #{@records.count} records for <strong>&ldquo;#{@search_term}&rdquo;</strong>.
+            = link_to 'Reset', register_path(@register.slug, anchor: 'records_wrapper'), class: 'reset-link'
+        - if @register.is_empty? || @records.any?
+          .fullscreen-content{data: {module: 'scrolling-tables'}}
+            %table.table.register-data-table
+              %thead
+                %tr
+                  - @register.register_fields.each do |field|
+                    %th{class: "#{field['field']}"}
+                      = field['cardinality'] == '1' ? records_table_sort_link(field['field'], request.query_parameters) : field['field'].tr('-', ' ').humanize
+                      = link_to register_field_url(@register.slug, field['field']), class: 'info-icon', remote: true, data: {"click-events" => true, "click-category" => "Register Table", "click-action" => "Help"} do
+                        %span.visually-hidden
+                          What does #{field['field']} mean
+                        ?
+              %tbody#records-tbody
+                - if @register.is_empty?
+                  %tr
+                    %td{colspan: @register.register_fields.count}
+                      .panel.panel-border-wide
+                        %p This register currently has no data. The owner of the register will publish the data once it has been gathered.
+                - else
+                  = render partial: 'record', collection: @records
+        - unless @records.any? || @register.is_empty?
+          .no-search-results
+            %p
+              - if @search_term.present?
+                No results found for <strong>"#{@search_term}"</strong>
+                %script
+                  var searchFilter = document.getElementById('search_records').querySelector('input[type="radio"]:checked').parentElement.querySelector('label').innerText.toLowerCase();
+                  ga('send', 'event', 'Search', 'No results filtered by: ' + searchFilter, '#{@search_term}', {nonInteraction: true});
+              - else
+                No results found.
+                %script
+                  ga('send', 'event', 'Search', 'No results', 'Search term not present');
+              - if @search_term.present? || params[:status].present?
+                = link_to 'Reset', register_path(@register.slug, anchor: 'search_wrapper'), class: 'reset-link'
+    #section{class: 'govuk-!-margin-top-4 govuk-grid-row'}
+      .govuk-grid-column-full
+        %h2{class: "govuk-heading-m"}
+          Feedback
+        = render partial: 'feedback/form'
 
 %dialog#modal_dialog.modal-dialog.dialog{role: "dialog", "aria-hidden" => "true", "aria-labelledby" => "dialog-title"}
   %button{type: 'button', class: 'modal-dialog__close', "aria-label" => "Close dialog"} Close

--- a/app/views/registers/show.html.haml
+++ b/app/views/registers/show.html.haml
@@ -13,7 +13,7 @@
       .govuk-grid-column-two-thirds{class: 'govuk-!-margin-top-2'}
         %h1{class: "govuk-heading-l govuk-!-margin-bottom-1"}
           #{@register.register_name} register
-        %p.govuk-body-l= @register.register_description
+        %p{class: 'govuk-body-l govuk-!-padding-top-2'}= @register.register_description
         %dl.govuk-metadata
           - if @register.authority.present?
             %dt.register-metadata__term Organisation:
@@ -27,7 +27,7 @@
         %p= link_to 'Access the data', register_choose_access_path(@register.slug), {id: 'access-the-data-button', class: 'registers__button--access govuk-!-margin-top-5'}
       .govuk-grid-column-one-third{'aria-hidden': 'true'}
         - if @register.authority.present?
-          %p{class: 'govuk-!-font-weight-bold'} Managed by:
+          %p{class: 'govuk-!-font-weight-bold govuk-!-margin-top-2'} Managed by:
           %div{class: "govuk-organisation-logo #{@register&.authority&.name&.parameterize}"}
             %div{class: "logo-container #{crest_class_name(@register&.authority&.name&.parameterize)}"}
               %span= @register&.authority&.name

--- a/app/views/registers/show.html.haml
+++ b/app/views/registers/show.html.haml
@@ -18,7 +18,7 @@
           - if @register.authority.present?
             %dt.register-metadata__term Organisation:
             %dd.register-metadata__definition= link_to @register&.authority&.name, authority_path(@register.authority.government_organisation_key)
-          - if @register&.category_id&.present? or @register.register_phase != 'Beta'
+          - if @register.show_category_link?
             %dt.register-metadata__term Category:
             %dd.register-metadata__definition= link_to @register.category&.name, category_path(@register.category&.slug)
           - unless @register.is_empty?

--- a/app/views/registers/show.html.haml
+++ b/app/views/registers/show.html.haml
@@ -37,7 +37,6 @@
           About the data
       .govuk-grid-column-two-thirds.subsection__content#about-the-data__1
         %p This register has #{number_with_delimiter(@register_records_total_count)} records and #{@register.register_fields.count} fields
-        -# = page_records_info(@records).inspect
       .govuk-grid-column-one-third.subsection__content#about-the-data__2
         = form_tag register_path(@register.slug, anchor: 'records_wrapper'), method: :get, id: 'search_records', class: 'records-search' do
           = label_tag 'Search', nil, for: 'q', class: 'visually-hidden'
@@ -82,12 +81,10 @@
         - unless @records.any? || @register.is_empty?
           - if @search_term.present?
             %script
-              -# TODO: current and archived no longer present; what goes here as the filter?
-              var searchFilter = 'current'; //
-              ga('send', 'event', 'Search', 'No results filtered by: ' + searchFilter, '#{@search_term}', {nonInteraction: true});
+              ga('send', 'event', 'Search', 'No results', '#{@search_term}', {nonInteraction: true});
           - else
             %script
-              ga('send', 'event', 'Search', 'No results', 'Search term not present');
+              ga('send', 'event', 'Search', 'No results', 'Search term not present', {nonInteraction: true});
     %section.govuk-grid-row{data: { module: 'accordion-with-descriptions'}}
       .govuk-grid-column-full.subsection__header
         %h2.govuk-heading-m.subsection__title

--- a/app/views/registers/show.html.haml
+++ b/app/views/registers/show.html.haml
@@ -36,7 +36,7 @@
         %h2.govuk-heading-m.subsection__title
           About the data
       .govuk-grid-column-two-thirds.subsection__content#about-the-data__1
-        %p This register has #{@register_records_total_count} records and #{@register.register_fields.count} fields
+        %p This register has #{number_with_delimiter(@register_records_total_count)} records and #{@register.register_fields.count} fields
       .govuk-grid-column-one-third.subsection__content#about-the-data__2
         = form_tag register_path(@register.slug, anchor: 'records_wrapper'), method: :get, id: 'search_records', class: 'records-search' do
           = label_tag 'Search', nil, for: 'q', class: 'visually-hidden'

--- a/app/views/registers/show.html.haml
+++ b/app/views/registers/show.html.haml
@@ -23,13 +23,14 @@
           - unless @register.is_empty?
             %dt.register-metadata__term Last updated:
             %dd.register-metadata__definition= link_to formatted_date(@register.register_last_updated), register_entries_path(@register.slug)
-        %p= link_to 'Access the data', register_choose_access_path(@register.slug), { class: 'registers__button--access govuk-!-margin-top-5'}
+        %p= link_to 'Access the data', register_choose_access_path(@register.slug), {id: 'access-the-data-button', class: 'registers__button--access govuk-!-margin-top-5'}
     %section.govuk-grid-row#records_wrapper{ data: { module: 'accordion-with-descriptions'}}
       .govuk-grid-column-full.subsection__header#search_wrapper
         %h2.govuk-heading-m.subsection__title
           About the data
       .govuk-grid-column-two-thirds.subsection__content#about-the-data__1
         %p This register has #{number_with_delimiter(@register_records_total_count)} records and #{@register.register_fields.count} fields
+        -# = page_records_info(@records).inspect
       .govuk-grid-column-one-third.subsection__content#about-the-data__2
         = form_tag register_path(@register.slug, anchor: 'records_wrapper'), method: :get, id: 'search_records', class: 'records-search' do
           = label_tag 'Search', nil, for: 'q', class: 'visually-hidden'
@@ -66,11 +67,11 @@
             .pager-controls.js-hidden
               = paginate @records, outer_window: 0, window: 3
             - unless @records.last_page?
-              %div{data: { "click-events" => true, "click-category" => "Register Table", "click-action" => "Load More" }}
+              %div
                 = link_to_next_page @records, 'Load more', id: 'load-more-records', class: 'js-load-more', remote: true
 
       .govuk-grid-column-full.subsection__content#about-the-data__5
-        %p= link_to 'Access all the data in this register', register_choose_access_path(@register.slug), { class: 'registers__button--access-large'}
+        %p= link_to 'Access all the data in this register', register_choose_access_path(@register.slug), { id: 'access-the-data-from-preview', class: 'registers__button--access-large'}
         - unless @records.any? || @register.is_empty?
           - if @search_term.present?
             %script
@@ -93,3 +94,40 @@
 
 = content_for :head do
   = render partial: 'registers/structured_data', locals: { register: @register }
+
+= content_for :javascript do
+  :javascript
+    var count = 0;
+    document.getElementById('load-more-records')
+      .addEventListener('click', function() {
+        count = count + 1
+        ga('send', {
+          hitType: 'event',
+          eventCategory: 'Register Table',
+          eventAction: 'Load more ' + count,
+          eventLabel: 'Load more',
+          nonInteraction: true
+        })
+      })
+  :javascript
+    document.getElementById('access-the-data-from-preview')
+      .addEventListener('click', function() {
+        ga('send', {
+          hitType: 'event',
+          eventCategory: 'Register Table',
+          eventAction: 'Access the data from preview',
+          eventLabel: 'Access the data',
+          nonInteraction: true
+        })
+      })
+  :javascript
+    document.getElementById('access-the-data-button')
+      .addEventListener('click', function() {
+        ga('send', {
+          hitType: 'event',
+          eventCategory: 'Register Table',
+          eventAction: 'Access the data',
+          eventLabel: 'Access the data',
+          nonInteraction: true
+        })
+      })

--- a/app/views/registers/show.html.haml
+++ b/app/views/registers/show.html.haml
@@ -37,7 +37,8 @@
           = submit_tag 'Search', name: nil, class: 'search-submit'
       .govuk-grid-column-full
         %p
-          = render partial: 'showing'
+          %span#records-count
+            = render partial: 'showing'
           - if @search_term.present?
             = link_to 'Reset', register_path(@register.slug, anchor: 'records_wrapper'), class: 'reset-link'
       .govuk-grid-column-full
@@ -61,22 +62,24 @@
                         %p This register currently has no data. The owner of the register will publish the data once it has been gathered.
                 - else
                   = render partial: 'record', collection: @records
-          .pager.js-hidden
-            .pager-controls
+          .pager
+            .pager-controls.js-hidden
               = paginate @records, outer_window: 0, window: 3
+            - unless @records.last_page?
+              %div{data: { "click-events" => true, "click-category" => "Register Table", "click-action" => "Load More" }}
+                = link_to_next_page @records, 'Load more', id: 'load-more-records', class: 'js-load-more', remote: true
+
       .govuk-grid-column-full
         %p= link_to 'Access all the data in this register', register_choose_access_path(@register.slug), { class: 'registers__button--access-large'}
-
         - unless @records.any? || @register.is_empty?
-          .no-search-results
-            %p
-              - if @search_term.present?
-                %script
-                  var searchFilter = document.getElementById('search_records').querySelector('input[type="radio"]:checked').parentElement.querySelector('label').innerText.toLowerCase();
-                  ga('send', 'event', 'Search', 'No results filtered by: ' + searchFilter, '#{@search_term}', {nonInteraction: true});
-              - else
-                %script
-                  ga('send', 'event', 'Search', 'No results', 'Search term not present');
+          - if @search_term.present?
+            %script
+              -# TODO: current and archived no longer present; what goes here as the filter?
+              var searchFilter = 'current'; //
+              ga('send', 'event', 'Search', 'No results filtered by: ' + searchFilter, '#{@search_term}', {nonInteraction: true});
+          - else
+            %script
+              ga('send', 'event', 'Search', 'No results', 'Search term not present');
     #section{class: 'govuk-!-margin-top-4 govuk-grid-row'}
       .govuk-grid-column-full
         %h2{class: "govuk-heading-m"}
@@ -86,12 +89,6 @@
 %dialog#modal_dialog.modal-dialog.dialog{role: "dialog", "aria-hidden" => "true", "aria-labelledby" => "dialog-title"}
   %button{type: 'button', class: 'modal-dialog__close', "aria-label" => "Close dialog"} Close
   .modal-dialog__inner
-
-= content_for :javascript do
-  :javascript
-    $("input[name='status']").change(function () {
-      $('#search_records').submit();
-    });
 
 = content_for :head do
   = render partial: 'registers/structured_data', locals: { register: @register }

--- a/app/views/registers/show.html.haml
+++ b/app/views/registers/show.html.haml
@@ -36,7 +36,7 @@
         %h2.govuk-heading-m.subsection__title
           About the data
       .govuk-grid-column-two-thirds.subsection__content#about-the-data__1
-        %p This register has #{number_with_delimiter(@register_records_total_count)} records and #{@register.register_fields.count} fields
+        %p This register has #{@register_records_total_count} records and #{@register.register_fields.count} fields
       .govuk-grid-column-one-third.subsection__content#about-the-data__2
         = form_tag register_path(@register.slug, anchor: 'records_wrapper'), method: :get, id: 'search_records', class: 'records-search' do
           = label_tag 'Search', nil, for: 'q', class: 'visually-hidden'
@@ -45,7 +45,9 @@
       .govuk-grid-column-full.subsection__content#about-the-data__3
         %p
           %span#records-count
-            = render partial: 'showing'
+            = page_entries_info(@records)
+            - if @search_term.present?
+              &nbsp;for &ldquo;<strong>#{@search_term}</strong>&rdquo;
           - if @search_term.present?
             = link_to 'Reset', register_path(@register.slug, anchor: 'records_wrapper'), class: 'reset-link'
       .govuk-grid-column-full.subsection__content#about-the-data__4

--- a/app/views/registers/show.html.haml
+++ b/app/views/registers/show.html.haml
@@ -35,14 +35,14 @@
       .govuk-grid-column-full.subsection__header#search_wrapper
         %h2.govuk-heading-m.subsection__title
           About the data
-      .govuk-grid-column-two-thirds.subsection__content#about-the-data__1
+      .govuk-grid-column-two-thirds.subsection__content.js-accordion-subsection#about-the-data__0
         %p This register has #{number_with_delimiter(@register_records_total_count)} records and #{@register.register_fields.count} fields
-      .govuk-grid-column-one-third.subsection__content#about-the-data__2
+      .govuk-grid-column-one-third.subsection__content.js-accordion-subsection#about-the-data__1
         = form_tag register_path(@register.slug, anchor: 'records_wrapper'), method: :get, id: 'search_records', class: 'records-search' do
           = label_tag 'Search', nil, for: 'q', class: 'visually-hidden'
           = search_field_tag 'q', nil, class: 'search-input', placeholder: 'Search', value: @search_term, autocomplete: 'off'
           = submit_tag 'Search', name: nil, class: 'search-submit'
-      .govuk-grid-column-full.subsection__content#about-the-data__3
+      .govuk-grid-column-full.subsection__content.js-accordion-subsection#about-the-data__2
         %p
           %span#records-count{'aria-live': 'polite'}
             = page_entries_info(@records)
@@ -50,7 +50,7 @@
               &nbsp;for &ldquo;<strong>#{@search_term}</strong>&rdquo;
           - if @search_term.present?
             = link_to 'Reset', register_path(@register.slug, anchor: 'records_wrapper'), class: 'reset-link'
-      .govuk-grid-column-full.subsection__content#about-the-data__4
+      .govuk-grid-column-full.subsection__content.js-accordion-subsection#about-the-data__3
         - if @register.is_empty? || @records.any?
           .fullscreen-content{data: {module: 'scrolling-tables'}}
             %table.table.register-data-table
@@ -78,7 +78,7 @@
               %div
                 = link_to_next_page @records, 'Load more', id: 'load-more-records', class: 'js-load-more', remote: true, 'aria-controls': 'records-count'
 
-      .govuk-grid-column-full.subsection__content#about-the-data__5
+      .govuk-grid-column-full.subsection__content.js-accordion-subsection#about-the-data__4
         %p= link_to 'Access all the data in this register', register_choose_access_path(@register.slug), { id: 'access-the-data-from-preview', class: 'registers__button--access-large'}
         - unless @records.any? || @register.is_empty?
           - if @search_term.present?
@@ -91,7 +91,7 @@
       .govuk-grid-column-full.subsection__header
         %h2.govuk-heading-m.subsection__title
           Feedback
-      .govuk-grid-column-full.subsection__content#feedback__1
+      .govuk-grid-column-full.subsection__content.js-accordion-subsection#feedback__0
         = render partial: 'feedback/form'
 
 %dialog#modal_dialog.modal-dialog.dialog{role: "dialog", "aria-hidden" => "true", "aria-labelledby" => "dialog-title"}

--- a/app/views/registers/show.html.haml
+++ b/app/views/registers/show.html.haml
@@ -3,7 +3,7 @@
 - content_for :body_classes, 'register-show'
 
 .govuk-width-container
-  %main#content.govuk-main-wrapper{role:'main'}
+  %main#content.govuk-main-wrapper{role:'main', class: 'govuk-!-padding-top-0'}
     .govuk-grid-row
       .govuk-grid-column-two-thirds
         - if @register.register_phase != 'Beta'
@@ -25,26 +25,22 @@
             %dd.register-metadata__definition= link_to formatted_date(@register.register_last_updated), register_entries_path(@register.slug)
         %p= link_to 'Access the data', register_choose_access_path(@register.slug), { class: 'registers__button--access govuk-!-margin-top-5'}
     .govuk-grid-row#records_wrapper
-      .govuk-grid-column-two-thirds
+      .govuk-grid-column-full
         %h2{class: "govuk-heading-m"}
           About the data
-        %p This register has #{number_with_delimiter(@records.total_count)} records and #{@register.register_fields.count} fields.
+      .govuk-grid-column-two-thirds
+        %p This register has #{number_with_delimiter(@register_records_total_count)} records and #{@register.register_fields.count} fields
       .govuk-grid-column-one-third
-        = form_tag register_path(@register.slug, anchor: 'records_wrapper'), method: :get, id: 'search_records' do
+        = form_tag register_path(@register.slug, anchor: 'records_wrapper'), method: :get, id: 'search_records', class: 'records-search' do
           = label_tag 'Search', nil, for: 'q', class: 'visually-hidden'
           = search_field_tag 'q', nil, class: 'search-input', placeholder: 'Search', value: @search_term, autocomplete: 'off'
           = submit_tag 'Search', name: nil, class: 'search-submit'
       .govuk-grid-column-full
-        %p{class: 'govuk-!-margin-bottom-2'}
-          - unless @search_term.present? || params[:status].present?
-            Showing
-            %strong 1 &ndash; #{@records.count + @records.offset_value}
-            of
-            %strong= @records.total_count
-            records.
-          - if @search_term.present? || params[:status].present?
-            Showing #{@records.count} records for <strong>&ldquo;#{@search_term}&rdquo;</strong>.
+        %p
+          = render partial: 'showing'
+          - if @search_term.present?
             = link_to 'Reset', register_path(@register.slug, anchor: 'records_wrapper'), class: 'reset-link'
+      .govuk-grid-column-full
         - if @register.is_empty? || @records.any?
           .fullscreen-content{data: {module: 'scrolling-tables'}}
             %table.table.register-data-table
@@ -65,20 +61,22 @@
                         %p This register currently has no data. The owner of the register will publish the data once it has been gathered.
                 - else
                   = render partial: 'record', collection: @records
+          .pager.js-hidden
+            .pager-controls
+              = paginate @records, outer_window: 0, window: 3
+      .govuk-grid-column-full
+        %p= link_to 'Access all the data in this register', register_choose_access_path(@register.slug), { class: 'registers__button--access-large'}
+
         - unless @records.any? || @register.is_empty?
           .no-search-results
             %p
               - if @search_term.present?
-                No results found for <strong>"#{@search_term}"</strong>
                 %script
                   var searchFilter = document.getElementById('search_records').querySelector('input[type="radio"]:checked').parentElement.querySelector('label').innerText.toLowerCase();
                   ga('send', 'event', 'Search', 'No results filtered by: ' + searchFilter, '#{@search_term}', {nonInteraction: true});
               - else
-                No results found.
                 %script
                   ga('send', 'event', 'Search', 'No results', 'Search term not present');
-              - if @search_term.present? || params[:status].present?
-                = link_to 'Reset', register_path(@register.slug, anchor: 'search_wrapper'), class: 'reset-link'
     #section{class: 'govuk-!-margin-top-4 govuk-grid-row'}
       .govuk-grid-column-full
         %h2{class: "govuk-heading-m"}

--- a/app/views/registers/show.html.haml
+++ b/app/views/registers/show.html.haml
@@ -19,29 +19,29 @@
             %dd.register-metadata__definition= link_to @register&.authority&.name, authority_path(@register.authority.government_organisation_key)
           - if @register&.category_id&.present? or @register.register_phase != 'Beta'
             %dt.register-metadata__term Category:
-            %dd.register-metadata__definition= link_to @register_category.name, category_path(@register_category.slug)
+            %dd.register-metadata__definition= link_to @register_category&.name, category_path(@register_category&.slug)
           - unless @register.is_empty?
             %dt.register-metadata__term Last updated:
             %dd.register-metadata__definition= link_to formatted_date(@register.register_last_updated), register_entries_path(@register.slug)
         %p= link_to 'Access the data', register_choose_access_path(@register.slug), { class: 'registers__button--access govuk-!-margin-top-5'}
     %section.govuk-grid-row#records_wrapper{ data: { module: 'accordion-with-descriptions'}}
-      .govuk-grid-column-full.subsection__header
+      .govuk-grid-column-full.subsection__header#search_wrapper
         %h2.govuk-heading-m.subsection__title
           About the data
-      .govuk-grid-column-two-thirds.subsection__content
+      .govuk-grid-column-two-thirds.subsection__content#about-the-data__1
         %p This register has #{number_with_delimiter(@register_records_total_count)} records and #{@register.register_fields.count} fields
-      .govuk-grid-column-one-third.subsection__content
+      .govuk-grid-column-one-third.subsection__content#about-the-data__2
         = form_tag register_path(@register.slug, anchor: 'records_wrapper'), method: :get, id: 'search_records', class: 'records-search' do
           = label_tag 'Search', nil, for: 'q', class: 'visually-hidden'
           = search_field_tag 'q', nil, class: 'search-input', placeholder: 'Search', value: @search_term, autocomplete: 'off'
           = submit_tag 'Search', name: nil, class: 'search-submit'
-      .govuk-grid-column-full.subsection__content
+      .govuk-grid-column-full.subsection__content#about-the-data__3
         %p
           %span#records-count
             = render partial: 'showing'
           - if @search_term.present?
             = link_to 'Reset', register_path(@register.slug, anchor: 'records_wrapper'), class: 'reset-link'
-      .govuk-grid-column-full.subsection__content
+      .govuk-grid-column-full.subsection__content#about-the-data__4
         - if @register.is_empty? || @records.any?
           .fullscreen-content{data: {module: 'scrolling-tables'}}
             %table.table.register-data-table
@@ -69,7 +69,7 @@
               %div{data: { "click-events" => true, "click-category" => "Register Table", "click-action" => "Load More" }}
                 = link_to_next_page @records, 'Load more', id: 'load-more-records', class: 'js-load-more', remote: true
 
-      .govuk-grid-column-full.subsection__content
+      .govuk-grid-column-full.subsection__content#about-the-data__5
         %p= link_to 'Access all the data in this register', register_choose_access_path(@register.slug), { class: 'registers__button--access-large'}
         - unless @records.any? || @register.is_empty?
           - if @search_term.present?
@@ -80,11 +80,11 @@
           - else
             %script
               ga('send', 'event', 'Search', 'No results', 'Search term not present');
-    %section{class: 'govuk-!-margin-top-4 govuk-grid-row', data: { module: 'accordion-with-descriptions'}}
+    %section.govuk-grid-row{data: { module: 'accordion-with-descriptions'}}
       .govuk-grid-column-full.subsection__header
         %h2.govuk-heading-m.subsection__title
           Feedback
-      .govuk-grid-column-full.subsection__content
+      .govuk-grid-column-full.subsection__content#feedback__1
         = render partial: 'feedback/form'
 
 %dialog#modal_dialog.modal-dialog.dialog{role: "dialog", "aria-hidden" => "true", "aria-labelledby" => "dialog-title"}

--- a/app/views/registers/show.html.haml
+++ b/app/views/registers/show.html.haml
@@ -20,7 +20,7 @@
             %dd.register-metadata__definition= link_to @register&.authority&.name, authority_path(@register.authority.government_organisation_key)
           - if @register&.category_id&.present? or @register.register_phase != 'Beta'
             %dt.register-metadata__term Category:
-            %dd.register-metadata__definition= link_to @register_category&.name, category_path(@register_category&.slug)
+            %dd.register-metadata__definition= link_to @register.category&.name, category_path(@register.category&.slug)
           - unless @register.is_empty?
             %dt.register-metadata__term Last updated:
             %dd.register-metadata__definition= link_to formatted_date(@register.register_last_updated), register_entries_path(@register.slug)

--- a/app/views/registers/show.html.haml
+++ b/app/views/registers/show.html.haml
@@ -25,7 +25,7 @@
             %dt.register-metadata__term Last updated:
             %dd.register-metadata__definition= link_to formatted_date(@register.register_last_updated), register_entries_path(@register.slug)
         %p= link_to 'Access the data', register_choose_access_path(@register.slug), {id: 'access-the-data-button', class: 'registers__button--access govuk-!-margin-top-5'}
-      .govuk-grid-column-one-third
+      .govuk-grid-column-one-third{'aria-hidden': 'true'}
         - if @register.authority.present?
           %p{class: 'govuk-!-font-weight-bold'} Managed by:
           %div{class: "govuk-organisation-logo #{@register&.authority&.name&.parameterize}"}
@@ -44,7 +44,7 @@
           = submit_tag 'Search', name: nil, class: 'search-submit'
       .govuk-grid-column-full.subsection__content#about-the-data__3
         %p
-          %span#records-count
+          %span#records-count{'aria-live': 'polite'}
             = page_entries_info(@records)
             - if @search_term.present?
               &nbsp;for &ldquo;<strong>#{@search_term}</strong>&rdquo;
@@ -76,7 +76,7 @@
               = paginate @records, outer_window: 0, window: 3
             - unless @records.last_page?
               %div
-                = link_to_next_page @records, 'Load more', id: 'load-more-records', class: 'js-load-more', remote: true
+                = link_to_next_page @records, 'Load more', id: 'load-more-records', class: 'js-load-more', remote: true, 'aria-controls': 'records-count'
 
       .govuk-grid-column-full.subsection__content#about-the-data__5
         %p= link_to 'Access all the data in this register', register_choose_access_path(@register.slug), { id: 'access-the-data-from-preview', class: 'registers__button--access-large'}

--- a/app/views/registers/show.html.haml
+++ b/app/views/registers/show.html.haml
@@ -4,13 +4,14 @@
 
 .govuk-width-container
   %main#content.govuk-main-wrapper{role:'main', class: 'govuk-!-padding-top-0'}
-    .govuk-grid-row
-      .govuk-grid-column-two-thirds
-        - if @register.register_phase != 'Beta'
+    .govuk-grid-row{class: 'govuk-!-margin-top-5'}
+      - if @register.register_phase != 'Beta'
+        .govuk-grid-column-full
           .govuk-inset-text
             %strong.govuk-tag In progress
             %p This data is in progress and it’s not ready for use.
-        %h1{class: "govuk-heading-l govuk-!-margin-top-7 govuk-!-margin-bottom-1"}
+      .govuk-grid-column-two-thirds{class: 'govuk-!-margin-top-2'}
+        %h1{class: "govuk-heading-l govuk-!-margin-bottom-1"}
           #{@register.register_name} register
         %p.govuk-body-l= @register.register_description
         %dl.govuk-metadata
@@ -24,6 +25,12 @@
             %dt.register-metadata__term Last updated:
             %dd.register-metadata__definition= link_to formatted_date(@register.register_last_updated), register_entries_path(@register.slug)
         %p= link_to 'Access the data', register_choose_access_path(@register.slug), {id: 'access-the-data-button', class: 'registers__button--access govuk-!-margin-top-5'}
+      .govuk-grid-column-one-third
+        - if @register.authority.present?
+          %p{class: 'govuk-!-font-weight-bold'} Managed by:
+          %div{class: "govuk-organisation-logo #{@register&.authority&.name&.parameterize}"}
+            %div{class: "logo-container #{crest_class_name(@register&.authority&.name&.parameterize)}"}
+              %span= @register&.authority&.name
     %section.govuk-grid-row#records_wrapper{ data: { module: 'accordion-with-descriptions'}}
       .govuk-grid-column-full.subsection__header#search_wrapper
         %h2.govuk-heading-m.subsection__title
@@ -97,6 +104,17 @@
 
 = content_for :javascript do
   :javascript
+    document.getElementById('access-the-data-button')
+      .addEventListener('click', function() {
+        ga('send', {
+          hitType: 'event',
+          eventCategory: 'Preview the data',
+          eventAction: 'Access the data',
+          eventLabel: 'Access the data',
+          nonInteraction: true
+        })
+      })
+  :javascript
     var count = 0;
     document.getElementById('load-more-records')
       .addEventListener('click', function() {
@@ -116,17 +134,6 @@
           hitType: 'event',
           eventCategory: 'Register Table',
           eventAction: 'Access the data from preview',
-          eventLabel: 'Access the data',
-          nonInteraction: true
-        })
-      })
-  :javascript
-    document.getElementById('access-the-data-button')
-      .addEventListener('click', function() {
-        ga('send', {
-          hitType: 'event',
-          eventCategory: 'Register Table',
-          eventAction: 'Access the data',
           eventLabel: 'Access the data',
           nonInteraction: true
         })

--- a/app/views/registers/show.html.haml
+++ b/app/views/registers/show.html.haml
@@ -24,24 +24,24 @@
             %dt.register-metadata__term Last updated:
             %dd.register-metadata__definition= link_to formatted_date(@register.register_last_updated), register_entries_path(@register.slug)
         %p= link_to 'Access the data', register_choose_access_path(@register.slug), { class: 'registers__button--access govuk-!-margin-top-5'}
-    .govuk-grid-row#records_wrapper
-      .govuk-grid-column-full
-        %h2{class: "govuk-heading-m"}
+    %section.govuk-grid-row#records_wrapper{ data: { module: 'accordion-with-descriptions'}}
+      .govuk-grid-column-full.subsection__header
+        %h2.govuk-heading-m.subsection__title
           About the data
-      .govuk-grid-column-two-thirds
+      .govuk-grid-column-two-thirds.subsection__content
         %p This register has #{number_with_delimiter(@register_records_total_count)} records and #{@register.register_fields.count} fields
-      .govuk-grid-column-one-third
+      .govuk-grid-column-one-third.subsection__content
         = form_tag register_path(@register.slug, anchor: 'records_wrapper'), method: :get, id: 'search_records', class: 'records-search' do
           = label_tag 'Search', nil, for: 'q', class: 'visually-hidden'
           = search_field_tag 'q', nil, class: 'search-input', placeholder: 'Search', value: @search_term, autocomplete: 'off'
           = submit_tag 'Search', name: nil, class: 'search-submit'
-      .govuk-grid-column-full
+      .govuk-grid-column-full.subsection__content
         %p
           %span#records-count
             = render partial: 'showing'
           - if @search_term.present?
             = link_to 'Reset', register_path(@register.slug, anchor: 'records_wrapper'), class: 'reset-link'
-      .govuk-grid-column-full
+      .govuk-grid-column-full.subsection__content
         - if @register.is_empty? || @records.any?
           .fullscreen-content{data: {module: 'scrolling-tables'}}
             %table.table.register-data-table
@@ -69,7 +69,7 @@
               %div{data: { "click-events" => true, "click-category" => "Register Table", "click-action" => "Load More" }}
                 = link_to_next_page @records, 'Load more', id: 'load-more-records', class: 'js-load-more', remote: true
 
-      .govuk-grid-column-full
+      .govuk-grid-column-full.subsection__content
         %p= link_to 'Access all the data in this register', register_choose_access_path(@register.slug), { class: 'registers__button--access-large'}
         - unless @records.any? || @register.is_empty?
           - if @search_term.present?
@@ -80,10 +80,11 @@
           - else
             %script
               ga('send', 'event', 'Search', 'No results', 'Search term not present');
-    #section{class: 'govuk-!-margin-top-4 govuk-grid-row'}
-      .govuk-grid-column-full
-        %h2{class: "govuk-heading-m"}
+    %section{class: 'govuk-!-margin-top-4 govuk-grid-row', data: { module: 'accordion-with-descriptions'}}
+      .govuk-grid-column-full.subsection__header
+        %h2.govuk-heading-m.subsection__title
           Feedback
+      .govuk-grid-column-full.subsection__content
         = render partial: 'feedback/form'
 
 %dialog#modal_dialog.modal-dialog.dialog{role: "dialog", "aria-hidden" => "true", "aria-labelledby" => "dialog-title"}

--- a/app/views/registers/show.html.haml
+++ b/app/views/registers/show.html.haml
@@ -16,7 +16,7 @@
         %dl.govuk-metadata
           - if @register.authority.present?
             %dt.register-metadata__term Organisation:
-            %dd.register-metadata__definition= @register&.authority&.name
+            %dd.register-metadata__definition= link_to @register&.authority&.name, authority_path(@register.authority.government_organisation_key)
           - if @register&.category_id&.present? or @register.register_phase != 'Beta'
             %dt.register-metadata__term Category:
             %dd.register-metadata__definition= link_to @register_category.name, category_path(@register_category.slug)

--- a/app/views/registers/show.js.erb
+++ b/app/views/registers/show.js.erb
@@ -1,8 +1,11 @@
-$("#records-tbody").append("<%= j(render(partial: 'record', collection: @records)) %>");
-$("#records-count").html('Showing <strong>1 &ndash; <%= @records.count + @records.offset_value %></strong> of <strong><%= @records.total_count %></strong> records <% if @search_term.present? %>for <strong>"<%= search_term %>"</strong><% end %>')
+document.getElementById('records-tbody').innerHTML += "<%= j(render(partial: 'record', collection: @records)) %>";
+
+document.getElementById('records-count').innerHTML = 'Showing <strong>1 &ndash; <%= @records.count + @records.offset_value %></strong> of <strong><%= @records.total_count %></strong> records <% if @search_term.present? %>for &ldquo;<strong><%= @search_term %></strong>&rdquo;<% end %>';
 
 <% if @records.last_page? %>
-  $("#load-more-records").hide();
+  var lmr = document.getElementById('load-more-records');
+  lmr.parentElement.removeChild(lmr);
 <% else %>
-  $("#load-more-records").replaceWith("<%= escape_javascript(link_to_next_page @records, 'Load more', id: 'load-more-records', class: 'js-load-more', remote: true) %>");
+  var markup = "<%= escape_javascript(link_to_next_page @records, 'Load more', id: 'load-more-records', class: 'js-load-more', remote: true) %>";
+  document.getElementById('load-more-records').parentElement.innerHTML = markup;
 <% end %>

--- a/app/views/registers/show.js.erb
+++ b/app/views/registers/show.js.erb
@@ -1,6 +1,6 @@
 document.getElementById('records-tbody').innerHTML += "<%= j(render(partial: 'record', collection: @records)) %>";
 
-document.getElementById('records-count').innerHTML = 'Showing <strong>1 &ndash; <%= @records.count + @records.offset_value %></strong> of <strong><%= @records.total_count %></strong> records <% if @search_term.present? %>for &ldquo;<strong><%= @search_term %></strong>&rdquo;<% end %>';
+document.getElementById('records-count').innerHTML = 'Showing <strong>1 &ndash; <%= @records.count + @records.offset_value %></strong> of <strong><%= number_with_delimiter(@records.total_count) %></strong> records <% if @search_term.present? %>for &ldquo;<strong><%= @search_term %></strong>&rdquo;<% end %>';
 
 <% if @records.last_page? %>
   var lmr = document.getElementById('load-more-records');

--- a/app/views/registers/show.js.erb
+++ b/app/views/registers/show.js.erb
@@ -6,6 +6,5 @@ document.getElementById('records-count').innerHTML = 'Showing <strong>1 &ndash; 
   var lmr = document.getElementById('load-more-records');
   lmr.parentElement.removeChild(lmr);
 <% else %>
-  var markup = "<%= escape_javascript(link_to_next_page @records, 'Load more', id: 'load-more-records', class: 'js-load-more', remote: true) %>";
-  document.getElementById('load-more-records').parentElement.innerHTML = markup;
+  document.getElementById('load-more-records').href = "<%= escape_javascript(path_to_next_page @records) %>"
 <% end %>

--- a/app/views/registers/show.js.erb
+++ b/app/views/registers/show.js.erb
@@ -1,6 +1,6 @@
 document.getElementById('records-tbody').innerHTML += "<%= j(render(partial: 'record', collection: @records)) %>";
 
-document.getElementById('records-count').innerHTML = 'Showing <strong>1 &ndash; <%= @records.count + @records.offset_value %></strong> of <strong><%= number_with_delimiter(@records.total_count) %></strong> records <% if @search_term.present? %>for &ldquo;<strong><%= @search_term %></strong>&rdquo;<% end %>';
+document.getElementById('records-count').innerHTML = 'Showing <strong>1 <span aria-hidden="true">&ndash;</span><span class="visually-hidden">to</span> <%= @records.count + @records.offset_value %></strong> of <strong><%= number_with_delimiter(@records.total_count) %></strong> records <% if @search_term.present? %>for &ldquo;<strong><%= @search_term %></strong>&rdquo;<% end %>';
 
 <% if @records.last_page? %>
   var lmr = document.getElementById('load-more-records');

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -32,7 +32,7 @@ en:
           one: "Showing <b>1</b> %{entry_name}"
           other: "Showing <b>%{count}</b> %{entry_name}"
       more_pages:
-        display_entries: "Showing <b>%{first}&nbsp;-&nbsp;%{last}</b> of <b>%{total}</b> %{entry_name}"
+        display_entries: "Showing <b>%{first}&ndash;%{last}</b> of <b>%{total}</b> %{entry_name}"
     label:
       sign_up_user:
         email: Email address

--- a/package.json
+++ b/package.json
@@ -18,8 +18,5 @@
   "private": true,
   "dependencies": {
     "govuk-frontend": "1.2.0"
-  },
-  "devDependencies": {
-    "standard": "^11.0.1"
   }
 }

--- a/spec/controllers/registers_controller_spec.rb
+++ b/spec/controllers/registers_controller_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe RegistersController, type: :controller do
     it { expect { subject }.to_not change(Register, :count) }
   end
 
-  describe 'Request: GET #show. Descr: Check default behaviour. Params: --. Result: 100 rows' do
+  describe 'Request: GET #show. Descr: Check default behaviour. Params: --. Result: 10 rows' do
     subject { get :show, params: { id: 'country' } }
 
     it { is_expected.to be_successful }
@@ -100,7 +100,7 @@ RSpec.describe RegistersController, type: :controller do
 
     it do
       subject
-      expect(assigns(:records).length).to eq(100)
+      expect(assigns(:records).length).to eq(10)
     end
   end
 
@@ -188,7 +188,7 @@ RSpec.describe RegistersController, type: :controller do
     end
   end
 
-  describe 'Request: GET #show. Descr: Sort by start date descending where some values are nil should show nil values last' do
+  describe "Request: GET #show. Descr: Sort by start date descending should show The Republic of South Sudan's start date" do
     subject { get :show, params: { id: 'country', sort_by: 'start-date', sort_direction: 'desc' } }
 
     it { is_expected.to be_successful }
@@ -198,6 +198,18 @@ RSpec.describe RegistersController, type: :controller do
     it do
       subject
       expect(assigns(:records).first.data['start-date']).to eq('2011-07-09')
+    end
+  end
+
+  describe "Request: GET #show. Descr: Sort by start date descending should show nil as the last record" do
+    subject { get :show, params: { id: 'country', sort_by: 'start-date', sort_direction: 'desc', page: 20 } }
+
+    it { is_expected.to be_successful }
+
+    it { is_expected.to render_template :show }
+
+    it do
+      subject
       expect(assigns(:records).last.data['start-date']).to be_nil
     end
   end

--- a/spec/features/view_register_spec.rb
+++ b/spec/features/view_register_spec.rb
@@ -66,14 +66,6 @@ RSpec.feature 'View register', type: :feature do
     expect(page).to have_content('Zimbabwe')
   end
 
-  scenario 'filter a register' do
-    visit('/registers/country')
-    choose('Archived records')
-    click_button('Search', match: :first)
-    expect(page).to have_current_path(/status=archived/)
-    expect(page).to have_content('USSR')
-  end
-
   scenario 'view updates' do
     visit('/registers/country/updates')
     first_update = find('h3', match: :first)

--- a/spec/features/view_register_spec.rb
+++ b/spec/features/view_register_spec.rb
@@ -74,12 +74,12 @@ RSpec.feature 'View register', type: :feature do
     expect(first_update.sibling('table')).to have_content("The Republic of Cote D'Ivoire")
   end
 
-  # scenario 'view register name' do
-  #   visit('/registers/industrial-classification-2003')
-  #   register_name = 'UK Standard Industrial Classification of Economic Activities 2003 register'
-  #   expect(find('h1')).to have_content(register_name)
-  #   expect(page.title).to have_content(register_name)
-  # end
+  scenario 'view register name' do
+    visit('/registers/industrial-classification-2003')
+    register_name = 'UK Standard Industrial Classification of Economic Activities 2003 register'
+    expect(find('h1')).to have_content(register_name)
+    expect(page.title).to have_content(register_name)
+  end
 
   after(:all) do
     DatabaseCleaner.clean_with(:truncation)

--- a/spec/features/view_register_spec.rb
+++ b/spec/features/view_register_spec.rb
@@ -74,12 +74,12 @@ RSpec.feature 'View register', type: :feature do
     expect(first_update.sibling('table')).to have_content("The Republic of Cote D'Ivoire")
   end
 
-  scenario 'view register name' do
-    visit('/registers/industrial-classification-2003')
-    register_name = 'UK Standard Industrial Classification of Economic Activities 2003 register'
-    expect(find('h1')).to have_content(register_name)
-    expect(page.title).to have_content(register_name)
-  end
+  # scenario 'view register name' do
+  #   visit('/registers/industrial-classification-2003')
+  #   register_name = 'UK Standard Industrial Classification of Economic Activities 2003 register'
+  #   expect(find('h1')).to have_content(register_name)
+  #   expect(page.title).to have_content(register_name)
+  # end
 
   after(:all) do
     DatabaseCleaner.clean_with(:truncation)


### PR DESCRIPTION
### Context
This updates the individual register page layout to meet the [requirements in the ticket](https://trello.com/c/Hf68Vi4C/95-implement-mvp-design-of-preview-the-data).

### Changes proposed in this pull request
 * Register show template partially updated and now uses Design System (both JavaScript and non-JavaScript versions)
 * Limits the number of records displayed to 10; paginated with no-JS, loads 10 more at a time with JS.
 * Records model updated to remove archived and current filter
 * Event tracking added

### Guidance to review
 * The accordion is a tweaked version of the old accordion; the reason this hasn't moved across to the new Design System is that there isn't an accordion in it...[yet](https://github.com/alphagov/govuk-frontend/pull/958).