### PR TITLE
Ensures all questions are answered before submitting.

### DIFF
--- a/app/views/download/_form--help-us-improve.html.haml
+++ b/app/views/download/_form--help-us-improve.html.haml
@@ -54,9 +54,18 @@
 
 = content_for :javascript do
   :javascript
-    accessibleAutocomplete.enhanceSelectElement({
-      selectElement: document.getElementById('government-organisations'),
-      showAllValues: false,
-      minLength: 2,
-      defaultValue: ''
-    });
+    if (typeof accessibleAutocomplete === 'undefined') {
+      var hidden = document.querySelectorAll('.govuk-radios__conditional--hidden')
+
+      for (var i = 0; i < hidden.length; i++) {
+        hidden[i].className = hidden[i].className.replace(/(| )govuk-radios__conditional--hidden/g, '')
+      }
+    }
+    else {
+      accessibleAutocomplete.enhanceSelectElement({
+        selectElement: document.getElementById('government-organisations'),
+        showAllValues: false,
+        minLength: 2,
+        defaultValue: ''
+      });
+    }

--- a/app/views/download/_form--help-us-improve.html.haml
+++ b/app/views/download/_form--help-us-improve.html.haml
@@ -1,40 +1,40 @@
-= form_tag(@next_page, { class: "js--ga-submit" }) do |f|
-  %div{ :class => "govuk-form-group access-to-data govuk-!-padding-bottom-2" }
+= form_tag(@next_page, { class: 'js--ga-submit', name: 'help-us-improve' }) do |f|
+
+  %div{ class: 'govuk-form-group js--is-government-group access-to-data govuk-!-padding-bottom-2' }
     %fieldset
-      %legend{ class: "heading-medium govuk-!-margin-bottom-2"} Do you work for the government?
-      .govuk-radios{ "data-module" => "radios" }
+      %legend{ class: 'heading-medium govuk-!-margin-bottom-2' } Do you work for the government?
+      %p.js--is-government-message#do-you-work-for-the-government
+      .govuk-radios{ data: { module: 'radios' }}
         .govuk-radios__item
-          = radio_button_tag("help_us_improve_user[is_government]", "Yes", false, class: "govuk-radios__input", id: "is-government-conditional-1", "data-aria-controls": "conditional-is-government-conditional-1" )
-          = label_tag("is-government-conditional-1", 'Yes', class: "govuk-label govuk-radios__label")
+          = radio_button_tag('help_us_improve_user[is_government]', 'Yes', false, class: 'govuk-radios__input', id: 'is-government-conditional-1', data: { 'aria-controls': 'conditional-is-government-conditional-1' })
+          = label_tag('is-government-conditional-1', 'Yes', class: 'govuk-label govuk-radios__label')
         #conditional-is-government-conditional-1.govuk-radios__conditional.govuk-radios__conditional--hidden
-          %div{ :class => "govuk-form-group govuk-!-padding-bottom-6 govuk-!-padding-top-2" }
-            %label{ :for => "gov-what-part-of-government", :class => "govuk-label govuk-!-padding-bottom-1"}
+          %div{ class: 'govuk-form-group govuk-!-padding-bottom-6 govuk-!-padding-top-2 js--which-part-of-government-group' }
+            %label{ class: 'govuk-label govuk-!-padding-bottom-1', for: 'government-organisations' }
               What part of government are you working for?
-              %span{ :class => "registers-!-faded-colour"}
-                (optional)
+            %p.js--which-part-of-government-message#which-part-of-government
             = select 'help_us_improve_user', 'gov_what_part_of_government', @government_organisations.all.collect{ |org| [org.data['name'], org.key] }, { include_blank: true }, id: 'government-organisations'
