### PR TITLE
Adds tests to check the access to data flow works correctly.

### DIFF
--- a/spec/features/access_data_flow_spec.rb
+++ b/spec/features/access_data_flow_spec.rb
@@ -47,10 +47,8 @@ RSpec.feature 'View register', type: :feature do
   scenario 'the states for all pages in API flow are 200' do
     visit('/registers/country')
     expect(page.status_code).to eq(200)
-
     click_link('Use the API')
     expect(page.status_code).to eq(200)
-
     click_link('Skip this step')
     expect(page.status_code).to eq(200)
   end
@@ -58,10 +56,8 @@ RSpec.feature 'View register', type: :feature do
   scenario 'the states for all pages in download flow are 200' do
     visit('/registers/country')
     expect(page.status_code).to eq(200)
-
     click_link('Download the data')
     expect(page.status_code).to eq(200)
-
     click_link('Skip this step')
     expect(page.status_code).to eq(200)
   end
@@ -69,31 +65,32 @@ RSpec.feature 'View register', type: :feature do
   scenario 'goes to questionnaire correctly when download option chosen' do
     visit('/registers/country')
     click_link('Download the data')
-
-    expect(page).to have_content('Before you download the data')
-    expect(page).to have_content('Help us improve GOV.UK Registers')
-
-    expect(page).to have_content('What part of government are you working for?')
-    expect(page).to have_content('What are you using registers for?')
-    expect(page).to have_content('Yes')
-    expect(page).to have_content('Building a service')
-    expect(page).to have_content('For data analysis or reporting')
-    expect(page).to have_content('Other')
-    expect(page).to have_content('No')
-    expect(page).to have_content('Commercial use')
-    expect(page).to have_content('Non-commercial use')
-    expect(page).to have_content('Personal use')
-
+    expect(page.body).to include(
+      'Before you download the data',
+      'Help us improve GOV.UK Registers',
+      'What part of government are you working for?',
+      'What are you using registers for?',
+      'Yes',
+      'Building a service',
+      'For data analysis or reporting',
+      'Other',
+      'No',
+      'Commercial use',
+      'Non-commercial use',
+      'Personal use'
+    )
     click_button('Submit')
   end
 
   scenario 'goes to questionnaire correctly when API option chosen' do
     visit('/registers/country')
     click_link('Use the API')
-    expect(page).to have_content('Before you use the API')
-    expect(page).to have_content('Help us improve GOV.UK Registers')
-    expect(page).to have_content('What part of government are you working for?')
-    expect(page).to have_content('What are you using registers for?')
+    expect(page.body).to include(
+      'Before you use the API',
+      'Help us improve GOV.UK Registers',
+      'What part of government are you working for?',
+      'What are you using registers for?'
+    )
   end
 
   scenario 'goes to download page correctly when questionnaire is skipped' do
@@ -116,9 +113,11 @@ RSpec.feature 'View register', type: :feature do
     click_link('Skip this step')
     visit('/registers/country')
     click_link('Download the data')
-    expect(page).to have_content('Download the data')
-    expect(page).to have_content('ODS (Excel compatible)')
-    expect(page).to have_content('CSV')
+    expect(page.body).to include(
+      'Download the data',
+      'ODS (Excel compatible)',
+      'CSV'
+    )
   end
 
   scenario 'goes to API page correctly when questionnaire is skipped' do
@@ -141,7 +140,6 @@ RSpec.feature 'View register', type: :feature do
     click_link('Skip this step')
     visit('/registers/country')
     click_link('Use the API')
-    expect(page).to have_content('Use the API')
-    expect(page).to have_content('register.gov.uk/records.json?page-size=5000')
+    expect(page.body).to include('Use the API', 'register.gov.uk/records.json?page-size=5000')
   end
 end

--- a/spec/features/access_data_flow_spec.rb
+++ b/spec/features/access_data_flow_spec.rb
@@ -39,11 +39,31 @@ RSpec.feature 'View register', type: :feature do
 
   scenario 'shows download and API options correctly' do
     visit('/registers/country')
-
     expect(page).to have_css '.highlight-box', count: 2
-
     expect(page).to have_content('Download the data')
     expect(page).to have_content('Use the API')
