### PR TITLE
Removes 'registers' from each event being fired, making them less wordy.

### DIFF
--- a/app/views/authority/show.html.haml
+++ b/app/views/authority/show.html.haml
@@ -28,7 +28,7 @@
         ga('send', {
           hitType: 'event',
           eventCategory: 'Show by',
-          eventAction: 'Organisation - #{@collection.name.html_safe} - ' + event.target.innerText,
+          eventAction: 'Organisation - #{@collection.name.html_safe} - ' + event.target.innerText.replace(/ register/, ''),
           eventLabel: 'Select register',
           nonInteraction: true
         })

--- a/app/views/category/show.html.haml
+++ b/app/views/category/show.html.haml
@@ -28,7 +28,7 @@
         ga('send', {
           hitType: 'event',
           eventCategory: 'Show by',
-          eventAction: 'Category - #{@collection.name} - ' + event.target.innerText.replace(/\./, ''),
+          eventAction: 'Category - #{@collection.name} - ' + event.target.innerText.replace(/ register/, ''),
           eventLabel: 'Select register',
           nonInteraction: true
         })

--- a/app/views/registers/index.html.haml
+++ b/app/views/registers/index.html.haml
@@ -113,7 +113,7 @@
         ga('send', {
           hitType: 'event',
           eventCategory: 'Show by',
-          eventAction: '#{@show_by_selected.capitalize} - ' + event.target.parentElement.querySelector('h3').innerText,
+          eventAction: '#{@show_by_selected.capitalize} - ' + event.target.parentElement.querySelector('h3').innerText.replace(/ register/, ''),
           eventLabel: 'Select #{ @show_by_selected == "name" ? "register" : "group" }',
           nonInteraction: true
         })


### PR DESCRIPTION
### Context
Cliff requested that the events that are when going from a collection / organisation / list page to the register page are changed.

### Changes proposed in this pull request
* 'register' to be removed from the end of the event actions; for example, _Organisation - Ministry of Justice - Prison estate register_ to be changed to _Organisation - Ministry of Justice - Prison estate_

### Guidance to review
None.