### PR TITLE
Fix/cookie banner

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+log/*

--- a/Makefile
+++ b/Makefile
@@ -8,5 +8,15 @@ populate:
 serve: build
 	docker-compose up -d
 
+stop:
+	docker-compose down
+
+# starts the web process interactively to attach to debugger breakpoints
+istart: build
+	docker-compose run --publish 3000:3000 web
+
+logs:
+	docker-compose logs --follow web
+
 shell:
 	docker-compose exec web bash

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,8 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
 
+  before_action :prevent_cookie_banner
+
   layout 'application'
 
   is_trial_domain = Rails.env.production? && JSON.parse(ENV.fetch('VCAP_APPLICATION'))['uris'].include?('registers-trial.service.gov.uk')
@@ -11,5 +13,13 @@ private
   def current_user
     @current_user ||= User.where(id: session[:user_id]).first if session[:user_id]
   end
+
   helper_method :current_user
+
+  def prevent_cookie_banner
+    request.cookie_jar[:seen_cookie_message] = {
+      value: 'true',
+      expires: 1.year.from_now
+    }
+  end
 end

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -1,9 +1,5 @@
 - @omit_header = true
 
-- content_for :top_of_page do
-  :javascript
-    window.GOVUK.addCookieMessage = false;
-
 - content_for :page_title, "#{@page_title.present? ? "#{@page_title} - GOV.UK Registers" : 'GOV.UK Registers' }"
 
 - content_for :body_classes, ' no-js'


### PR DESCRIPTION
### Context
The previous PR (https://github.com/openregister/registers-frontend/pull/713) attempted to remove the cookie banner by setting a property on the global `window` object. Unfortunately this object is just set regardless by the `govuk-template` JS, then immediately called, effectively ignoring whatever value we've set[1].

So instead, just set the `seen_cookie_banner` before everyone else gets a change to, effectively discouraging `govuk-template` from showing the banner[2].

Only cavehat: the error pages still have it. See commit log for details.

\[1\]: https://github.com/alphagov/govuk_template/blob/master/source/assets/javascripts/core.js#L6
\[2\]: https://github.com/alphagov/govuk_template/blob/master/source/assets/javascripts/cookie-bar.js#L12

### Changes proposed in this pull request
* Remove tentative JS fix for cookie banner;
* Enforce `seen_cookie_banner` cookie.

### Guidance to review
* Read commit log;
* Try locally (works here).