### PR TITLE
Add universal Google Analytics code

### DIFF
--- a/app/views/layouts/_analytics.html.erb
+++ b/app/views/layouts/_analytics.html.erb
@@ -16,6 +16,12 @@
   ga('set', 'displayFeaturesTask', null)
   ga('set', 'transport', 'beacon')
 
+  ga('create', 'UA-145652997-1', 'auto', 'govuk_shared', {'allowLinker': true});
+  ga('govuk_shared.require', 'linker');
+  ga('govuk_shared.linker.set', 'anonymizeIp', true);
+  ga('govuk_shared.linker:autoLink', ['registers.service.gov.uk', 'www.gov.uk']);
+
   ga('send', 'pageview')
+  ga('govuk_shared.send', 'pageview');
 </script>
 <script src="https://www.google-analytics.com/analytics.js" async></script>


### PR DESCRIPTION
### Context

Because Brexit, we've been asked to add a universal GA code to all
government services on a GOV.UK service domain. This does so for
Registers frontend.

### Changes proposed in this pull request

Add the universal GA code to registers frontend.

### Guidance to review
