### PR TITLE
Fix/error pages

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,12 +11,5 @@ private
   def current_user
     @current_user ||= User.where(id: session[:user_id]).first if session[:user_id]
   end
-
-  def remove_cookie_banner(content)
-    #  Hot patch to remove the cookie banner before rendering
-    cookie_banner_regex = %r{<div id="global-cookie-message">\s*.*\s*<\/div>}
-    content.gsub(cookie_banner_regex, '')
-  end
-
-  helper_method :current_user, :remove_cookie_banner
+  helper_method :current_user
 end

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -1,5 +1,9 @@
 - @omit_header = true
 
+- content_for :top_of_page do
+  :javascript
+    window.GOVUK.addCookieMessage = false;
+
 - content_for :page_title, "#{@page_title.present? ? "#{@page_title} - GOV.UK Registers" : 'GOV.UK Registers' }"
 
 - content_for :body_classes, ' no-js'

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -76,5 +76,4 @@
       %li= link_to 'Privacy notice', privacy_notice_path
       %li= link_to 'Cookies', cookies_path
 
-- s = render file: 'layouts/govuk_template'
-= raw remove_cookie_banner(s)
+= render file: 'layouts/govuk_template'


### PR DESCRIPTION
### Context
We are getting intermittent failures from the `registers` which can be crashed by visiting any error-causing page (like a 404), because our error pages are missing a method needed to render their layout. This might possibly push the app outside of its resources, which causes a chain of crash/restarts to be triggered. The full explanation is in commit https://github.com/openregister/registers-frontend/commit/bcba8859afa640de64bbe9d7a85881b1a5c4e40a.

### Changes proposed in this pull request
* Remove the hack to remove the cookie banner;
* Disable the cookie banner with a simple window-level attribute.

### Guidance to review
* Read commit log;
* Run `make serve` locally  (looks fine on my machine).