### PR TITLE
Adds Markdown rendering for records

### DIFF
--- a/app/controllers/registers_controller.rb
+++ b/app/controllers/registers_controller.rb
@@ -2,7 +2,7 @@
 
 class RegistersController < ApplicationController
   include ActionView::Helpers::UrlHelper
-  helper_method :field_link_resolver
+  helper_method :field_formatter
 
 
   def index
@@ -53,16 +53,11 @@ class RegistersController < ApplicationController
     end
   end
 
-  def field_link_resolver(field, field_value, register_slug: @register.slug, whitelist: register_whitelist)
+  def field_formatter(field, field_value, register_slug: @register.slug, whitelist: register_whitelist)
     resolver = LinkResolver.new(current_register_slug: register_slug, register_whitelist: whitelist)
+    with_links = field_value.is_a?(Array) ? field_value.map { |fv| resolver.resolve(field, fv) }.join(', ') : resolver.resolve(field, field_value)
 
-    if field_value.is_a?(Array)
-      list = field_value.map { |fv| resolver.resolve(field, fv) }.join(', ')
-      BlueCloth.new(list, auto_links: false).to_html
-    else
-      text = resolver.resolve(field, field_value)
-      BlueCloth.new(text, auto_links: false).to_html
-    end
+    field['datatype'] === 'text' ? BlueCloth.new(with_links, auto_links: false).to_html : with_links
   end
 
 private

--- a/app/controllers/registers_controller.rb
+++ b/app/controllers/registers_controller.rb
@@ -4,6 +4,7 @@ class RegistersController < ApplicationController
   include ActionView::Helpers::UrlHelper
   helper_method :field_link_resolver
 
+
   def index
     @search_term = search_term
 
@@ -56,9 +57,11 @@ class RegistersController < ApplicationController
     resolver = LinkResolver.new(current_register_slug: register_slug, register_whitelist: whitelist)
 
     if field_value.is_a?(Array)
-      field_value.map { |fv| resolver.resolve(field, fv) }.join(', ').html_safe
+      list = field_value.map { |fv| resolver.resolve(field, fv) }.join(', ')
+      BlueCloth.new(list, auto_links: false).to_html
     else
-      resolver.resolve(field, field_value)
+      text = resolver.resolve(field, field_value)
+      BlueCloth.new(text, auto_links: false).to_html
     end
   end
 

--- a/app/views/registers/_record.html.haml
+++ b/app/views/registers/_record.html.haml
@@ -1,5 +1,4 @@
 %tr
   - @register.register_fields.each do |field|
     - field_value = record.data[field['field']]
-    %td
-      = field_value ? field_link_resolver(field, field_value) :  "<span class='unknown'>No data</span>".html_safe
+    %td= field_value ? field_link_resolver(field, field_value).html_safe :  "<span class='unknown'>No data</span>".html_safe

--- a/app/views/registers/_record.html.haml
+++ b/app/views/registers/_record.html.haml
@@ -1,4 +1,4 @@
 %tr
   - @register.register_fields.each do |field|
     - field_value = record.data[field['field']]
-    %td= field_value ? field_link_resolver(field, field_value).html_safe :  "<span class='unknown'>No data</span>".html_safe
+    %td= field_value ? field_formatter(field, field_value).html_safe :  "<span class='unknown'>No data</span>".html_safe

--- a/spec/controllers/registers_controller_spec.rb
+++ b/spec/controllers/registers_controller_spec.rb
@@ -122,7 +122,7 @@ RSpec.describe RegistersController, type: :controller do
     it "links to external URL" do
       field = { "text" => "The website for a register entry.", "field" => "website", "phase" => "beta", "datatype" => "url", "cardinality" => "1" }
       field_value = "https://www.gov.uk/government/organisations/academy-for-justice-commissioning"
