### PR TITLE
Change breadcrumb to reflect new Service Toolkit nomenclature

### DIFF
--- a/app/views/pages/home.html.haml
+++ b/app/views/pages/home.html.haml
@@ -5,7 +5,7 @@
     %nav.breadcrumbs.breadcrumbs--inverse{"aria-label" => "Breadcrumb"}
       %ol
         %li.breadcrumbs__item
-          = link_to 'GOV.UK Services', 'https://www.gov.uk/service-toolkit#gov-uk-services'
+          = link_to 'GOV.UK services', 'https://www.gov.uk/service-toolkit#gov-uk-services'
         %li.breadcrumbs__item.breadcrumbs__item--active
           = link_to 'GOV.UK Registers', '#content', "aria-current" => "page"
 

--- a/app/views/pages/home.html.haml
+++ b/app/views/pages/home.html.haml
@@ -5,7 +5,7 @@
     %nav.breadcrumbs.breadcrumbs--inverse{"aria-label" => "Breadcrumb"}
       %ol
         %li.breadcrumbs__item
-          = link_to 'Components', 'https://www.gov.uk/service-toolkit#components'
+          = link_to 'GOV.UK Services', 'https://www.gov.uk/service-toolkit#gov-uk-services'
         %li.breadcrumbs__item.breadcrumbs__item--active
           = link_to 'GOV.UK Registers', '#content', "aria-current" => "page"
 


### PR DESCRIPTION
The Service Toolkit<sup>1</sup> used to categorise Government as a Platform Programme<sup>2</sup> things under ‘Components’ so the breadcrumb reflected this.

This commit also fixes the anchor link, which has also changed<sup>3</sup> to the new terminology.

1. https://www.gov.uk/service-toolkit
2. Rest in peace
3. https://www.w3.org/Provider/Style/URI