-          %div{ :class => "govuk-form-group govuk-!-padding-bottom-3" }
-            %label{ :for => "help_us_improve_user[gov_what_are_you_using_registers_for]", :class => "govuk-label govuk-!-padding-bottom-1"}
+          %div{ class: 'govuk-form-group govuk-!-padding-bottom-3 js--gov-registers-use-group' }
+            %legend{ class: 'govuk-label govuk-!-padding-bottom-1'}
               What are you using registers for?
-              %span{ :class => "registers-!-faded-colour"}
-                (optional)
+            %p.js--gov-registers-use-message#gov-registers-use
             .govuk-radios__item
-              = radio_button_tag("help_us_improve_user[gov_what_are_you_using_registers_for]", "Building a service", false, class: "govuk-radios__input", id: "gov-building-a-service")
-              = label_tag("gov-building-a-service", 'Building a service', class: "govuk-label govuk-radios__label")
+              = radio_button_tag('help_us_improve_user[gov_what_are_you_using_registers_for]', 'Building a service', false, class: 'govuk-radios__input', id: 'gov-building-a-service')
+              = label_tag('gov-building-a-service', 'Building a service', class: 'govuk-label govuk-radios__label')
             .govuk-radios__item
-              = radio_button_tag("help_us_improve_user[gov_what_are_you_using_registers_for]", "For data analysis or reporting", false, class: "govuk-radios__input", id: "gov-for-data-analysis-or-reporting")
-              = label_tag("gov-for-data-analysis-or-reporting", 'For data analysis or reporting', class: "govuk-label govuk-radios__label")
+              = radio_button_tag('help_us_improve_user[gov_what_are_you_using_registers_for]', 'For data analysis or reporting', false, class: 'govuk-radios__input', id: 'gov-for-data-analysis-or-reporting')
+              = label_tag('gov-for-data-analysis-or-reporting', 'For data analysis or reporting', class: 'govuk-label govuk-radios__label')
             .govuk-radios__item
-              = radio_button_tag("help_us_improve_user[gov_what_are_you_using_registers_for]", "Other", false, class: "govuk-radios__input", id: "gov-other")
-              = label_tag("gov-other", 'Other', class: "govuk-label govuk-radios__label")
+              = radio_button_tag('help_us_improve_user[gov_what_are_you_using_registers_for]', 'Other', false, class: 'govuk-radios__input', id: 'gov-other')
+              = label_tag('gov-other', 'Other', class: 'govuk-label govuk-radios__label')
         .govuk-radios__item
           = radio_button_tag("help_us_improve_user[is_government]", "No", false, class: "govuk-radios__input", id: "is-government-conditional-2", "data-aria-controls": "conditional-is-government-conditional-2" )
           = label_tag("is-government-conditional-2", 'No', class: "govuk-label govuk-radios__label")
         #conditional-is-government-conditional-2.govuk-radios__conditional.govuk-radios__conditional--hidden
-          %div{ :class => "govuk-form-group govuk-!-padding-bottom-3 govuk-!-padding-top-3" }
-            %label{ :for => "what-are-you-using-registers-for", :class => "govuk-label govuk-!-padding-bottom-1"}
+          %div{ class: 'govuk-form-group govuk-!-padding-bottom-3 govuk-!-padding-top-3 js--nongov-registers-use-group' }
+            %label{ for: 'what-are-you-using-registers-for', class: 'govuk-label govuk-!-padding-bottom-1'}
               What are you using registers for?
-              %span{ :class => "registers-!-faded-colour"} (optional)
+            %p.js--nongov-registers-use-message#nongov-registers-use
             .govuk-radios__item
               = radio_button_tag("help_us_improve_user[nongov_what_are_you_using_registers_for]", "Commercial use", false, class: "govuk-radios__input", id: "commercial-use")
               = label_tag("commercial-use", 'Commercial use', class: "govuk-label govuk-radios__label")
@@ -48,7 +48,7 @@
               = radio_button_tag("help_us_improve_user[nongov_what_are_you_using_registers_for]", "Other", false, class: "govuk-radios__input", id: "other")
               = label_tag("other", 'Other', class: "govuk-label govuk-radios__label")
   %div{ class: "govuk-form-group access-to-data__submit-group"}