-      expect(subject.field_link_resolver(field, field_value, register_slug: 'government-organisation')).to eq("<p><a href=\"https://www.gov.uk/government/organisations/academy-for-justice-commissioning\">https://www.gov.uk/government/organisations/academy-for-justice-commissioning</a></p>")
+      expect(subject.field_formatter(field, field_value, register_slug: 'government-organisation')).to eq("<a href=\"https://www.gov.uk/government/organisations/academy-for-justice-commissioning\">https://www.gov.uk/government/organisations/academy-for-justice-commissioning</a>")
     end
   end
 
@@ -130,19 +130,19 @@ RSpec.describe RegistersController, type: :controller do
     it "does not link primary key field" do
       field = { "text" => "The unique code for a government organisation.", "field" => "government-organisation", "phase" => "beta", "datatype" => "string", "register" => "government-organisation", "cardinality" => "1" }
       field_value = "D13"
-      expect(subject.field_link_resolver(field, field_value, register_slug: 'government-organisation')).to eq("<p>D13</p>")
+      expect(subject.field_formatter(field, field_value, register_slug: 'government-organisation')).to eq("D13")
     end
 
     it "links register type fields" do
       field = { "text" => "The unique code for a government organisation.", "field" => "government-organisation", "phase" => "beta", "datatype" => "string", "register" => "government-organisation", "cardinality" => "1" }
       field_value = "D13"
-      expect(subject.field_link_resolver(field, field_value, register_slug: 'government-service', whitelist: %w(government-organisation))).to eq("<p><a href=\"/registers/government-organisation/records/D13\">D13</a></p>")
+      expect(subject.field_formatter(field, field_value, register_slug: 'government-service', whitelist: %w(government-organisation))).to eq("<a href=\"/registers/government-organisation/records/D13\">D13</a>")
     end
 
     it "does not link if the register is not in the whitelist" do
       field = { "text" => "The unique code for a government organisation.", "field" => "government-organisation", "phase" => "beta", "datatype" => "string", "register" => "government-organisation", "cardinality" => "1" }
       field_value = "D13"
-      expect(subject.field_link_resolver(field, field_value, register_slug: 'government-service', whitelist: [])).to eq("<p>D13</p>")
+      expect(subject.field_formatter(field, field_value, register_slug: 'government-service', whitelist: [])).to eq("D13")
     end
   end
 
@@ -150,25 +150,25 @@ RSpec.describe RegistersController, type: :controller do
     it "resolves CURIE to record" do
       field = { "text" => "The unique code for a government organisation.", "field" => "government-organisation", "phase" => "beta", "datatype" => "curie", "cardinality" => "1" }
       field_value = "government-organisation:D13"
-      expect(subject.field_link_resolver(field, field_value, register_slug: 'government-organisation', whitelist: %w(government-organisation))).to eq("<p><a href=\"/registers/government-organisation/records/D13\">government-organisation:D13</a></p>")
+      expect(subject.field_formatter(field, field_value, register_slug: 'government-organisation', whitelist: %w(government-organisation))).to eq("<a href=\"/registers/government-organisation/records/D13\">government-organisation:D13</a>")
     end
 
     it "does not resolve CURIE to a record if the register doesn't contain records" do
       field = { "text" => "The unique code for a government organisation.", "field" => "government-organisation", "phase" => "beta", "datatype" => "curie", "cardinality" => "1" }
       field_value = "government-organisation:D13"
-      expect(subject.field_link_resolver(field, field_value, register_slug: 'government-organisation', whitelist: [])).to eq("<p>government-organisation:D13</p>")
+      expect(subject.field_formatter(field, field_value, register_slug: 'government-organisation', whitelist: [])).to eq("government-organisation:D13")
     end
 
     it "links one sided CURIE to register" do
       field = { "text" => "The unique code for a government organisation.", "field" => "government-organisation", "phase" => "beta", "datatype" => "curie", "cardinality" => "1" }
       field_value = "government-organisation:"
