### PR TITLE
remove unused dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,6 @@ gem 'uglifier', '>= 1.3.0'
 gem 'jquery-rails'
 gem 'jquery-ui-rails', '~> 5.0', '>= 5.0.5'
 gem 'jbuilder', '~> 2.8'
-gem 'http', '2.2.1'
 
 # HAML templating
 gem 'haml-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -168,15 +168,8 @@ GEM
       nokogiri (>= 1.6.0)
       ruby_parser (~> 3.5)
     htmlentities (4.3.4)
-    http (2.2.1)
-      addressable (~> 2.3)
-      http-cookie (~> 1.0)
-      http-form_data (~> 1.0.1)
-      http_parser.rb (~> 0.6.0)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
-    http-form_data (1.0.3)
-    http_parser.rb (0.6.0)
     httparty (0.16.3)
       mime-types (~> 3.0)
       multi_xml (>= 0.5.2)
@@ -433,7 +426,6 @@ DEPENDENCIES
   govuk_template
   haml-rails
   health_check (~> 3.0)
-  http (= 2.2.1)
   httparty (~> 0.16.3)
   invisible_captcha
   iso8601 (~> 0.12.1)


### PR DESCRIPTION
### Context
remove unused dependency

### Changes proposed in this pull request
remove 'http' unused dependency.
*It appears this was used previously for an integration with DeskPro, which we later replaced with a different integration with ZenDesk*

### Guidance to review
build should pass
