### PR TITLE
Changes 'Suggest a new register' link to new form.

### DIFF
--- a/app/views/suggest_a_register/complete.haml
+++ b/app/views/suggest_a_register/complete.haml
@@ -11,19 +11,17 @@
 .govuk-width-container
   %main{class: 'govuk-main-wrapper govuk-!-padding-top-7 govuk-!-padding-bottom-8', role:'main'}
     .govuk-grid-row
-      .govuk-grid-column-full
-        %h1{class: 'govuk-heading-l govuk-!-margin-bottom-3'} Suggest a new register
       .govuk-grid-column-two-thirds
+        %h1{class: 'govuk-heading-l govuk-!-margin-bottom-3'} Suggest a new register
+
         %p You need to complete our engagement form to suggest a new register.
         %p The details you provide will help us to better understand your needs for a register, the data you have to offer and whether it is suitable to become a register.
-        %p.govuk-inset-text
-          = link_to 'Use our Google form', 'https://docs.google.com/forms/d/e/1FAIpQLSfw54dI5uYuF-15zH6Iu7KRQnj8lRY3Wcl9JI5hC80cENx-jw/viewform', {data: {'ga-label': 'Suggest a register Google form'}}
-          &nbsp;to suggest a new register.
+
+        %p.govuk-inset-text #{link_to 'Use our Google form', 'https://goo.gl/forms/GFaJgfnn7dH7AH5f1', {data: {'ga-label': 'Suggest a register Google form'}} } to suggest a new register.
 
         %h3{class: 'govuk-heading-s govuk-!-margin-bottom-1'} Can’t access Google forms?
-        %p
-          = link_to 'Contact the GOV.UK Registers team', support_question_url
-          &nbsp;for support
+
+        %p #{link_to 'Contact the GOV.UK Registers team', support_question_url} for support.
 
 
 = content_for :javascript do

--- a/app/views/suggest_a_register/complete.haml
+++ b/app/views/suggest_a_register/complete.haml
@@ -17,7 +17,7 @@
         %p You need to complete our engagement form to suggest a new register.
         %p The details you provide will help us to better understand your needs for a register, the data you have to offer and whether it is suitable to become a register.
 
-        %p.govuk-inset-text #{link_to 'Use our Google form', 'https://goo.gl/forms/GFaJgfnn7dH7AH5f1', {data: {'ga-label': 'Suggest a register Google form'}} } to suggest a new register.
+        %p.govuk-inset-text #{link_to 'Use our Google form', 'https://docs.google.com/forms/d/e/1FAIpQLScRNr-1oAxlt_fwy9JPEjzglnyi0qJVFKNw1odbAHX5ZV9fIQ/viewform', {data: {'ga-label': 'Suggest a register Google form'}} } to suggest a new register.
 
         %h3{class: 'govuk-heading-s govuk-!-margin-bottom-1'} Can’t access Google forms?
 


### PR DESCRIPTION
### Context
The Google form for suggesting a new register has been updated. The old form link needs to be replaced with the new link.

### Changes proposed in this pull request
 * Changes form link from old to new form, as per the [card](https://trello.com/c/bW179gSd/3084-update-google-form-link-on-suggest-a-new-register)

### Guidance to review
None.