+  end
+
+  scenario 'the states for all pages in API flow are 200' do
+    visit('/registers/country')
+    expect(page.status_code).to eq(200)
+
+    click_link('Use the API')
+    expect(page.status_code).to eq(200)
+
+    click_link('Skip this step')
+    expect(page.status_code).to eq(200)
+  end
+
+  scenario 'the states for all pages in download flow are 200' do
+    visit('/registers/country')
+    expect(page.status_code).to eq(200)
+
+    click_link('Download the data')
+    expect(page.status_code).to eq(200)
+
+    click_link('Skip this step')
+    expect(page.status_code).to eq(200)
   end
 
   scenario 'goes to questionnaire correctly when download option chosen' do

--- a/spec/features/access_data_flow_spec.rb
+++ b/spec/features/access_data_flow_spec.rb
@@ -52,6 +52,19 @@ RSpec.feature 'View register', type: :feature do
 
     expect(page).to have_content('Before you download the data')
     expect(page).to have_content('Help us improve GOV.UK Registers')
+
+    expect(page).to have_content('What part of government are you working for?')
+    expect(page).to have_content('What are you using registers for?')
+    expect(page).to have_content('Yes')
+    expect(page).to have_content('Building a service')
+    expect(page).to have_content('For data analysis or reporting')
+    expect(page).to have_content('Other')
+    expect(page).to have_content('No')
+    expect(page).to have_content('Commercial use')
+    expect(page).to have_content('Non-commercial use')
+    expect(page).to have_content('Personal use')
+
+    click_button('Submit')
   end
 
   scenario 'goes to questionnaire correctly when API option chosen' do
@@ -59,5 +72,56 @@ RSpec.feature 'View register', type: :feature do
     click_link('Use the API')
     expect(page).to have_content('Before you use the API')
     expect(page).to have_content('Help us improve GOV.UK Registers')
+    expect(page).to have_content('What part of government are you working for?')
+    expect(page).to have_content('What are you using registers for?')
+  end
+
+  scenario 'goes to download page correctly when questionnaire is skipped' do
+    visit('/registers/country')
+    click_link('Download the data')
+    click_link('Skip this step')
+    expect(page).to have_content('Download the data')
+  end
+
+  scenario 'goes to download page correctly when questionnaire is submitted' do
+    visit('/registers/country')
+    click_link('Download the data')
+    click_button('Submit') # No JavaScript, so the empty form should just submit and go to the next page.
+    expect(page).to have_content('Download the data')
+  end
+
+  scenario "download link skips the questionnaire if it's already been seen" do
+    visit('/registers/country')
+    click_link('Download the data')
+    click_link('Skip this step')
+    visit('/registers/country')
+    click_link('Download the data')
+    expect(page).to have_content('Download the data')
+    expect(page).to have_content('ODS (Excel compatible)')
+    expect(page).to have_content('CSV')
+  end
+
+  scenario 'goes to API page correctly when questionnaire is skipped' do
+    visit('/registers/country')
+    click_link('Use the API')
+    click_link('Skip this step')
+    expect(page).to have_content('Use the API')
+  end
+
+  scenario 'goes to API page correctly when questionnaire is submitted' do
+    visit('/registers/country')
+    click_link('Use the API')
+    click_button('Submit') # No JavaScript, so the empty form should just submit and go to the next page.
+    expect(page).to have_content('Use the API')
+  end
+
+  scenario "API access link skips the questionnaire if it's already been seen" do
+    visit('/registers/country')
+    click_link('Use the API')
+    click_link('Skip this step')
+    visit('/registers/country')
+    click_link('Use the API')
+    expect(page).to have_content('Use the API')
+    expect(page).to have_content('register.gov.uk/records.json?page-size=5000')
   end
 end


### PR DESCRIPTION
### Context
The Access to data flow should have tests - this is to make sure both download and API flows are working, and that the questionnaire is shown only on the first visit through the flow. This will make sure that this flow is working without requiring unreliable manual testing.

[Card](https://trello.com/c/QnOSyqSS/3158-create-feature-test-for-access-to-data-flow).

### Changes proposed in this pull request
  * Checks both API and download paths are working
  * Checks questionnaire
  * Checks questionnaire is skipped if it's already been seen
  * Checks content on flow

### Guidance to review
* The new tests should run with the command `bundle exec rake spec`
* The balance between making a test easy to understand and keeping it all DRY - this falls on the side of not being DRY and (hopefully) being easier to understand. Improvements on that welcome
* Let me know if I've missed anything that should be tested