### PR TITLE
fix: remove unnecessary install of Bundle 1.17.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ cache: bundler
 
 before_install:
   - gem update --system
-  - gem install bundler -v 1.17.3
+
 env:
   global:
   - CF_API="https://api.cloud.service.gov.uk"


### PR DESCRIPTION
The deploy step is now failing when ran from Travis, which indicates
an issue in the way we do these builds. Remove this bundler 1.x hack
as we're trying to move forward and it might confuse the bundler
installed by CloudFoundry more than anything.