### PR TITLE
filter category listing to registers with records only

### DIFF
--- a/app/models/authority.rb
+++ b/app/models/authority.rb
@@ -12,7 +12,7 @@ class Authority < ApplicationRecord
   }
 
   def registers_by_this_collection
-    @registers_by_this_collection ||= registers.in_beta.by_name
+    @registers_by_this_collection ||= registers.in_beta.has_records.by_name
   end
 
   def register_count

--- a/app/models/authority.rb
+++ b/app/models/authority.rb
@@ -16,6 +16,6 @@ class Authority < ApplicationRecord
   end
 
   def register_count
-    @register_count ||= registers.in_beta.count
+    @register_count ||= registers.in_beta.has_records.count
   end
 end

--- a/app/models/authority.rb
+++ b/app/models/authority.rb
@@ -4,7 +4,7 @@ class Authority < ApplicationRecord
   scope :by_authority_name, -> { order name: :asc }
 
   scope :with_a_register, -> {
-    joins(:registers).merge(Register.in_beta).distinct.by_authority_name
+    joins(:registers).merge(Register.in_beta.has_records).distinct.by_authority_name
   }
 
   scope :collection, ->(id) {

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -16,7 +16,7 @@ class Category < ApplicationRecord
   }
 
   def registers_by_this_collection
-    @registers_by_this_collection ||= registers.in_beta.by_name
+    @registers_by_this_collection ||= registers.in_beta.has_records.by_name
   end
 
   def register_count

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -20,6 +20,6 @@ class Category < ApplicationRecord
   end
 
   def register_count
-    @register_count ||= registers.in_beta.count
+    @register_count ||= registers.in_beta.has_records.count
   end
 end


### PR DESCRIPTION
### Context
Previously when a register was added to the CMS but had not yet been indexed it would be linked to from the category list and cause a 404

### Changes proposed in this pull request
only show registers with records in category list

### Guidance to review
Add a beta register with a category in the CMS
It should not appear in the CMS until the populate data script has been run
