### PR TITLE
Questionnaire cookie duration change.

### DIFF
--- a/app/controllers/download_controller.rb
+++ b/app/controllers/download_controller.rb
@@ -17,7 +17,7 @@ class DownloadController < ApplicationController
     unless cookies[:seen_help_us_improve_questions]
       cookies[:seen_help_us_improve_questions] = {
         value: true,
-        expires: 2.weeks.from_now
+        expires: 2.days.from_now
       }
     end
     render :index
@@ -55,7 +55,7 @@ class DownloadController < ApplicationController
     unless cookies[:seen_help_us_improve_questions]
       cookies[:seen_help_us_improve_questions] = {
         value: true,
-        expires: 2.weeks.from_now
+        expires: 2.days.from_now
       }
     end
   end

--- a/app/controllers/download_controller.rb
+++ b/app/controllers/download_controller.rb
@@ -17,7 +17,7 @@ class DownloadController < ApplicationController
     unless cookies[:seen_help_us_improve_questions]
       cookies[:seen_help_us_improve_questions] = {
         value: true,
-        expires: 2.days.from_now
+        expires: 24.hours.from_now
       }
     end
     render :index
@@ -55,7 +55,7 @@ class DownloadController < ApplicationController
     unless cookies[:seen_help_us_improve_questions]
       cookies[:seen_help_us_improve_questions] = {
         value: true,
-        expires: 2.days.from_now
+        expires: 24.hours.from_now
       }
     end
   end

--- a/app/views/pages/cookies.html.haml
+++ b/app/views/pages/cookies.html.haml
@@ -93,4 +93,4 @@
           %tr
             %th{:width => "33%"} seen_help_us_improve_questions
             %td Saves a message to let us know that you’ve seen these questions
-            %td{:width => "16%"} 2 days
+            %td{:width => "16%"} 1 day

--- a/app/views/pages/cookies.html.haml
+++ b/app/views/pages/cookies.html.haml
@@ -93,4 +93,4 @@
           %tr
             %th{:width => "33%"} seen_help_us_improve_questions
             %td Saves a message to let us know that you’ve seen these questions
-            %td{:width => "16%"} 2 weeks
+            %td{:width => "16%"} 2 days


### PR DESCRIPTION
### Context
The 'Help us improve Registers' questionnaire is hidden when a user returns to the website within two weeks. This length of time needs to be reduced to two days.

### Changes proposed in this pull request
 * Cookie now set to expire in twenty-four hours.
 * Cookie page updated to reflect this.

### Guidance to review
None.