### PR TITLE
Removes table sorting

### DIFF
--- a/app/assets/stylesheets/modules/_sorting-link.scss
+++ b/app/assets/stylesheets/modules/_sorting-link.scss
@@ -1,21 +1,12 @@
-%sort-arrow {
-  border-left: 5px solid transparent;
-  border-right: 5px solid transparent;
-  content: "";
-  display: block;
-  margin-left: 5px;
-  position: absolute;
-  right: 0;
-}
-
-.sort-link-th {
+.table-header {
   &.active {
     background-color: $govuk-blue;
     color: $white;
+    font-weight: bold;
     margin: -15px -55px -15px -15px;
     padding: 15px 55px 15px 15px;
 
-    + .info-icon {
+    .info-icon {
       background: $white;
       color: $govuk-blue;
 
@@ -24,55 +15,5 @@
         color: $govuk-blue;
       }
     }
-  }
-}
-
-.sort-link {
-  font-weight: normal;
-  padding-right: 15px;
-  position: relative;
-  text-decoration: none;
-
-  .active & {
-    color: $white;
-    font-weight: bold;
-  }
-
-  &:focus,
-  &:hover {
-    text-decoration: underline;
-  }
-
-  // small top arrow
-  &:before {
-    @extend %sort-arrow;
-    border-bottom: 5px solid $govuk-blue;
-    top: 4px;
-  }
-
-  // remove small top arrow when 'active'
-  &.asc:before,
-  &.desc:before {
-    content: none;
-  }
-
-  // small bottom arrow
-  &:after {
-    @extend %sort-arrow;
-    border-top: 5px solid $govuk-blue;
-    top: 11px;
-  }
-
-  // large active arrows
-  &.asc:after {
-    border-bottom: 8px solid $white;
-    border-top: 0;
-    top: 7px;
-  }
-
-  &.desc:after {
-    border-bottom: 0;
-    border-top: 8px solid $white;
-    top: 7px;
   }
 }

--- a/app/controllers/registers_controller.rb
+++ b/app/controllers/registers_controller.rb
@@ -88,12 +88,11 @@ private
     }
 
     sort_by = params[:sort_by] ||= default_sort_by.call
-    sort_direction = params[:sort_direction] ||= 'asc'
 
     @register.records
              .where(entry_type: 'user')
              .search_for(fields, search_term)
-             .sort_by_field(sort_by, sort_direction)
+             .sort_by_field(sort_by, 'asc')
              .page(params[:page])
              .per(10)
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -43,18 +43,13 @@ module ApplicationHelper
     Date.parse(date).strftime('%d/%m/%Y')
   end
 
-  def records_table_sort_link(field_value, query_parameters)
-    direction = params[:sort_direction] == 'asc' && params[:sort_by] == field_value ? 'desc' : 'asc'
-    css_class = params[:sort_by] == field_value ? "sort-link #{params[:sort_direction]}" : "sort-link"
-    wrapper_css_class = params[:sort_by] == field_value ? 'sort-link-th active' : 'sort-link-th'
+  def records_table_header(field_value)
+    wrapper_css_class = params[:sort_by] == field_value ? 'table-header active' : 'table-header'
+    what_does_this_mean = content_tag('span', "What does #{field_value} mean", class: 'visually-hidden') + '?'
 
-    content_tag 'div', class: wrapper_css_class do
-      link_to field_value.tr('-', ' ').humanize, register_path(@register.slug,
-                                                 query_parameters.except(:sort_by, :sort_direction)
-                                                 .to_h.merge(sort_direction: direction,
-                                                 sort_by: field_value,
-                                                 anchor: 'search_wrapper')),
-                                                 class: css_class
+    content_tag 'th', class: "#{field_value} #{wrapper_css_class}" do
+      content_tag('span', field_value.tr('-', ' ').humanize) +
+        link_to(what_does_this_mean, register_field_url(@register.slug, field_value), class: 'info-icon', remote: true, data: { "click-events" => true, "click-category" => "Register Table", "click-action" => "Help" })
     end
   end
 end

