### PR TITLE
Fixes the register of Registers title not displaying correctly.

### DIFF
--- a/app/models/register.rb
+++ b/app/models/register.rb
@@ -89,7 +89,7 @@ class Register < ApplicationRecord
     [[title, seo_title, name].find(&:present?), 'register']
       .compact
       .join(' ')
-      .gsub(/register register$/i, 'register')
+      .gsub(/register register$/, 'register')
   end
 
 private


### PR DESCRIPTION
### Context
The case insensitivity was causing the register of registers (Register register) title to not display correctly. This fixes it.

### Changes proposed in this pull request
* Remove case insensitivity from the Regular Expression - so `register register` will be replaced, but `Register register` won't.

### Guidance to review
* Check the Register register page to see if the name is displaying correctly; check other registers.