-    = submit_tag("Submit", class: "button")
+    %button{type: 'submit', class: 'govuk-button'} Submit
     %span or
     = link_to "I'd prefer not to say", @next_page, { class: 'js--ga-watch-click' }
 

--- a/app/views/download/_form--help-us-improve.html.haml
+++ b/app/views/download/_form--help-us-improve.html.haml
@@ -2,20 +2,20 @@
 
   %div{ class: 'govuk-form-group js--is-government-group access-to-data govuk-!-padding-bottom-2' }
     %fieldset
-      %legend{ class: 'heading-medium govuk-!-margin-bottom-2' } Do you work for the government?
+      %legend{ class: 'heading-medium govuk-!-margin-bottom-2 govuk-!-margin-top-3' } Do you work for the government?
       %p.js--is-government-message#do-you-work-for-the-government
       .govuk-radios{ data: { module: 'radios' }}
         .govuk-radios__item
           = radio_button_tag('help_us_improve_user[is_government]', 'Yes', false, class: 'govuk-radios__input', id: 'is-government-conditional-1', data: { 'aria-controls': 'conditional-is-government-conditional-1' })
           = label_tag('is-government-conditional-1', 'Yes', class: 'govuk-label govuk-radios__label')
         #conditional-is-government-conditional-1.govuk-radios__conditional.govuk-radios__conditional--hidden
-          %div{ class: 'govuk-form-group govuk-!-padding-bottom-6 govuk-!-padding-top-2 js--which-part-of-government-group' }
-            %label{ class: 'govuk-label govuk-!-padding-bottom-1', for: 'government-organisations' }
+          %div{ class: 'govuk-form-group govuk-!-padding-bottom-4 govuk-!-padding-top-2 js--which-part-of-government-group' }
+            %label{ class: 'govuk-label govuk-!-padding-bottom-1 govuk-!-font-weight-bold', for: 'government-organisations' }
               What part of government are you working for?
             %p.js--which-part-of-government-message#which-part-of-government
             = select 'help_us_improve_user', 'gov_what_part_of_government', @government_organisations.all.collect{ |org| [org.data['name'], org.key] }, { include_blank: true }, id: 'government-organisations'
-          %div{ class: 'govuk-form-group govuk-!-padding-bottom-3 js--gov-registers-use-group' }
-            %legend{ class: 'govuk-label govuk-!-padding-bottom-1'}
+          %div{ class: 'govuk-form-group govuk-!-padding-bottom-3 govuk-!-padding-top-2  js--gov-registers-use-group' }
+            %legend{ class: 'govuk-label govuk-!-padding-bottom-1 govuk-!-font-weight-bold'}
               What are you using registers for?
             %p.js--gov-registers-use-message#gov-registers-use
             .govuk-radios__item
@@ -32,7 +32,7 @@
           = label_tag("is-government-conditional-2", 'No', class: "govuk-label govuk-radios__label")
         #conditional-is-government-conditional-2.govuk-radios__conditional.govuk-radios__conditional--hidden
           %div{ class: 'govuk-form-group govuk-!-padding-bottom-3 govuk-!-padding-top-3 js--nongov-registers-use-group' }
-            %label{ for: 'what-are-you-using-registers-for', class: 'govuk-label govuk-!-padding-bottom-1'}
+            %label{ for: 'what-are-you-using-registers-for', class: 'govuk-label govuk-!-padding-bottom-1 govuk-!-font-weight-bold'}
               What are you using registers for?
             %p.js--nongov-registers-use-message#nongov-registers-use
             .govuk-radios__item
@@ -48,7 +48,7 @@
               = radio_button_tag("help_us_improve_user[nongov_what_are_you_using_registers_for]", "Other", false, class: "govuk-radios__input", id: "other")
               = label_tag("other", 'Other', class: "govuk-label govuk-radios__label")
   %div{ class: "govuk-form-group access-to-data__submit-group"}