-      expect(subject.field_link_resolver(field, field_value, register_slug: 'government-domain', whitelist: %w(government-organisation))).to eq("<p><a href=\"/registers/government-organisation\">government-organisation:</a></p>")
+      expect(subject.field_formatter(field, field_value, register_slug: 'government-domain', whitelist: %w(government-organisation))).to eq("<a href=\"/registers/government-organisation\">government-organisation:</a>")
     end
 
     it "doesn't link a one sided CURIE to the register if the register has no records" do
       field = { "text" => "The unique code for a government organisation.", "field" => "government-organisation", "phase" => "beta", "datatype" => "curie", "cardinality" => "1" }
       field_value = "government-organisation:"
-      expect(subject.field_link_resolver(field, field_value, register_slug: 'government-domain', whitelist: [])).to eq("<p>government-organisation:</p>")
+      expect(subject.field_formatter(field, field_value, register_slug: 'government-domain', whitelist: [])).to eq("government-organisation:")
     end
   end
 
@@ -176,13 +176,13 @@ RSpec.describe RegistersController, type: :controller do
     it "links each field value in cardinality N fields" do
       field = { "text" => "The classes that a charity falls into.", "field" => "charity-classes", "phase" => "discovery", "datatype" => "string", "register" => "charity-class", "cardinality" => "n" }
       field_value = %w[307 302 301 207 103 102 101]
-      expect(subject.field_link_resolver(field, field_value, register_slug: 'charity', whitelist: %w(charity-class))).to eq("<p><a href=\"/registers/charity-class/records/307\">307</a>, <a href=\"/registers/charity-class/records/302\">302</a>, <a href=\"/registers/charity-class/records/301\">301</a>, <a href=\"/registers/charity-class/records/207\">207</a>, <a href=\"/registers/charity-class/records/103\">103</a>, <a href=\"/registers/charity-class/records/102\">102</a>, <a href=\"/registers/charity-class/records/101\">101</a></p>")
+      expect(subject.field_formatter(field, field_value, register_slug: 'charity', whitelist: %w(charity-class))).to eq("<a href=\"/registers/charity-class/records/307\">307</a>, <a href=\"/registers/charity-class/records/302\">302</a>, <a href=\"/registers/charity-class/records/301\">301</a>, <a href=\"/registers/charity-class/records/207\">207</a>, <a href=\"/registers/charity-class/records/103\">103</a>, <a href=\"/registers/charity-class/records/102\">102</a>, <a href=\"/registers/charity-class/records/101\">101</a>")
     end
 
     it "does not link field values if a cardinality N field references registers without records" do
       field = { "text" => "The classes that a charity falls into.", "field" => "charity-classes", "phase" => "discovery", "datatype" => "string", "register" => "charity-class", "cardinality" => "n" }
       field_value = %w[307 302 301 207 103 102 101]
-      expect(subject.field_link_resolver(field, field_value, register_slug: 'charity', whitelist: [])).to eq("<p>307, 302, 301, 207, 103, 102, 101</p>")
+      expect(subject.field_formatter(field, field_value, register_slug: 'charity', whitelist: [])).to eq("307, 302, 301, 207, 103, 102, 101")
     end
   end
 end

--- a/spec/controllers/registers_controller_spec.rb
+++ b/spec/controllers/registers_controller_spec.rb
@@ -122,7 +122,7 @@ RSpec.describe RegistersController, type: :controller do
     it "links to external URL" do
       field = { "text" => "The website for a register entry.", "field" => "website", "phase" => "beta", "datatype" => "url", "cardinality" => "1" }
       field_value = "https://www.gov.uk/government/organisations/academy-for-justice-commissioning"
