### PR TITLE
Header and footer 

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -59,7 +59,7 @@
         .govuk-grid-column-one-third
           %h2{class: 'govuk-footer__heading govuk-heading-m govuk-!-margin-bottom-0'} About
           %ul{class: 'govuk-footer__list govuk-!-padding-bottom-7'}
-            %li.govuk-footer__list-item= link_to 'What is a register?', about_path, {class: 'govuk-footer__link'}
+            %li.govuk-footer__list-item= link_to 'What is a data register?', about_path, {class: 'govuk-footer__link'}
             %li.govuk-footer__list-item= link_to 'Organisations providing data', registers_path(show_by: "organisation"), {class: 'govuk-footer__link'}
             %li.govuk-footer__list-item
               %a{href: "https://www.gov.uk/performance/govuk-registers"}Performance

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -21,21 +21,19 @@
             GOV.UK
           /-
           %span.header__title
-            Registers
+            Data Registers
             %span.phase-banner Alpha
 
-      = check_box_tag 'show-menu', nil, false, class: 'header__navigation-toggle-checkbox', "aria-controls" => "navigation", "aria-expanded" => "false"
+      = check_box_tag 'show-menu', nil, false, class: 'header__navigation-toggle-checkbox', 'aria-controls': 'navigation', 'aria-expanded': 'false'
       = label_tag 'show-menu', 'Menu', class: 'header__navigation-toggle'
-      %nav{id: "navigation", class: "header__navigation", role: "Navigation", "aria-label" => "Top Level Navigation", "aria-hidden" => "true"}
+      %nav{id: 'navigation', class: 'header__navigation', role: 'Navigation', 'aria-label': 'Top Level Navigation'}
         %ul
           %li{class: "#{'active' if current_page?(about_path)}"}
-            = link_to "About", about_path
+            = link_to 'About', about_path
           %li{class: "#{'active' if current_page?(registers_path)}"}
-            = link_to "Registers collection", registers_path
+            = link_to 'Government structured data', registers_path
           %li{class: "#{'active' if current_page?(support_path)}"}
-            = link_to "Support", support_path
-          %li
-            = link_to "Documentation", "https://docs.registers.service.gov.uk"
+            = link_to 'Contact', support_path
 
 - content_for :head do
   = canonical_tag
@@ -48,7 +46,7 @@
   %aside.notice
     .container
       %h2.visually-hidden Upcoming data format changes
-      %p{data: {"click-events" => "", "click-category" => "Content", "click-action" => "Notice link clicked"}} GOV.UK Registers will stop supporting data formats other than JSON and CSV from 1 December 2018. #{link_to "Read more about format changes", data_format_changes_path}
+      %p{data: {'click-events': '', 'click-category': 'Content', 'click-action': 'Notice link clicked'}} GOV.UK Registers will stop supporting data formats other than JSON and CSV from 1 December 2018. #{link_to 'Read more about format changes', data_format_changes_path}
 
 - content_for :body_end do
   = javascript_include_tag 'application'
@@ -61,25 +59,24 @@
         .govuk-grid-column-one-third
           %h2{class: 'govuk-footer__heading govuk-heading-m govuk-!-margin-bottom-0'} About
           %ul{class: 'govuk-footer__list govuk-!-padding-bottom-7'}
-            %li.govuk-footer__list-item= link_to 'Our service', about_path, {class: 'govuk-footer__link'}
-            %li.govuk-footer__list-item= link_to 'Organisations managing registers', registers_path(show_by: "organisation"), {class: 'govuk-footer__link'}
-            %li.govuk-footer__list-item= link_to "Services using registers", services_using_registers_path, {class: 'govuk-footer__link'}
-            -# %li.govuk-footer__list-item
-              -# %a{href: "https://www.gov.uk/performance/govuk-registers"}Performance data
+            %li.govuk-footer__list-item= link_to 'What is a register?', about_path, {class: 'govuk-footer__link'}
+            %li.govuk-footer__list-item= link_to 'Organisations providing data', registers_path(show_by: "organisation"), {class: 'govuk-footer__link'}
+            %li.govuk-footer__list-item
+              %a{href: "https://www.gov.uk/performance/govuk-registers"}Performance
 
         .govuk-grid-column-one-third
           %h2{class: 'govuk-footer__heading govuk-heading-m govuk-!-margin-bottom-0'} Use
           %ul{class: 'govuk-footer__list govuk-!-padding-bottom-7'}
-            %li.govuk-footer__list-item= link_to 'Registers collection', registers_path, {class: 'govuk-footer__link'}
-            %li.govuk-footer__list-item= link_to 'Upcoming registers', registers_in_progress_path, {class: 'govuk-footer__link'}
-            %li.govuk-footer__list-item= link_to 'Documentation', 'https://docs.registers.service.gov.uk', {class: 'govuk-footer__link'}
+            %li.govuk-footer__list-item= link_to 'Government structured data', registers_path, {class: 'govuk-footer__link'}
+            %li.govuk-footer__list-item= link_to "Services using registers", services_using_registers_path, {class: 'govuk-footer__link'}
+            %li.govuk-footer__list-item= link_to 'API Documentation', 'https://docs.registers.service.gov.uk', {class: 'govuk-footer__link'}
 
         .govuk-grid-column-one-third
           %h2{class: 'govuk-footer__heading govuk-heading-m govuk-!-margin-bottom-0'} Support
           %ul{class: 'govuk-footer__list govuk-!-padding-bottom-7'}
-            %li.govuk-footer__list-item= link_to 'Sign up for updates', sign_up_index_path, {class: 'govuk-footer__link'}
             %li.govuk-footer__list-item= link_to 'Contact', support_path, {class: 'govuk-footer__link'}
-
+            %li.govuk-footer__list-item= link_to 'Sign up for updates', sign_up_index_path, {class: 'govuk-footer__link'}
+            %li.govuk-footer__list-item= link_to 'Suggest a new register', suggest_new_register_path, {class: 'govuk-footer__link'}
       %hr
 
 - content_for :footer_support_links do


### PR DESCRIPTION
### Context
The header and footer of the frontend needs updating, as per [this card](https://trello.com/c/GDGJm4ql/3067-update-header-and-footer).

### Changes proposed in this pull request

**Update Header**

- rename 'GOV.UK Registers ALPHA' to 'GOV.UK Data Registers ALPHA'
- rename 'Registers collection' to 'Government structured data'
- rename 'Support' to 'Contact'
- remove 'Documentation' link

**Update Footer**
- rename 'Our service' to 'What is a data register?'
- rename 'Organisations managing registers' to 'Organisations providing data'
- rename 'Registers collection' to 'Government structured data'
- rename 'Documentation' to 'API Documentation'
- add 'Performance' to bottom of ‘About’ section
- move 'Services using registers' link to ‘Use’ section
-  add 'Suggest a register' to bottom of  ‘Contact’ section
-  Support column should read:
    - Contact
    - Sign up for updates
    - Suggest a register

### Guidance to review
None.