--- a/app/views/registers/show.html.haml
+++ b/app/views/registers/show.html.haml
@@ -57,12 +57,7 @@
               %thead
                 %tr
                   - @register.register_fields.each do |field|
-                    %th{class: "#{field['field']}"}
-                      = field['cardinality'] == '1' ? records_table_sort_link(field['field'], request.query_parameters) : field['field'].tr('-', ' ').humanize
-                      = link_to register_field_url(@register.slug, field['field']), class: 'info-icon', remote: true, data: {"click-events" => true, "click-category" => "Register Table", "click-action" => "Help"} do
-                        %span.visually-hidden
-                          What does #{field['field']} mean
-                        ?
+                    = records_table_header(field['field'])
               %tbody#records-tbody
                 - if @register.is_empty?
                   %tr

--- a/spec/controllers/registers_controller_spec.rb
+++ b/spec/controllers/registers_controller_spec.rb
@@ -160,8 +160,8 @@ RSpec.describe RegistersController, type: :controller do
     end
   end
 
-  describe 'Request: GET #show. Descr: Sort by Name ascending. Result: Afghanistan is first result' do
-    subject { get :show, params: { id: 'country', sort_by: 'name', sort_direction: 'asc' } }
+  describe 'Request: GET #show. Descr: Afghanistan is first result' do
+    subject { get :show, params: { id: 'country' } }
 
     it { is_expected.to be_successful }
 
@@ -171,46 +171,6 @@ RSpec.describe RegistersController, type: :controller do
       subject
 
       expect(assigns(:records).first.data['name']).to eq('Afghanistan')
-    end
-  end
-
-  describe 'Request: GET #show. Descr: Sort by name descending. Result: Zimbabwe is first result' do
-    subject { get :show, params: { id: 'country', sort_by: 'name', sort_direction: 'desc' } }
-
-    it { is_expected.to be_successful }
-
-    it { is_expected.to render_template :show }
-
-    it do
-      subject
-
-      expect(assigns(:records).first.data['name']).to eq('Zimbabwe')
-    end
-  end
-
-  describe "Request: GET #show. Descr: Sort by start date descending should show The Republic of South Sudan's start date" do
-    subject { get :show, params: { id: 'country', sort_by: 'start-date', sort_direction: 'desc' } }
-
-    it { is_expected.to be_successful }
-
-    it { is_expected.to render_template :show }
-
-    it do
-      subject
-      expect(assigns(:records).first.data['start-date']).to eq('2011-07-09')
-    end
-  end
-
-  describe "Request: GET #show. Descr: Sort by start date descending should show nil as the last record" do
-    subject { get :show, params: { id: 'country', sort_by: 'start-date', sort_direction: 'desc', page: 20 } }
-
-    it { is_expected.to be_successful }
-
-    it { is_expected.to render_template :show }
-
-    it do
-      subject
-      expect(assigns(:records).last.data['start-date']).to be_nil
     end
   end
 

--- a/spec/features/view_register_spec.rb
+++ b/spec/features/view_register_spec.rb
@@ -59,11 +59,12 @@ RSpec.feature 'View register', type: :feature do
     expect(page).to have_content('Country')
   end
 
-  scenario 'view and sort a register' do
+  scenario 'view a register' do
     visit('/registers/country')
+    first_row_item = find('#records-tbody tr td', match: :first)
+    expect(first_row_item).to have_content("AF")
     expect(page).to have_content('Country register')
-    click_link('Name')
-    expect(page).to have_content('Zimbabwe')
+    expect(page).to have_content('Afghanistan')
   end
 
   scenario 'view updates' do


### PR DESCRIPTION
### Context
Removes the front-end functionality that allows each table to be sorted by the column; defaults to 'Name', then the first column.

### Changes proposed in this pull request
* Moves the logic and the elements into the helper to avoid logic in the templates
* Style changes to account for the change in markup.

### Guidance to review
None.