-      expect(subject.field_link_resolver(field, field_value, register_slug: 'government-organisation')).to eq("<a href=\"https://www.gov.uk/government/organisations/academy-for-justice-commissioning\">https://www.gov.uk/government/organisations/academy-for-justice-commissioning</a>")
+      expect(subject.field_link_resolver(field, field_value, register_slug: 'government-organisation')).to eq("<p><a href=\"https://www.gov.uk/government/organisations/academy-for-justice-commissioning\">https://www.gov.uk/government/organisations/academy-for-justice-commissioning</a></p>")
     end
   end
 
@@ -130,19 +130,19 @@ RSpec.describe RegistersController, type: :controller do
     it "does not link primary key field" do
       field = { "text" => "The unique code for a government organisation.", "field" => "government-organisation", "phase" => "beta", "datatype" => "string", "register" => "government-organisation", "cardinality" => "1" }
       field_value = "D13"
-      expect(subject.field_link_resolver(field, field_value, register_slug: 'government-organisation')).to eq("D13")
+      expect(subject.field_link_resolver(field, field_value, register_slug: 'government-organisation')).to eq("<p>D13</p>")
     end
 
     it "links register type fields" do
       field = { "text" => "The unique code for a government organisation.", "field" => "government-organisation", "phase" => "beta", "datatype" => "string", "register" => "government-organisation", "cardinality" => "1" }
       field_value = "D13"
-      expect(subject.field_link_resolver(field, field_value, register_slug: 'government-service', whitelist: %w(government-organisation))).to eq("<a href=\"/registers/government-organisation/records/D13\">D13</a>")
+      expect(subject.field_link_resolver(field, field_value, register_slug: 'government-service', whitelist: %w(government-organisation))).to eq("<p><a href=\"/registers/government-organisation/records/D13\">D13</a></p>")
     end
 
     it "does not link if the register is not in the whitelist" do
       field = { "text" => "The unique code for a government organisation.", "field" => "government-organisation", "phase" => "beta", "datatype" => "string", "register" => "government-organisation", "cardinality" => "1" }
       field_value = "D13"
-      expect(subject.field_link_resolver(field, field_value, register_slug: 'government-service', whitelist: [])).to eq("D13")
+      expect(subject.field_link_resolver(field, field_value, register_slug: 'government-service', whitelist: [])).to eq("<p>D13</p>")
     end
   end
 
@@ -150,25 +150,25 @@ RSpec.describe RegistersController, type: :controller do
     it "resolves CURIE to record" do
       field = { "text" => "The unique code for a government organisation.", "field" => "government-organisation", "phase" => "beta", "datatype" => "curie", "cardinality" => "1" }
       field_value = "government-organisation:D13"
-      expect(subject.field_link_resolver(field, field_value, register_slug: 'government-organisation', whitelist: %w(government-organisation))).to eq("<a href=\"/registers/government-organisation/records/D13\">government-organisation:D13</a>")
+      expect(subject.field_link_resolver(field, field_value, register_slug: 'government-organisation', whitelist: %w(government-organisation))).to eq("<p><a href=\"/registers/government-organisation/records/D13\">government-organisation:D13</a></p>")
     end
 
     it "does not resolve CURIE to a record if the register doesn't contain records" do
       field = { "text" => "The unique code for a government organisation.", "field" => "government-organisation", "phase" => "beta", "datatype" => "curie", "cardinality" => "1" }
       field_value = "government-organisation:D13"
-      expect(subject.field_link_resolver(field, field_value, register_slug: 'government-organisation', whitelist: [])).to eq("government-organisation:D13")
+      expect(subject.field_link_resolver(field, field_value, register_slug: 'government-organisation', whitelist: [])).to eq("<p>government-organisation:D13</p>")
     end
 
     it "links one sided CURIE to register" do
       field = { "text" => "The unique code for a government organisation.", "field" => "government-organisation", "phase" => "beta", "datatype" => "curie", "cardinality" => "1" }
       field_value = "government-organisation:"
