### PR TITLE
Changes to register page header and meta

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -121,36 +121,6 @@ html {
 }
 // scss-lint:enable IdSelector
 
-.govuk-metadata {
-  font-size: 16px;
-  margin-bottom: 20px;
-  @extend %contain-floats;
-
-  @supports (display: grid) {
-    display: grid;
-    grid-template-columns: 6.25em auto;
-    grid-column-gap: 0.35em;
-  }
-
-  dl {
-    overflow: hidden;
-  }
-
-  dt {
-    clear: left;
-    float: left;
-    max-width: 150px;
-    padding-bottom: 0.5rem;
-    padding-right: 1%;
-  }
-
-  dd {
-    float: left;
-    margin: 0;
-    max-width: 480px;
-    padding-bottom: 0.5rem;
-  }
-}
 
 .list-number-big {
   font-size: 24px;

--- a/app/assets/stylesheets/govuk_component/_organisation-logo.scss
+++ b/app/assets/stylesheets/govuk_component/_organisation-logo.scss
@@ -41,8 +41,11 @@
     border-left: 2px solid $black;
     padding-top: 20px;
     padding-left: 6px;
+    margin-left: 1px;
+    margin-top: 5px;
 
     @include media(tablet) {
+      margin-top: 10px;
       padding-top: 25px;
       padding-left: 7px;
     }

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -40,7 +40,11 @@ module ApplicationHelper
   end
 
   def formatted_date(date)
-    Date.parse(date).strftime('%d/%m/%Y')
+    Date.parse(date).strftime('%d/%m/%Y') # eg 03/08/2015
+  end
+
+  def human_readable_date(date)
+    Date.parse(date).strftime('%e %B %Y') # eg 3 August 2015
   end
 
   def records_table_header(field_value)

--- a/app/models/register.rb
+++ b/app/models/register.rb
@@ -45,6 +45,14 @@ class Register < ApplicationRecord
       .to_s
   end
 
+  def register_first_updated
+    Record.select('timestamp')
+      .where(register_id: id)
+      .order(timestamp: :asc)
+      .first[:timestamp]
+      .to_s
+  end
+
   def register_description
     Record.where(register_id: id, key: "register:#{name.parameterize}")
     .pluck(Arel.sql("data -> 'text' as text"))

--- a/app/views/registers/show.html.haml
+++ b/app/views/registers/show.html.haml
@@ -22,7 +22,7 @@
         - if @register.category.present?
           %p{class: 'govuk-body-s govuk-!-margin-bottom-2'}
             Category: #{link_to @register.category&.name, category_path(@register.category&.slug), {class: 'govuk-!-font-weight-bold', data: { 'click-events' => '', 'click-category' => 'Register metadata', 'click-action' => "Category - #{@register&.category&.name}", 'click-label' => 'Category'}}}
-      .govuk-grid-column-one-third{'aria-hidden': 'true'}
+      .govuk-grid-column-one-third
         - if @register.authority.present?
           %p{class: 'govuk-body-s govuk-!-margin-top-2 govuk-!-margin-bottom-2'} Managed by:
           %div{class: "govuk-organisation-logo #{@register&.authority&.name&.parameterize}"}

--- a/app/views/registers/show.html.haml
+++ b/app/views/registers/show.html.haml
@@ -15,16 +15,16 @@
           #{@register.register_name} register
         %p{class: 'govuk-body-l govuk-!-padding-top-2'}= @register.register_description
         - unless @register.is_empty?
-          %p{class: 'govuk-body-s govuk-!-margin-bottom-2'}
+          %p{class: 'govuk-body-s govuk-!-margin-bottom-1'}
             First published #{human_readable_date(@register.register_first_updated) }
-          %p{class: 'govuk-body-s govuk-!-margin-bottom-2'}
+          %p{class: 'govuk-body-s govuk-!-margin-bottom-1'}
             Last updated #{human_readable_date(@register.register_last_updated) } &mdash; #{link_to 'see all updates' , register_entries_path(@register.slug), {data: { 'click-events' => '', 'click-category' => 'Register metadata', 'click-action' => "Last updated - #{@register.register_name}", 'click-label' => 'Last updated'}}}
         - if @register.category.present?
-          %p{class: 'govuk-body-s govuk-!-margin-bottom-2'}
+          %p{class: 'govuk-body-s govuk-!-margin-bottom-1'}
             Category: #{link_to @register.category&.name, category_path(@register.category&.slug), {class: 'govuk-!-font-weight-bold', data: { 'click-events' => '', 'click-category' => 'Register metadata', 'click-action' => "Category - #{@register&.category&.name}", 'click-label' => 'Category'}}}
       .govuk-grid-column-one-third
         - if @register.authority.present?
-          %p{class: 'govuk-body-s govuk-!-margin-top-2 govuk-!-margin-bottom-2'} Managed by:
+          %p{class: 'govuk-body-s govuk-!-margin-top-1 govuk-!-margin-bottom-0'} Managed by:
           %div{class: "govuk-organisation-logo #{@register&.authority&.name&.parameterize}"}
             %div{class: "logo-container #{crest_class_name(@register&.authority&.name&.parameterize)}"}
               %span= @register&.authority&.name

--- a/app/views/registers/show.html.haml
+++ b/app/views/registers/show.html.haml
@@ -4,7 +4,7 @@
 
 .govuk-width-container
   %main#content.govuk-main-wrapper{role:'main', class: 'govuk-!-padding-top-0'}
-    .govuk-grid-row{class: 'govuk-!-margin-top-5'}
+    .govuk-grid-row{class: 'govuk-!-padding-top-6'}
       - if @register.register_phase != 'Beta'
         .govuk-grid-column-full
           .govuk-inset-text
@@ -14,23 +14,23 @@
         %h1{class: "govuk-heading-l govuk-!-margin-bottom-1"}
           #{@register.register_name} register
         %p{class: 'govuk-body-l govuk-!-padding-top-2'}= @register.register_description
-        %dl.govuk-metadata
-          - if @register.authority.present?
-            %dt.register-metadata__term Organisation:
-            %dd.register-metadata__definition= link_to @register&.authority&.name, authority_path(@register.authority.government_organisation_key), {data: { 'click-events' => '', 'click-category' => 'Register metadata', 'click-action' => "Organisation - #{@register&.authority&.name} ", 'click-label' => 'Organisation'}}
-          - if @register.show_category_link?
-            %dt.register-metadata__term Category:
-            %dd.register-metadata__definition= link_to @register.category&.name, category_path(@register.category&.slug), {data: { 'click-events' => '', 'click-category' => 'Register metadata', 'click-action' => "Category - #{@register&.category&.name} ", 'click-label' => 'Category'}}
-          - unless @register.is_empty?
-            %dt.register-metadata__term Last updated:
-            %dd.register-metadata__definition= link_to formatted_date(@register.register_last_updated), register_entries_path(@register.slug), {data: { 'click-events' => '', 'click-category' => 'Register metadata', 'click-action' => "Last updated - #{@register.register_name}", 'click-label' => 'Last updated'}}
-        %p= link_to 'Access the data', register_choose_access_path(@register.slug), {id: 'access-the-data-button', class: 'registers__button--access govuk-!-margin-top-5'}
+        - unless @register.is_empty?
+          %p{class: 'govuk-body-s govuk-!-margin-bottom-2'}
+            First published #{human_readable_date(@register.register_first_updated) }
+          %p{class: 'govuk-body-s govuk-!-margin-bottom-2'}
+            Last updated #{human_readable_date(@register.register_last_updated) } &mdash; #{link_to 'see all updates' , register_entries_path(@register.slug), {data: { 'click-events' => '', 'click-category' => 'Register metadata', 'click-action' => "Last updated - #{@register.register_name}", 'click-label' => 'Last updated'}}}
+        - if @register.category.present?
+          %p{class: 'govuk-body-s govuk-!-margin-bottom-2'}
+            Category: #{link_to @register.category&.name, category_path(@register.category&.slug), {class: 'govuk-!-font-weight-bold', data: { 'click-events' => '', 'click-category' => 'Register metadata', 'click-action' => "Category - #{@register&.category&.name}", 'click-label' => 'Category'}}}
       .govuk-grid-column-one-third{'aria-hidden': 'true'}
         - if @register.authority.present?
-          %p{class: 'govuk-!-font-weight-bold govuk-!-margin-top-2'} Managed by:
+          %p{class: 'govuk-body-s govuk-!-margin-top-2 govuk-!-margin-bottom-2'} Managed by:
           %div{class: "govuk-organisation-logo #{@register&.authority&.name&.parameterize}"}
             %div{class: "logo-container #{crest_class_name(@register&.authority&.name&.parameterize)}"}
               %span= @register&.authority&.name
+      .govuk-grid-column-full
+        %p= link_to 'Access the data', register_choose_access_path(@register.slug), {id: 'access-the-data-button', class: 'registers__button--access govuk-!-margin-top-5'}
+
     %section.govuk-grid-row#records_wrapper{ data: { module: 'accordion-with-descriptions'}}
       .govuk-grid-column-full.subsection__header#search_wrapper
         %h2.govuk-heading-m.subsection__title


### PR DESCRIPTION
### Context
First in the set of changes to the register page, as [detailed in the card](https://trello.com/c/Kn6y0mKh/3094-implement-new-access-the-data-options-individual-register-page-changes). 

This changes the layouts of the register page header and refines what metadata is shown.

### Changes proposed in this pull request
 * Publishing organisation removed from metadata
 * First published date added to metadata; added method for getting the date
 * CSS for previous metadata layout removed
 * Date format changed, including helper method to make it human readable

### Guidance to review
 * This is only part one of the changes asked for - this is to avoid a mega-deploy.