### PR TITLE
Delayed Job metrics

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,6 +54,7 @@ gem 'clockwork'
 
 # Monitoring
 gem 'gds_metrics', '~> 0.1.0'
+gem 'prometheus_exporter', '~> 0.4.5'
 
 # Encrypted password
 gem 'bcrypt'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -242,6 +242,7 @@ GEM
     pg (1.1.4)
     powerpack (0.1.2)
     prometheus-client-mmap (0.9.1)
+    prometheus_exporter (0.4.5)
     pry (0.11.3)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
@@ -437,6 +438,7 @@ DEPENDENCIES
   lograge (~> 0.10.0)
   logstash-event (~> 1.2, >= 1.2.02)
   pg (~> 1.1)
+  prometheus_exporter (~> 0.4.5)
   pry-byebug
   puma (~> 3.0)
   rails (~> 5.2.2)

--- a/config/initializers/prometheus_exporter.rb
+++ b/config/initializers/prometheus_exporter.rb
@@ -1,0 +1,14 @@
+if ENV['PROMETHEUS_EXPORTER']
+  require 'prometheus_exporter/instrumentation'
+  require 'uri'
+
+  PROMETHEUS_EXPORTER = URI.parse(ENV['PROMETHEUS_EXPORTER'])
+
+
+  PrometheusExporter::Client.default = PrometheusExporter::Client.new(
+    host: PROMETHEUS_EXPORTER.host,
+    port: PROMETHEUS_EXPORTER.port
+  )
+
+  PrometheusExporter::Instrumentation::DelayedJob.register_plugin
+end

--- a/manifest.yml
+++ b/manifest.yml
@@ -41,6 +41,8 @@ applications:
   command: bundle exec 'prometheus_exporter -p 8080'
   health-check-type: http
   health-check-http-endpoint: /metrics
+  services:
+    - prometheus
 - name: registers-frontend-scheduler
   <<: *defaults
   instances: 1

--- a/manifest.yml
+++ b/manifest.yml
@@ -39,7 +39,8 @@ applications:
   <<: *defaults
   instances: 1
   command: bundle exec 'prometheus_exporter -p 8080'
-  health-check-type: process
+  health-check-type: http
+  health-check-http-endpoint: /metrics
 - name: registers-frontend-scheduler
   <<: *defaults
   instances: 1

--- a/manifest.yml
+++ b/manifest.yml
@@ -29,8 +29,20 @@ applications:
   instances: 1
   command: bundle exec 'rake environment jobs:work'
   health-check-type: process
+  no-route: true
+  env: 
+    PROMETHEUS_EXPORTER: http://registers-frontend-queue-prometheus-exporter.apps.internal:8080
+- name: registers-frontend-queue-prometheus-exporter
+  routes:
+    - route: registers-frontend-queue-prometheus-exporter.apps.internal
+    - route: registers-frontend-queue-prometheus-exporter.cloudapps.digital/metrics
+  <<: *defaults
+  instances: 1
+  command: bundle exec 'prometheus_exporter -p 8080'
+  health-check-type: process
 - name: registers-frontend-scheduler
   <<: *defaults
   instances: 1
   command: bundle exec clockwork 'lib/clock.rb'
   health-check-type: process
+  no-route: true


### PR DESCRIPTION
### Context
we did not have any monitoring or alerting on Active Job tasks

### Changes proposed in this pull request
Adds a new sidecar application which exposes Delayed Job metrics using [`prometheus_exporter` delayed job plugin](https://github.com/discourse/prometheus_exporter#delayed-job-plugin).
Note, this makes use of the [PaaS private apps functionality](https://docs.cloud.service.gov.uk/deploying_apps.html#deploying-private-apps) to allow communication between the queue and prometheus_exporter application. The `/metrics` endpoint is exposed publicly to allow scraping by the [`gds-prometheus` service](https://reliability-engineering.cloudapps.digital/monitoring-alerts.html#bind-your-exporter-to-prometheus).

### Guidance to review
* There are some manual steps after deployment to configure the private app communication as described in https://docs.cloud.service.gov.uk/deploying_apps.html#create-a-network-policy
* I have tested this in the `sandbox` space. 
* Setting up alerts is done separately and will require a separate PR in https://github.com/alphagov/prometheus-aws-configuration-beta