### PR TITLE
fix: properly ignore the bundle folder created by CI

### DIFF
--- a/.cfignore
+++ b/.cfignore
@@ -5,7 +5,7 @@
 #   git config --global core.excludesfile '~/.gitignore_global'
 
 # Ignore bundler config.
-/.bundle
+.bundle
 
 # Ignore all logfiles and tempfiles.
 /log/*
@@ -21,4 +21,4 @@
 *.iml
 
 # Ignore outputs from travis.
-/vendor
+vendor


### PR DESCRIPTION
We're suffering Bundler loosing path to gems on CI which would
indicate that the deploy script (powered by CF) is getting confused by
the artifacts of the CI build (i.e a `.bundle` folder).

This directory should be ignored by CF, however a leading slash is not
guaranteed to work in all configurations so favour `.bundle` instead.

### Context


### Changes proposed in this pull request


### Guidance to review
