### PR TITLE
exclude NHS from crown branding

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -19,7 +19,7 @@ module ApplicationHelper
       'logo-with-crest crest-so'
     when 'uk-atomic-energy-authority'
       'logo-with-crest crest-ukaea'
-    when 'nhs', 'scottish-government', 'welsh-government', 'office-for-national-statistics'
+    when 'nhs', 'scottish-government', 'welsh-government', 'office-for-national-statistics', 'nhs-digital'
       ' '
     else
       'logo-with-crest crest-org'


### PR DESCRIPTION
### Context
NHS digital should not show crown branding

### Changes proposed in this pull request
NHS digital should not show crown branding

### Guidance to review
if you load CCGs register it should not show crown branding
![screen shot 2019-02-08 at 15 03 50](https://user-images.githubusercontent.com/1764158/52486334-c3c2b000-2bb2-11e9-85a2-00f43014154d.png)