-    %button{type: 'submit', class: 'govuk-button'} Submit
+    %button{type: 'submit', class: 'govuk-button govuk-!-margin-bottom-0'} Submit
     %span or
     = link_to "I'd prefer not to say", @next_page, { class: 'js--ga-watch-click' }
 

--- a/app/views/download/help_improve.html.haml
+++ b/app/views/download/help_improve.html.haml
@@ -19,7 +19,8 @@
       var forms = document.querySelectorAll('.js--ga-submit')
 
       var state = {
-        errorSummary: []
+        errorSummary: [],
+        documentTitle: document.title
       }
 
       var readFormFn = {
@@ -108,7 +109,7 @@
           return $errorSummary;
         },
         showErrorSummary: function(form) {
-          document.title = 'Error - ' + document.title
+          document.title = 'Error - ' + state.documentTitle
           var $errorSummary = document.querySelector('.govuk-error-summary') ? document.querySelector('.govuk-error-summary') : errorFn.createErrorSummary(form)
 
           var $errorSummaryBodyList = document.querySelector('.govuk-error-summary__list') ? document.querySelector('.govuk-error-summary__list') : $errorSummary.querySelector('.govuk-error-summary__list');

--- a/app/views/download/help_improve.html.haml
+++ b/app/views/download/help_improve.html.haml
@@ -176,25 +176,25 @@
 
               if (partOfGov === false) {
                 state.errorSummary.push({
-                  messageShouldRead: 'Enter a government organisation',
+                  messageShouldRead: "#{t('errors.attributes.department.blank')}",
                   link: '#which-part-of-government'
                 })
                 errorFn.showErrorWarning(form, {
                   addClassTo: '.js--which-part-of-government-group',
                   putMessageIn: '.js--which-part-of-government-message',
-                  messageShouldRead:  'Enter a government organisation'
+                  messageShouldRead:  "#{t('errors.attributes.department.blank')}"
                 })
               }
 
               if (registerUse === false) {
                 state.errorSummary.push({
-                  messageShouldRead: "Select what you're using registers for",
+                  messageShouldRead: "#{t('errors.attributes.use_category.blank').html_safe}",
                   link: '#gov-registers-use'
                 })
                 errorFn.showErrorWarning(form, {
                   addClassTo: '.js--gov-registers-use-group',
                   putMessageIn: '.js--gov-registers-use-message',
-                  messageShouldRead:  "Select what you're using registers for"
+                  messageShouldRead:  "#{t('errors.attributes.use_category.blank').html_safe}"
                 })
               }
 
@@ -210,13 +210,13 @@
               var registerUse = readFormFn.checkAnswer(form, 'help_us_improve_user[nongov_what_are_you_using_registers_for]')
               if (registerUse === false) {
                 state.errorSummary.push({
-                  messageShouldRead: "Select what you're using registers for",
+                  messageShouldRead: "#{t('errors.attributes.use_category.blank').html_safe}",
                   link: '#nongov-registers-use'
                 })
                 errorFn.showErrorWarning(form, {
                   addClassTo: '.js--nongov-registers-use-group',
                   putMessageIn: '.js--nongov-registers-use-message',
-                  messageShouldRead: "Select what you're using registers for"
+                  messageShouldRead: "#{t('errors.attributes.use_category.blank').html_safe}"
                 })
                 errorFn.showErrorSummary(form)
               }
@@ -230,10 +230,10 @@
               errorFn.showErrorWarning(form, {
                 addClassTo: '.js--is-government-group',
                 putMessageIn: '.js--is-government-message',
-                messageShouldRead: 'Select yes if you work for the government'
+                messageShouldRead: "#{t('errors.attributes.is_government.blank')}"
               })
               state.errorSummary.push({
-                messageShouldRead: 'Select yes if you work for the government',
+                messageShouldRead: "#{t('errors.attributes.is_government.blank')}",
                 link: '#do-you-work-for-the-government'
               })
               errorFn.showErrorSummary(form)

--- a/app/views/download/help_improve.html.haml
+++ b/app/views/download/help_improve.html.haml
@@ -18,39 +18,34 @@
     (function(document, window, undefined) {
       var forms = document.querySelectorAll('.js--ga-submit')
 
-      var getValue = function(element) {
-          if (element === null) {
-            return 'Blank'
-          }
-          else if (element.value) {
-            return element.value
-          }
-
-          return false;
+      var state = {
+        errorSummary: []
       }
 
-      for (var i = 0; i < forms.length; i += 1) {
-        forms[i].addEventListener('submit', function(event) {
-          var form = event.target
+      var readFormFn = {
+        checkAnswer: function(form, nameToCheck) {
+          var elementsToCheck = form.querySelectorAll('[name="' + nameToCheck + '"]');
 
-          var isGovernment = getValue(form.querySelector('input[name="help_us_improve_user[is_government]"]:checked'))
-          var whatAreYouUsingRegistersFor = function() {
-            if (isGovernment === "Yes") {
-              return getValue(form.querySelector('input[name="help_us_improve_user[gov_what_are_you_using_registers_for]"]:checked'))
+          for (var i = 0; i < elementsToCheck.length; i++) {
+            var element = elementsToCheck[i]
+            if (element === null) {
+              return false
             }
-            else if (isGovernment === "No") {
-              return getValue(form.querySelector('input[name="help_us_improve_user[nongov_what_are_you_using_registers_for]"]:checked'))
+
+            if (element.tagName === 'SELECT' && element.options[element.selectedIndex].text.length > 0) {
+              return element.options[element.selectedIndex].text
             }
-            return false
+
+            if (element.type === 'radio' && element.checked === true) {
+              return element.value
+            }
           }
-          var whatPartOfGovernmentAreYouWorkingFor = function() {
-            var element = form.querySelector('select[name="help_us_improve_user[gov_what_part_of_government]"]')
-            var governmentDept = element.options[element.selectedIndex].text
-            if (governmentDept.length === 0) {
-              return 'blank'
-            }
-            return governmentDept;
-          }
+          return false;
+        },
+        sendData: function(form) {
+          var isGovernment = readFormFn.checkAnswer(form, 'help_us_improve_user[is_government]')
+          var whatPartOfGovernmentAreYouWorkingFor = readFormFn.checkAnswer(form, 'help_us_improve_user[gov_what_part_of_government]')
+          var whatAreYouUsingRegisterFor = isGovernment === 'Yes' ? readFormFn.checkAnswer(form, 'help_us_improve_user[gov_what_part_of_government]') : readFormFn.checkAnswer(form, 'help_us_improve_user[nongov_what_are_you_using_registers_for]')
 
           ga('send', {
             hitType: 'event',
@@ -63,7 +58,7 @@
           ga('send', {
             hitType: 'event',
             eventCategory: 'Form',
-            eventAction: 'Radio - ' + isGovernment + ' - ' + whatAreYouUsingRegistersFor(),
+            eventAction: 'Radio - ' + isGovernment + ' - ' + whatAreYouUsingRegisterFor,
             eventLabel: 'What are you using registers for?',
             nonInteraction: true
           })
@@ -72,7 +67,7 @@
             ga('send', {
               hitType: 'event',
               eventCategory: 'Form',
-              eventAction: 'Text - ' + whatAreYouUsingRegistersFor() + ' - ' + whatPartOfGovernmentAreYouWorkingFor() ,
+              eventAction: 'Text - ' + whatAreYouUsingRegisterFor + ' - ' + whatPartOfGovernmentAreYouWorkingFor,
               eventLabel: 'What part of government are you working for?',
               nonInteraction: true
             })
@@ -85,8 +80,164 @@
             eventLabel: 'Help us improve',
             nonInteraction: true
           })
+        }
+      }
 
+      var errorFn = {
+        createErrorSummary: function(form) {
+          var $errorSummary = document.createElement('div')
+            $errorSummary.className = 'govuk-error-summary'
+            $errorSummary.setAttribute('aria-labelledby', 'error-summary-title')
+            $errorSummary.setAttribute('role', 'alert')
+            $errorSummary.setAttribute('tabindex', '-1')
+            $errorSummary.setAttribute('data-module', 'error-summary')
+          var $errorSummaryTitle = document.createElement('h2')
+            $errorSummaryTitle.id = 'error-summary-title'
+            $errorSummaryTitle.className = 'govuk-error-summary__title'
+            $errorSummaryTitle.appendChild(document.createTextNode('There is a problem'))
+          var $errorSummaryBody = document.createElement('div')
+            $errorSummaryBody.className = 'govuk-error-summary__body'
+          var $errorSummaryBodyList = document.createElement('ul')
+          $errorSummaryBodyList.className = 'govuk-list govuk-error-summary__list'
 
+          $errorSummaryBody.appendChild($errorSummaryBodyList)
+
+          $errorSummary.appendChild($errorSummaryTitle)
+          $errorSummary.appendChild($errorSummaryBody)
+
+          return $errorSummary;
+        },
+        showErrorSummary: function(form) {
+          document.title = 'Error - ' + document.title
+          var $errorSummary = document.querySelector('.govuk-error-summary') ? document.querySelector('.govuk-error-summary') : errorFn.createErrorSummary(form)
+
+          var $errorSummaryBodyList = document.querySelector('.govuk-error-summary__list') ? document.querySelector('.govuk-error-summary__list') : $errorSummary.querySelector('.govuk-error-summary__list');
+
+          $errorSummaryBodyList.innerHTML = ''
+
+          for(var i = 0; i < state.errorSummary.length; i++) {
+            var content = state.errorSummary[i]
+            var $errorSummaryBodyListItem = document.createElement('li')
+            var $errorSummaryBodyListItemLink = document.createElement('a')
+              $errorSummaryBodyListItemLink.href = content.link
+              $errorSummaryBodyListItemLink.appendChild(document.createTextNode(content.messageShouldRead))
+
+            $errorSummaryBodyListItem.appendChild($errorSummaryBodyListItemLink)
+            $errorSummaryBodyList.appendChild($errorSummaryBodyListItem)
+          }
+
+          form.insertBefore($errorSummary, form.querySelector('.js--is-government-group'));
+
+          $errorSummary.focus();
+
+          state.errorSummary = [];
+        },
+        showErrorWarning: function(form, info) {
+          var classTarget = form.querySelector(info.addClassTo)
+          var messageTarget = form.querySelector(info.putMessageIn)
+          var messageText = document.createTextNode(info.messageShouldRead)
+
+          messageTarget.className += ' govuk-error-message'
+          messageTarget.innerHTML = '';
+          messageTarget.appendChild(messageText)
+
+          classTarget.className += ' govuk-form-group--error'
+        },
+        clearErrorWarnings: function(form) {
+          var existingClassTargets = form.querySelectorAll('.govuk-form-group--error')
+          for(var i = 0; i < existingClassTargets.length; i++) {
+            existingClassTargets[i].className = existingClassTargets[i].className.replace(/(| )govuk-form-group--error/g, '')
+          }
+
+          var existingWarnings = form.querySelectorAll('.govuk-error-message')
+          for(var j = 0; j < existingWarnings.length; j++) {
+            existingWarnings[j].innerHTML = '';
+            existingWarnings[j].className = existingWarnings[j].className.replace(/(| )govuk-error-message/g, '')
+          }
+        }
+      }
+
+      for (var i = 0; i < forms.length; i += 1) {
+        forms[i].addEventListener('submit', function(event) {
+          event.preventDefault()
+
+          var form = event.target
+
+          errorFn.clearErrorWarnings(form)
+
+          var isGov = readFormFn.checkAnswer(form, 'help_us_improve_user[is_government]')
+
+          switch (isGov) {
+            case 'Yes':
+              // check questions
+              var partOfGov = readFormFn.checkAnswer(form, 'help_us_improve_user[gov_what_part_of_government]')
+              var registerUse = readFormFn.checkAnswer(form, 'help_us_improve_user[gov_what_are_you_using_registers_for]')
+
+              if (partOfGov === false) {
+                state.errorSummary.push({
+                  messageShouldRead: 'Enter a government organisation',
+                  link: '#which-part-of-government'
+                })
+                errorFn.showErrorWarning(form, {
+                  addClassTo: '.js--which-part-of-government-group',
+                  putMessageIn: '.js--which-part-of-government-message',
+                  messageShouldRead:  'Enter a government organisation'
+                })
+              }
+
+              if (registerUse === false) {
+                state.errorSummary.push({
+                  messageShouldRead: "Select what you're using registers for",
+                  link: '#gov-registers-use'
+                })
+                errorFn.showErrorWarning(form, {
+                  addClassTo: '.js--gov-registers-use-group',
+                  putMessageIn: '.js--gov-registers-use-message',
+                  messageShouldRead:  "Select what you're using registers for"
+                })
+              }
+
+              if (registerUse === false || partOfGov === false) {
+                errorFn.showErrorSummary(form)
+              }
+              else {
+                readFormFn.sendData(form);
+                form.submit();
+              }
+              break
+            case 'No':
+              var registerUse = readFormFn.checkAnswer(form, 'help_us_improve_user[nongov_what_are_you_using_registers_for]')
+              if (registerUse === false) {
+                state.errorSummary.push({
+                  messageShouldRead: "Select what you're using registers for",
+                  link: '#nongov-registers-use'
+                })
+                errorFn.showErrorWarning(form, {
+                  addClassTo: '.js--nongov-registers-use-group',
+                  putMessageIn: '.js--nongov-registers-use-message',
+                  messageShouldRead: "Select what you're using registers for"
+                })
+                errorFn.showErrorSummary(form)
+              }
+              else {
+                readFormFn.sendData(form);
+                form.submit();
+              }
+              break
+            case false:
+            default:
+              errorFn.showErrorWarning(form, {
+                addClassTo: '.js--is-government-group',
+                putMessageIn: '.js--is-government-message',
+                messageShouldRead: 'Select yes if you work for the government'
+              })
+              state.errorSummary.push({
+                messageShouldRead: 'Select yes if you work for the government',
+                link: '#do-you-work-for-the-government'
+              })
+              errorFn.showErrorSummary(form)
+              break
+          }
         })
       }
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -83,17 +83,11 @@ en:
   errors:
     attributes:
       is_government:
-        blank: 'Select if you work for government or not'
+        blank: 'Select yes if you work for the government'
       department:
-        blank: 'Enter which government organisation you work for'
-      email_gov:
-        blank: 'Enter your email address'
-        invalid: 'Enter a valid email address'
-      email_non_gov:
-        blank: 'Enter your email address'
-        invalid: 'Enter a valid email address'
-      non_gov_use_category:
-        blank: "Enter what you're using GOV.UK Registers for"
+        blank: 'Enter a government organisation'
+      use_category:
+        blank: "Select what you're using registers for"
       email:
         blank: 'Enter your email address'
       useful:


### PR DESCRIPTION
### Context
The access to data questionnaire needs all questions to be answered before submitting.

### Changes proposed in this pull request
* Makes all questions required
* Verifies only the questions relevant - only checks the government questions when the visitor has said they work for government, and only checks the non-government question when the visitor has said that they don't work for government.
* Shows error messages when required fields have not been filled in

### Guidance to review
The questions are still skippable by clicking either the ‘Skip this step’ or the ‘I'd prefer not to say’ step.