-      expect(subject.field_link_resolver(field, field_value, register_slug: 'government-domain', whitelist: %w(government-organisation))).to eq("<a href=\"/registers/government-organisation\">government-organisation:</a>")
+      expect(subject.field_link_resolver(field, field_value, register_slug: 'government-domain', whitelist: %w(government-organisation))).to eq("<p><a href=\"/registers/government-organisation\">government-organisation:</a></p>")
     end
 
     it "doesn't link a one sided CURIE to the register if the register has no records" do
       field = { "text" => "The unique code for a government organisation.", "field" => "government-organisation", "phase" => "beta", "datatype" => "curie", "cardinality" => "1" }
       field_value = "government-organisation:"
-      expect(subject.field_link_resolver(field, field_value, register_slug: 'government-domain', whitelist: [])).to eq("government-organisation:")
+      expect(subject.field_link_resolver(field, field_value, register_slug: 'government-domain', whitelist: [])).to eq("<p>government-organisation:</p>")
     end
   end
 
@@ -176,13 +176,13 @@ RSpec.describe RegistersController, type: :controller do
     it "links each field value in cardinality N fields" do
       field = { "text" => "The classes that a charity falls into.", "field" => "charity-classes", "phase" => "discovery", "datatype" => "string", "register" => "charity-class", "cardinality" => "n" }
       field_value = %w[307 302 301 207 103 102 101]
-      expect(subject.field_link_resolver(field, field_value, register_slug: 'charity', whitelist: %w(charity-class))).to eq("<a href=\"/registers/charity-class/records/307\">307</a>, <a href=\"/registers/charity-class/records/302\">302</a>, <a href=\"/registers/charity-class/records/301\">301</a>, <a href=\"/registers/charity-class/records/207\">207</a>, <a href=\"/registers/charity-class/records/103\">103</a>, <a href=\"/registers/charity-class/records/102\">102</a>, <a href=\"/registers/charity-class/records/101\">101</a>")
+      expect(subject.field_link_resolver(field, field_value, register_slug: 'charity', whitelist: %w(charity-class))).to eq("<p><a href=\"/registers/charity-class/records/307\">307</a>, <a href=\"/registers/charity-class/records/302\">302</a>, <a href=\"/registers/charity-class/records/301\">301</a>, <a href=\"/registers/charity-class/records/207\">207</a>, <a href=\"/registers/charity-class/records/103\">103</a>, <a href=\"/registers/charity-class/records/102\">102</a>, <a href=\"/registers/charity-class/records/101\">101</a></p>")
     end
 
     it "does not link field values if a cardinality N field references registers without records" do
       field = { "text" => "The classes that a charity falls into.", "field" => "charity-classes", "phase" => "discovery", "datatype" => "string", "register" => "charity-class", "cardinality" => "n" }
       field_value = %w[307 302 301 207 103 102 101]
-      expect(subject.field_link_resolver(field, field_value, register_slug: 'charity', whitelist: [])).to eq("307, 302, 301, 207, 103, 102, 101")
+      expect(subject.field_link_resolver(field, field_value, register_slug: 'charity', whitelist: [])).to eq("<p>307, 302, 301, 207, 103, 102, 101</p>")
     end
   end
 end


### PR DESCRIPTION
### Context
The frontend was rendering the text datatype as plain text rather than markup. This led to any Markdown not being rendered - see the [datatype register](https://www.registers.service.gov.uk/registers/datatype) as a good example of this. The expected behaviour is that any text datatype is rendered as Markdown.

Barebones [card](https://trello.com/c/1e8Q5d8r/3175-we-do-not-render-markdown-in-fields-with-text-datatype).

### Changes proposed in this pull request
* Adds Bluecloth Markdown renderer to the gem
* Edits the `field_link_resolver` in the registers controller to add Markdown parsing
* Updates tests

### Guidance to review
* Remember to `bundle install` to get Bluecloth
* Registers with interesting text fields that are worth checking:
  * Datatype register
  * Register register
  * Approved open standard guidance register